### PR TITLE
Update SinglePassengerPickupActivity

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
@@ -44,10 +44,10 @@ public class SinglePassengerPickupActivity
         this.pickupTask = pickupTask;
         this.request = request;
         this.pickupDuration = pickupDuration;
-        
+
         // Only happens for direct requests (not prescheduled)
-		tryPickupPassenger(pickupTask.getBeginTime());
-		
+        tryPickupPassenger(pickupTask.getBeginTime());
+
         if (!passengerAboard) {
             //try to predict the end time and stay alive
             endTime = Math.max(pickupTask.getBeginTime(), request.getT0()) + pickupDuration + 1.0;
@@ -72,23 +72,23 @@ public class SinglePassengerPickupActivity
     {
         return "PassengerPickup";
     }
-    
+
     private void tryPickupPassenger(double now) {
-		DynAgent driver = pickupTask.getSchedule().getVehicle().getAgentLogic().getDynAgent();
-		passengerAboard = passengerEngine.pickUpPassenger(this, driver, request, now);
-		
-		if (passengerAboard) {
-			endTime = now + pickupDuration;
-		}
+        DynAgent driver = pickupTask.getSchedule().getVehicle().getAgentLogic().getDynAgent();
+        passengerAboard = passengerEngine.pickUpPassenger(this, driver, request, now);
+
+        if (passengerAboard) {
+            endTime = now + pickupDuration;
+        }
     }
 
     @Override
     public void doSimStep(double now)
     {
-    	if (passengerWaiting && !passengerAboard) {
-    		tryPickupPassenger(now);
-    	}
-    	
+        if (passengerWaiting && !passengerAboard) {
+            tryPickupPassenger(now);
+        }
+
         if (!passengerAboard) {
             // try to predict the end time and stay alive
             endTime = Math.max(now, request.getT0()) + pickupDuration + 1.0;
@@ -102,7 +102,7 @@ public class SinglePassengerPickupActivity
         if (passenger.equals(request.getPassenger())) {
             throw new IllegalArgumentException("I am waiting for a different passenger!");
         }
-        
+
         passengerWaiting = true;
     }
 }


### PR DESCRIPTION
@michalmac I came across some problems with the pickup behaviour for prescheduled trips in the dvrp framework.

**1. Check if the right passenger is notifying for pickup**
If the agents are extended using a decorator pattern (for pt), then

    if (passenger != request.getPassenger()) {

is always `false`, and using `.equals` is safer in general, I think

**2. Zero pickupDuration**
The end-time of the activity is dynamically updated to

    endTime = Math.max(now, request.getT0()) + pickupDuration;

However, if the passenger agent is arriving later than expected (i.e. `T0` is already expired), this will set `endTime = now`, which in turn makes the `DynActivityEngine` make the agent proceed to the next activity. So it won't wait for a late passenger if `pickupDuration = 0`. Here it is solved by adding one more second delay (it doesn't change anything about the final end time, actually).

**3. Late DynAgents**
If the DynAgent is late, but the passenger already arrives at the pickup link, `notifyPassengerIsReadyForDeparture` is called. Since the driver is not there yet, the call to `passengerEngine.pickupPassenger` will return `false`, which leads to an exception:

`throw new IllegalStateException("The passenger is not on the link or not available for departure!");`

This is wrong, since actually the problem is that the driver is missing! So here it is solved by setting the `passengerWaiting` variable and performing the pickup in `doSimStep` as soon as both the driver and passenger are at the link.

Sidenote: I actually came across this behaviour when I had zero pickupDuration and the exception was thrown because the driver already had *departed* when the passenger arrived, because the pickup activity had been stopped to early...