### PR TITLE
using floor function before adding current time step to it. This will

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -698,9 +698,9 @@ final class QueueWithBuffer extends QLaneI implements SignalizeableItem {
 
 		// compute and set earliest link exit time:
 		double linkTravelTime = this.length / this.network.simEngine.getLinkSpeedCalculator().getMaximumVelocity(veh, link, now);
+		linkTravelTime = timeStepSize * Math.floor( linkTravelTime / timeStepSize );
+		
 		double earliestExitTime = now + linkTravelTime ;
-
-		earliestExitTime = timeStepSize * Math.floor(earliestExitTime/timeStepSize );
 
 		veh.setEarliestLinkExitTime(earliestExitTime);
 


### PR DESCRIPTION
using math.floor function before adding current time step to link travel time. This will
eliminate some of the rounding error (see following example) due to java double precision.

Math.floor( 60 + 59.99999999999999) will return 120.0 whereas 
Math.floor(59.99999999999999) + 60 will return 119.0