### PR TITLE
Avoid null pointer exceptions

### DIFF
--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/events/handlers/PersonArrivalDepartureHandler.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/events/handlers/PersonArrivalDepartureHandler.java
@@ -123,28 +123,31 @@ public class PersonArrivalDepartureHandler implements PersonDepartureEventHandle
 
 		String vehId = event.getVehicleId().toString();
 		String arrivalMode = this.personArrivalMode.get(event.getPersonId());
-		if (vehId.startsWith("OW") &&
-				!arrivalMode.equals("access_walk_ow")) {
-			Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
-			Link link = network.getLinks().get(linkId);
-			this.carsharingManager.freeParkingSpot(vehId, linkId);
 
-			this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "oneway");
-		
-		}		
-		else if (vehId.startsWith("FF") &&
-				!arrivalMode.equals("access_walk_ff")) {
-			Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
-			Link link = network.getLinks().get(linkId);
+		if (arrivalMode != null) {
+			if (vehId.startsWith("OW") &&
+					!arrivalMode.equals("access_walk_ow")) {
+				Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
+				Link link = network.getLinks().get(linkId);
+				this.carsharingManager.freeParkingSpot(vehId, linkId);
 
-			this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "freefloating");
-		}
-		else if (vehId.startsWith("TW") &&
-				!arrivalMode.equals("access_walk_tw")) {
-			Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
-			Link link = network.getLinks().get(linkId);
+				this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "oneway");
+			
+			}		
+			else if (vehId.startsWith("FF") &&
+					!arrivalMode.equals("access_walk_ff")) {
+				Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
+				Link link = network.getLinks().get(linkId);
 
-			this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "twoway");
+				this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "freefloating");
+			}
+			else if (vehId.startsWith("TW") &&
+					!arrivalMode.equals("access_walk_tw")) {
+				Id<Link> linkId = this.personDepartureMap.get(event.getPersonId());
+				Link link = network.getLinks().get(linkId);
+
+				this.currentDemand.removeVehicle(event.getPersonId(), link, carsharingSupply.getAllVehicles().get(vehId), "twoway");
+			}
 		}
 	}	
 }

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/CurrentTotalDemand.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/CurrentTotalDemand.java
@@ -63,7 +63,13 @@ public class CurrentTotalDemand {
 	}
 	
 	public boolean removeVehicle(Id<Person> personId, Link link, CSVehicle vehicle, String type) {
-		return currentDemand.get(personId).removeVehicle(link, vehicle, type);
+		CarsharingCurrentRentalsInfo personRentals = this.currentDemand.get(personId);
+
+		if (personRentals != null) {
+			return personRentals.removeVehicle(link, vehicle, type);
+		}
+
+		return false;
 	}
 
 	public void reset() {

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/DemandHandler.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/DemandHandler.java
@@ -66,9 +66,9 @@ PersonEntersVehicleEventHandler, LinkLeaveEventHandler, StartRentalEventHandler,
 		info.setAccessStartTime(event.getTime());
 		info.setStartTime(event.getTime());
 		info.setOriginLinkId(event.getOriginLinkId());
-		info.setPickupLinkId(event.getPickuplinkId());	
+		info.setPickupLinkId(event.getPickuplinkId());
+
 		if (agentRentalsMap.containsKey(event.getPersonId())) {
-			
 			AgentRentals agentRentals = this.agentRentalsMap.get(event.getPersonId());
 			agentRentals.getStatsPerVehicle().put(event.getvehicleId(), info);
 			
@@ -84,11 +84,14 @@ PersonEntersVehicleEventHandler, LinkLeaveEventHandler, StartRentalEventHandler,
 	public void handleEvent(LinkLeaveEvent event) {
 		if (carsharingTrip(event.getVehicleId())) {
 			Id<Person> personId = this.vehiclePersonMap.get(event.getVehicleId());
-			AgentRentals agentRentals = this.agentRentalsMap.get(personId);
 			Network network = this.scenario.getNetwork();
-			RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
-			info.setVehId(event.getVehicleId());
-			info.setDistance(info.getDistance() + network.getLinks().get(event.getLinkId()).getLength());
+
+			if (agentRentalsMap.containsKey(personId)) {
+				AgentRentals agentRentals = this.agentRentalsMap.get(personId);
+				RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
+				info.setVehId(event.getVehicleId());
+				info.setDistance(info.getDistance() + network.getLinks().get(event.getLinkId()).getLength());
+			}
 		}
 		
 	}
@@ -100,11 +103,14 @@ PersonEntersVehicleEventHandler, LinkLeaveEventHandler, StartRentalEventHandler,
 			this.enterVehicleTimes.put(event.getPersonId(), event.getTime());
 			
 			Id<Person> personId = this.vehiclePersonMap.get(event.getVehicleId());
-			AgentRentals agentRentals = this.agentRentalsMap.get(personId);
-			
-			RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
-			if (info.getAccessEndTime() == 0.0)
-				info.setAccessEndTime(event.getTime());
+
+			if (agentRentalsMap.containsKey(event.getPersonId())) {
+				AgentRentals agentRentals = this.agentRentalsMap.get(personId);
+				RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
+
+				if (info.getAccessEndTime() == 0.0)
+					info.setAccessEndTime(event.getTime());
+			}
 		}
 		
 	}
@@ -115,10 +121,14 @@ PersonEntersVehicleEventHandler, LinkLeaveEventHandler, StartRentalEventHandler,
 		if (carsharingTrip(event.getVehicleId())) {
 			double enterTime = this.enterVehicleTimes.get(event.getPersonId());	
 			double totalTime = event.getTime() - enterTime;
+
 			Id<Person> personId = this.vehiclePersonMap.get(event.getVehicleId());
-			AgentRentals agentRentals = this.agentRentalsMap.get(personId);
-			RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
-			info.setInVehicleTime(info.getInVehicleTime() + totalTime);
+
+			if (agentRentalsMap.containsKey(event.getPersonId())) {
+				AgentRentals agentRentals = this.agentRentalsMap.get(personId);
+				RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
+				info.setInVehicleTime(info.getInVehicleTime() + totalTime);
+			}
 		}
 	}
 

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/DemandHandler.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/manager/demand/DemandHandler.java
@@ -102,7 +102,7 @@ PersonEntersVehicleEventHandler, LinkLeaveEventHandler, StartRentalEventHandler,
 			Id<Person> personId = this.vehiclePersonMap.get(event.getVehicleId());
 			AgentRentals agentRentals = this.agentRentalsMap.get(personId);
 			
-			RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());			
+			RentalInfo info = agentRentals.getStatsPerVehicle().get(event.getVehicleId().toString());
 			if (info.getAccessEndTime() == 0.0)
 				info.setAccessEndTime(event.getTime());
 		}


### PR DESCRIPTION
this PR adds checks to avoid NullPointerExceptions in PersonArrivalDepartureHandler.java and CurrentTotalDemand.java in cases where the person ID passed with the event instance is not available in the handler instance variable used to track data about the agents actions.

The background is that the PersonEntersVehicleEvent and LinkLeaveEvent are also triggered by the relocation agents actions, and I think it would be confusing to track these in this way.