### PR TITLE
Update SinglePassengerPickupActivity

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
@@ -52,8 +52,8 @@ public class SinglePassengerPickupActivity
             endTime = now + pickupDuration;
         }
         else {
-            //try to predict the end time
-            endTime = Math.max(now, request.getT0()) + pickupDuration;
+            //try to predict the end time and stay alive
+            endTime = Math.max(now, request.getT0()) + pickupDuration + 1.0;
         }
     }
 
@@ -81,8 +81,8 @@ public class SinglePassengerPickupActivity
     public void doSimStep(double now)
     {
         if (!passengerAboard) {
-            //try to predict the end time
-            endTime = Math.max(now, request.getT0()) + pickupDuration;
+            //try to predict the end time and stay alive
+            endTime = Math.max(now, request.getT0()) + pickupDuration + 1.0;
         }
     }
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
@@ -90,7 +90,7 @@ public class SinglePassengerPickupActivity
     @Override
     public void notifyPassengerIsReadyForDeparture(MobsimPassengerAgent passenger, double now)
     {
-        if (passenger != request.getPassenger()) {
+        if (passenger.getId().equals(request.getPassenger().getId())) {
             throw new IllegalArgumentException("I am waiting for a different passenger!");
         }
 


### PR DESCRIPTION
@michalmac Fixed two small problems

**1. Check if the right passenger is notifying for pickup**
If the agents are extended using a decorator pattern (for pt), then

    if (passenger != request.getPassenger()) {

is always false, and using .equals on the Id is safer in general, I think

**2. Zero pickupDuration**
The end-time of the activity is dynamically updated to

    endTime = Math.max(now, request.getT0()) + pickupDuration;

However, if the passenger agent is arriving later than expected (i.e. T0 is already expired), this will set `endTime = now`, which in turn makes the `DynActivityEngine` make the agent proceed to the next activity. So it won't wait for a late passenger if `pickupDuration = 0`. 

This leads to the driver already going through the leg, while the passenger is not ready to depart yet. Finally, when `notifyPassengerIsReadyForDeparture` is called, the second exception will be thrown since the pickup action was not successful (but, contrary to the state error is because the driver is already gone!)

Here, adding the `+ 1.0` to keep the activity alive should not change the final end time when the passenger arrives.