### PR TITLE
bugfix Dijkstra.addToPendingLinks -- prevLink may be null

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/Dijkstra.java
+++ b/matsim/src/main/java/org/matsim/core/router/Dijkstra.java
@@ -463,7 +463,8 @@ public class Dijkstra implements LeastCostPathCalculator {
 		} else if (totalCost == nCost) {
 			// Special case: a node can be reached from two links with exactly the same costs.
 			// Decide based on the linkId which one to take... just have to common criteria to be deterministic.
-			if (data.getPrevLink().getId().compareTo(l.getId()) > 0) {
+			Link prevLink = data.getPrevLink();
+			if (prevLink != null && prevLink.getId().compareTo(l.getId()) > 0) {
 				revisitNode(n, data, pendingNodes, currTime + travelTime, totalCost, l);
 				return true;
 			}


### PR DESCRIPTION
NullPointerException was thrown if prevLink is null, because node n is the node from where the search started (happened for many-to-one search, where n is an ImaginaryNode)