### PR TITLE
scenario loading does not overwrite the link factory of a time variant

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -26,6 +26,8 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.groups.NetworkConfigGroup;
 import org.matsim.core.utils.geometry.CoordUtils;
 
 import java.util.*;
@@ -39,10 +41,27 @@ public class NetworkUtils {
 
     private static Logger log = Logger.getLogger(NetworkUtils.class);
 
-	public static Network createNetwork() {
-		return new NetworkImpl() ;
-	}
-	
+    public static Network createNetwork() {
+        return new NetworkImpl() ;
+    }
+
+
+    public static Network createNetwork(Config config) {
+        return createNetwork(config.network());
+    }
+
+
+    public static Network createNetwork(NetworkConfigGroup networkConfigGroup) {
+        NetworkImpl network = new NetworkImpl();
+        
+        if (networkConfigGroup.isTimeVariantNetwork()) {
+            network.getFactory().setLinkFactory(new VariableIntervalTimeVariantLinkFactory());
+        }
+        
+        return network;
+    }
+
+
 	/**
 	 * @return The bounding box of all the given nodes as <code>double[] = {minX, minY, maxX, maxY}</code>
 	 */

--- a/matsim/src/main/java/org/matsim/core/scenario/MutableScenario.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/MutableScenario.java
@@ -27,8 +27,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.config.Config;
-import org.matsim.core.network.NetworkImpl;
-import org.matsim.core.population.PopulationImpl;
+import org.matsim.core.network.*;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.ActivityFacilitiesImpl;
@@ -69,7 +68,7 @@ public final class MutableScenario implements Scenario {
 
 	MutableScenario(Config config) {
 		this.config = config;
-		this.network = NetworkImpl.createNetwork();
+		this.network = NetworkUtils.createNetwork(this.config);
 		this.population = PopulationUtils.createPopulation(this.config, this.network);
 		this.facilities = new ActivityFacilitiesImpl();
 		this.households = new HouseholdsImpl();

--- a/matsim/src/main/java/org/matsim/core/scenario/ScenarioLoaderImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/ScenarioLoaderImpl.java
@@ -123,14 +123,6 @@ class ScenarioLoaderImpl {
 			final String networkFileName = this.config.network().getInputFile();
 
 			log.info("loading network from " + networkFileName);
-
-			NetworkImpl network = (NetworkImpl) this.scenario.getNetwork();
-
-			if (this.config.network().isTimeVariantNetwork()) {
-				log.info("use TimeVariantLinks in NetworkFactory.");
-				network.getFactory().setLinkFactory(new VariableIntervalTimeVariantLinkFactory());
-			}
-
 			if ( config.network().getInputCRS() == null ) {
 				new MatsimNetworkReader(this.scenario.getNetwork()).parse(networkFileName);
 			}
@@ -145,6 +137,7 @@ class ScenarioLoaderImpl {
 
 			if ((this.config.network().getChangeEventsInputFile() != null) && this.config.network().isTimeVariantNetwork()) {
 				log.info("loading network change events from " + this.config.network().getChangeEventsInputFile());
+	            NetworkImpl network = (NetworkImpl) this.scenario.getNetwork();
 				NetworkChangeEventsParser parser = new NetworkChangeEventsParser(network);
 				parser.parse(this.config.network().getChangeEventsInputFile());
 				network.setNetworkChangeEvents(parser.getEvents());


### PR DESCRIPTION
This is a fix for MATSIM-513: No way of choosing the link factory while loading a scenario with a time variant network