### PR TITLE
Test the whole packaging. Fix Javadoc Errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - oracle-java8-installer  # https://github.com/travis-ci/travis-ci/issues/3259
 script:
-  - mvn test -B -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
+  - mvn package -B -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
 env:
   global:
     - MAVEN_OPTS="-Xmx2g"

--- a/tutorial/pom.xml
+++ b/tutorial/pom.xml
@@ -52,6 +52,8 @@
 					<quiet>true</quiet>
 					<header>MATSim Tutorial</header>
 					<detectLinks>true</detectLinks>
+					<linksource>true</linksource>
+					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
I'm having travis create the full set of packages, instead of only running the tests.

This would have picked up e.g. MATSIM-727. Now Javadoc generation is under test.