### PR TITLE
Flow cap easing for buses

### DIFF
--- a/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QSimExternalTransitionLink.java
+++ b/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QSimExternalTransitionLink.java
@@ -224,7 +224,7 @@ public class QSimExternalTransitionLink extends AbstractQLink {
 		}
 
 		@Override
-		boolean isAcceptingFromWait() {
+		boolean isAcceptingFromWait(QVehicle veh) {
 			// TODO Auto-generated method stub
 			throw new RuntimeException("not implemented") ;
 		}

--- a/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
@@ -51,7 +51,7 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	private static final String SIM_STARTTIME_INTERPRETATION = "simStarttimeInterpretation";
 	private static final String USE_PERSON_ID_FOR_MISSING_VEHICLE_ID = "usePersonIdForMissingVehicleId";
 	private static final String SIM_ENDTIME_INTERPRETATION = "simEndtimeInterpretation";
-
+	
 	public static enum TrafficDynamics { queue, withHoles,
 		KWM //  MATSim-630; previously, the switch was InflowConstraint.maxflowFromFdiag. Amit Jan 2017.
 	} ;
@@ -76,6 +76,20 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	
 	private StarttimeInterpretation simStarttimeInterpretation = StarttimeInterpretation.maxOfStarttimeAndEarliestActivityEnd;
 	
+	//Vehicles of size (in PCU) smaller than this threshold will be allowed to enter the buffer even
+	//if flowcap_accumulate is not positive.
+	//The default value is 0.0 meaning that all vehicles of non-zero sizes will be let into buffer only
+	//if flowcap_accumulate > 0.
+	//
+	//Flow capacity easing prevents buses from waiting long time for entering the buffer in sub-sampled scenarios
+	//For instance, for 10% scenario, a car (representing 10 cars) has a size of 1.0, a bus (representing 1 bus) of 0.3,
+	//and link flow capacities are reduced to about 0.1 of the original capacity.
+	//(1) If pcuThresholdForFlowCapacityEasing == 0, all busses following private cars wait long times before entering
+	//the buffer (recovering the flow capacity accumulator takes approx. 10 times longer than in the 100% scenario).
+	//(2) If pcuThresholdForFlowCapacityEasing == 0.3, busses at the front of the queue immediately enter the buffer
+	//(once they arrive at the end of a link).
+	private double pcuThresholdForFlowCapacityEasing = 0.0;
+
 	// ---
 	private static final String VEHICLE_BEHAVIOR = "vehicleBehavior";
 	public static enum VehicleBehavior { teleport, wait, exception } ;
@@ -543,5 +557,14 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	public boolean setUsingTravelTimeCheckInTeleportation( boolean val ) {
 		// yyyyyy this should better become a threshold number!  kai, aug'16
 		return this.usingTravelTimeCheckInTeleportation = val ;
+	}
+	
+	
+	public double getPcuThresholdForFlowCapacityEasing() {
+		return pcuThresholdForFlowCapacityEasing;
+	}
+	
+	public void setPcuThresholdForFlowCapacityEasing(double pcuThresholdForFlowCapacityEasing) {
+		this.pcuThresholdForFlowCapacityEasing = pcuThresholdForFlowCapacityEasing;
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
@@ -76,18 +76,20 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	
 	private StarttimeInterpretation simStarttimeInterpretation = StarttimeInterpretation.maxOfStarttimeAndEarliestActivityEnd;
 	
-	//Vehicles of size (in PCU) smaller than this threshold will be allowed to enter the buffer even
-	//if flowcap_accumulate is not positive.
+	//Vehicles of size (in PCU) smaller than or equal to this threshold will be allowed to enter the buffer even
+	//if flowcap_accumulate <= 0.
 	//The default value is 0.0 meaning that all vehicles of non-zero sizes will be let into buffer only
 	//if flowcap_accumulate > 0.
 	//
 	//Flow capacity easing prevents buses from waiting long time for entering the buffer in sub-sampled scenarios
-	//For instance, for 10% scenario, a car (representing 10 cars) has a size of 1.0, a bus (representing 1 bus) of 0.3,
-	//and link flow capacities are reduced to about 0.1 of the original capacity.
-	//(1) If pcuThresholdForFlowCapacityEasing == 0, all busses following private cars wait long times before entering
-	//the buffer (recovering the flow capacity accumulator takes approx. 10 times longer than in the 100% scenario).
-	//(2) If pcuThresholdForFlowCapacityEasing == 0.3, busses at the front of the queue immediately enter the buffer
-	//(once they arrive at the end of a link).
+	//For instance, for 10% scenario, a car (representing 10 cars) has a size of 1.0 PCU, a bus (representing 1 bus)
+	//has a size of 0.3 PCU, and link flow capacities are reduced to about 0.1 of the original capacity.
+	//(1) If pcuThresholdForFlowCapacityEasing == 0, all buses moving just behind private cars wait long times before
+	//entering the buffer (recovering the flow capacity accumulator in a 10% scenario takes approx. 10 times longer than
+	//in the 100% scenario).
+	//(2) If pcuThresholdForFlowCapacityEasing == 0.3, buses at the front of the queue immediately enter the buffer
+	//(once they arrive at the end of a link). If they (one or more buses) have been queued behind a private car,
+	//they all leave the link at the same time as the preceding private car.
 	private double pcuThresholdForFlowCapacityEasing = 0.0;
 
 	// ---

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLaneI.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLaneI.java
@@ -42,7 +42,7 @@ abstract class QLaneI implements Identifiable<Lane> {
 	
 	abstract void addFromWait( final QVehicle veh);
 
-	abstract boolean isAcceptingFromWait();
+	abstract boolean isAcceptingFromWait(QVehicle veh);
 
 	abstract boolean isActive();
 

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkImpl.java
@@ -134,7 +134,7 @@ public final class QLinkImpl extends AbstractQLink implements SignalizeableItem 
 	 */
 	private void moveWaitToRoad() {
 		while (!getWaitingList().isEmpty()) {
-			if (!qlane.isAcceptingFromWait()) {
+			if (!qlane.isAcceptingFromWait(this.getWaitingList().peek())) {
 				return;
 			}
             QVehicle veh = this.getWaitingList().poll();

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkLanesImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkLanesImpl.java
@@ -381,7 +381,7 @@ public final class QLinkLanesImpl extends AbstractQLink {
 	private boolean moveWaitToRoad(final double now) {
 		boolean movedWaitToRoad = false;
 		while (!getWaitingList().isEmpty()) {
-		    if (!firstLaneQueue.isAcceptingFromWait()) {
+		    if (!firstLaneQueue.isAcceptingFromWait(this.getWaitingList().peek())) {
 		        return movedWaitToRoad;
 		    }
 		    QVehicle veh = this.getWaitingList().poll();

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -204,10 +204,6 @@ final class QueueWithBuffer extends QLaneI implements SignalizeableItem {
 		
 	}
 
-	//for the time being we are not checking veh type etc.; PCU equivalent is fine for testing purposes
-	//vehicles of sizes smaller than the threshold can violate flowCap
-	private static final double PCU_THRESHOLD_FOR_FLOW_CAP_EASING = 0.0;// 0 means no easing...
-	
 	@Override
 	 final void addFromWait(final QVehicle veh) {
 		addToBuffer(veh);
@@ -222,7 +218,8 @@ final class QueueWithBuffer extends QLaneI implements SignalizeableItem {
 		//this check can be moved to 'addFromWait'
 		//it is a double check, and makes only sense to protect against calling addToBuffer() without calling
 		//hasFlowCapacityLeft() first. This only could happen for addFromWait(), because it can be called from outside
-	    if (flowcap_accumulate.getValue() > 0.0  || veh.getVehicle().getType().getPcuEquivalents() < PCU_THRESHOLD_FOR_FLOW_CAP_EASING) {
+		if (flowcap_accumulate.getValue() > 0.0 || veh.getVehicle().getType().getPcuEquivalents() <= context.qsimConfig
+				.getPcuThresholdForFlowCapacityEasing()) {
 			flowcap_accumulate.addValue(-veh.getFlowCapacityConsumptionInEquivalents(), now);
 		} else {
 			throw new IllegalStateException("Buffer of link " + this.id + " has no space left!");
@@ -250,7 +247,8 @@ final class QueueWithBuffer extends QLaneI implements SignalizeableItem {
             updateFastFlowAccumulation();
         }
         
-		return flowcap_accumulate.getValue() > 0.0 || veh.getVehicle().getType().getPcuEquivalents() < PCU_THRESHOLD_FOR_FLOW_CAP_EASING;
+		return flowcap_accumulate.getValue() > 0.0 || veh.getVehicle().getType()
+				.getPcuEquivalents() <= context.qsimConfig.getPcuThresholdForFlowCapacityEasing();
 	}
 
 

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -220,8 +220,8 @@ final class QueueWithBuffer extends QLaneI implements SignalizeableItem {
 		double now = context.getSimTimer().getTimeOfDay() ;
 		
 		//this check can be moved to 'addFromWait'
-		//it is a double check, and makes only sense to protect against calling addToBuffer without calling
-		//hasFlowCapacityLeft() first. This only could happen for addFromWait()
+		//it is a double check, and makes only sense to protect against calling addToBuffer() without calling
+		//hasFlowCapacityLeft() first. This only could happen for addFromWait(), because it can be called from outside
 	    if (flowcap_accumulate.getValue() > 0.0  || veh.getVehicle().getType().getPcuEquivalents() < PCU_THRESHOLD_FOR_FLOW_CAP_EASING) {
 			flowcap_accumulate.addValue(-veh.getFlowCapacityConsumptionInEquivalents(), now);
 		} else {

--- a/playgrounds/kai/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AssignmentEmulatingQLane.java
+++ b/playgrounds/kai/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AssignmentEmulatingQLane.java
@@ -115,7 +115,7 @@ class AssignmentEmulatingQLane extends QLaneI {
 		qLink.getToNode().activateNode();
 	}
 	@Override
-	public final boolean isAcceptingFromWait() {
+	public final boolean isAcceptingFromWait(QVehicle veh) {
 		return true ; // we always accept
 	}
 

--- a/playgrounds/michalm/src/main/java/playground/michalm/telaviv/RunFlowCapEasingScenario.java
+++ b/playgrounds/michalm/src/main/java/playground/michalm/telaviv/RunFlowCapEasingScenario.java
@@ -1,0 +1,34 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package playground.michalm.telaviv;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.config.*;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+
+public class RunFlowCapEasingScenario {
+	public static void main(String[] args) {
+		Config config = ConfigUtils.loadConfig("d:/temp/golan/configtest.xml");
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+		Controler controler = new Controler(scenario);
+		controler.run();	
+	}
+}

--- a/playgrounds/vsptelematics/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/KNCALink.java
+++ b/playgrounds/vsptelematics/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/KNCALink.java
@@ -244,7 +244,7 @@ public class KNCALink {
 			@Override void addFromWait(QVehicle veh) {
 			}
 
-			@Override boolean isAcceptingFromWait() {
+			@Override boolean isAcceptingFromWait(QVehicle veh) {
 				return false ;
 			}
 


### PR DESCRIPTION
This pull request addresses the issue of buses running behind their schedule in sub-sampled scenarios.

Vehicles of size (in PCU) smaller than or equal to this threshold will be allowed to enter the buffer (QueueWithBuffer) even if flowcap_accumulate <= 0.

The default value is 0.0 meaning that all vehicles of non-zero sizes will be let into buffer only if flowcap_accumulate > 0.

Flow capacity easing prevents buses from waiting long time for entering the buffer in sub-sampled scenarios. For instance, for 10% scenario, a car (representing 10 cars) has a size of 1.0 PCU, a bus (representing 1 bus) has a size of 0.3 PCU, and link flow capacities are reduced to about 0.1 of the original capacity.

(1) If pcuThresholdForFlowCapacityEasing == 0, all buses moving just behind private cars wait long times before entering the buffer (recovering the flow capacity accumulator in a 10% scenario takes approx. 10 times longer than in the 100% scenario).

(2) If pcuThresholdForFlowCapacityEasing == 0.3, buses at the front of the queue immediately enter the buffer (once they arrive at the end of a link). If they (one or more buses) have been queued behind a private car, they all leave the link at the same time as the preceding private car.

In both cases, when buses enter the buffer, the corresponding flowcap_accumulate gets reduced appropriately. When using flow capacity easing for selected (not all) vehicles, in the long term, QueueWithBuffer "behaves" similar and flow capacities are not violated. However, temporarily we may reach a higher flow than the limit.