### PR TITLE
inprovements in OsmNetworkReader

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
@@ -102,8 +102,6 @@ public class OsmNetworkReader implements MatsimSomeReader {
 
 	private boolean slowButLowMemory = false;
 	
-	private boolean laneTagSumOfBothDirections = false;
-
 	/*package*/ final List<OsmFilter> hierarchyLayers = new ArrayList<OsmFilter>();
 
 	/**
@@ -303,19 +301,6 @@ public class OsmNetworkReader implements MatsimSomeReader {
 		this.slowButLowMemory = memoryEnabled;
 	}
 	
-	/**
-	 * Defines if the number of lanes specified by the <code>lanes</code> tag pertains to one (false) or both directions (true).
-	 * For example, if <code>false</code> then "lanes=2" means 2 lanes in each direction (e.g. in Berlin); otherwise, we have 1 lane in each direction (e.g. in Poznan).
-     * 
-     * This switch influences only two-way roads.
-     * 
-     * Defaults to <code>false</code>.
-	 */
-	public void setLaneTagSumOfBothDirections(boolean laneTagSumOfBothDirections)
-    {
-        this.laneTagSumOfBothDirections = laneTagSumOfBothDirections;
-    }
-
 	private void convert() {
 		if (this.network instanceof NetworkImpl) {
 			((NetworkImpl) this.network).setCapacityPeriod(3600);
@@ -496,8 +481,6 @@ public class OsmNetworkReader implements MatsimSomeReader {
 				oneway = false;
 			} else if ("no".equals(onewayTag)) {
 				oneway = false; // may be used to overwrite defaults
-			} else if ("alternating".equals(onewayTag)){
-                oneway = false;
             }
 			else {
                 log.warn("Could not interpret oneway tag:" + onewayTag + ". Ignoring it.");
@@ -532,7 +515,10 @@ public class OsmNetworkReader implements MatsimSomeReader {
 				if (tmp > 0) {
 					nofLanes = tmp;
 
-		            if (laneTagSumOfBothDirections && !(oneway || onewayReverse)) {
+					//By default, the OSM lanes tag specifies the total number of lanes in both directions.
+					//So if the road is not oneway (onewayReverse), let's distribute them between both directions
+					//michalm, jan'16
+		            if (!oneway && !onewayReverse) {
 		                nofLanes /= 2;
 		            }
 				}

--- a/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
@@ -223,7 +223,7 @@ public class OsmNetworkReader implements MatsimSomeReader {
 	 *
 	 * @param hierarchy The hierarchy layer the highway appears.
 	 * @param highwayType The type of highway these defaults are for.
-	 * @param lanes number of lanes on that road type (in each direction)
+	 * @param lanes number of lanes on that road type (<em>in each direction</em>)
 	 * @param freespeed the free speed vehicles can drive on that road type [meters/second]
 	 * @param freespeedFactor the factor the freespeed is scaled
 	 * @param laneCapacity_vehPerHour the capacity per lane [veh/h]
@@ -239,7 +239,7 @@ public class OsmNetworkReader implements MatsimSomeReader {
 	 *
 	 * @param hierarchy The hierarchy layer the highway appears in.
 	 * @param highwayType The type of highway these defaults are for.
-	 * @param lanes number of lanes on that road type (in each direction)
+	 * @param lanes number of lanes on that road type (<em>in each direction</em>)
 	 * @param freespeed the free speed vehicles can drive on that road type [meters/second]
 	 * @param freespeedFactor the factor the freespeed is scaled
 	 * @param laneCapacity_vehPerHour the capacity per lane [veh/h]
@@ -533,7 +533,7 @@ public class OsmNetworkReader implements MatsimSomeReader {
 					nofLanes = tmp;
 
 		            if (laneTagSumOfBothDirections && !(oneway || onewayReverse)) {
-		                nofLanes /= 2; 
+		                nofLanes /= 2;
 		            }
 				}
 			} catch (Exception e) {

--- a/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/OsmNetworkReader.java
@@ -364,7 +364,7 @@ public class OsmNetworkReader implements MatsimSomeReader {
 		if (!this.keepPaths) {
 			// marked nodes as unused where only one way leads through
 			for (OsmNode node : this.nodes.values()) {
-				if ((node.ways == 1) && (!this.keepPaths)) {
+				if (node.ways == 1) {
 					node.used = false;
 				}
 			}

--- a/matsim/src/test/java/org/matsim/core/utils/io/OsmNetworkReaderTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/io/OsmNetworkReaderTest.java
@@ -56,7 +56,7 @@ public class OsmNetworkReaderTest {
 		new OsmNetworkReader(net,ct).parse(filename);
 
 		Assert.assertEquals("number of nodes is wrong.", 399, net.getNodes().size());
-		Assert.assertEquals("number of links is wrong.", 874, net.getLinks().size());
+		Assert.assertEquals("number of links is wrong.", 872, net.getLinks().size());
 
 		new NetworkCleaner().run(net);
 		Assert.assertEquals("number of nodes is wrong.", 344, net.getNodes().size());
@@ -77,7 +77,7 @@ public class OsmNetworkReaderTest {
 		reader.parse(filename);
 
 		Assert.assertEquals("number of nodes is wrong.", 1844, net.getNodes().size());
-		Assert.assertEquals("number of links is wrong.", 3537, net.getLinks().size());
+		Assert.assertEquals("number of links is wrong.", 3535, net.getLinks().size());
 
 		new NetworkCleaner().run(net);
 		Assert.assertEquals("number of nodes is wrong.", 1561, net.getNodes().size());
@@ -99,7 +99,7 @@ public class OsmNetworkReaderTest {
 		reader.parse(filename);
 
 		Assert.assertEquals("number of nodes is wrong.", 1844, net.getNodes().size());
-		Assert.assertEquals("number of links is wrong.", 3537, net.getLinks().size());
+		Assert.assertEquals("number of links is wrong.", 3535, net.getLinks().size());
 
 		new NetworkCleaner().run(net);
 		Assert.assertEquals("number of nodes is wrong.", 1561, net.getNodes().size());


### PR DESCRIPTION
Two major changes are:
1.  the OSM lanes tag specifies the total no of lanes (i.e. in both directions). Therefore, for 2-way roads the numbers of lanes in each direction is 'lanes/2'. The osm maps of Poznan and Berlin follow this rule.
2. the access tag was added to prevent building links where no traffic is allowed
In particular, change 1 may result in reduced flow and storage capacities of some links in newly converted networks. 

These changes are also (being?) introduced by Michael Z. in josm-matsim-plugin

Besides that, a few smaller improvements/bugfixes were introduced.