### PR TITLE
Check sequence of activities and legs in DTD

### DIFF
--- a/matsim/src/main/resources/dtd/population_v5.dtd
+++ b/matsim/src/main/resources/dtd/population_v5.dtd
@@ -13,7 +13,7 @@
           car_avail      (always|never|sometimes) #IMPLIED
           employed       (yes|no)                 #IMPLIED>
 
-<!ELEMENT plan           (act|leg)*>
+<!ELEMENT plan           (act,(leg,act)*)>
 <!ATTLIST plan
           score          CDATA    #IMPLIED
           type           CDATA    #IMPLIED


### PR DESCRIPTION
This actually works on my system when I pass this DTD to `xmllint`. YMMV. Has this been discussed before?