### PR TITLE
remove dependency cycle

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -185,13 +185,6 @@
 							<packages>org.matsim.vis:org.matsim.vis.*</packages>
 						</group>
 					</groups>
-					<additionalDependencies>
-						<additionalDependency>
-							<groupId>org.matsim</groupId>
-							<artifactId>matsim-tutorial</artifactId>
-							<version>0.9.0-SNAPSHOT</version>
-						</additionalDependency>
-					</additionalDependencies>
 					<detectLinks>true</detectLinks>
 					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>


### PR DESCRIPTION
Can we remove that cyclic dependency? Makes it somewhat difficult to build matsim from scratch.
`matsim-tutorial` depends on `matsim `and the maven-javadoc-plugin of `matsim `depends again on `matsim-tutorial`