### PR TITLE
Charging tolls as they occur rather than once per day

### DIFF
--- a/contribs/roadpricing/src/main/java/org/matsim/roadpricing/RoadPricingControlerListener.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/roadpricing/RoadPricingControlerListener.java
@@ -20,22 +20,18 @@
 
 package org.matsim.roadpricing;
 
+import javax.inject.Inject;
+
 import org.apache.log4j.Logger;
-import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.controler.events.AfterMobsimEvent;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
 import org.matsim.core.controler.events.StartupEvent;
-import org.matsim.core.controler.listener.AfterMobsimListener;
 import org.matsim.core.controler.listener.IterationEndsListener;
 import org.matsim.core.controler.listener.ShutdownListener;
 import org.matsim.core.controler.listener.StartupListener;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.utils.misc.Time;
-
-import javax.inject.Inject;
 
 /**
  * Integrates the RoadPricing functionality into the MATSim Controler.  Does the 
@@ -57,23 +53,20 @@ import javax.inject.Inject;
  *
  * @author mrieser
  */
-class RoadPricingControlerListener implements StartupListener, AfterMobsimListener,
-IterationEndsListener, ShutdownListener {
+class RoadPricingControlerListener implements StartupListener, IterationEndsListener, ShutdownListener {
 
 	final static private Logger log = Logger.getLogger(RoadPricingControlerListener.class);
 
 	private final RoadPricingScheme scheme;
 	private final CalcPaidToll calcPaidToll;
 	private final CalcAverageTolledTripLength cattl;
-	private EventsManager eventsManager;
 	private OutputDirectoryHierarchy controlerIO;
 
 	@Inject
-	RoadPricingControlerListener(RoadPricingScheme scheme, CalcPaidToll calcPaidToll, CalcAverageTolledTripLength cattl, EventsManager eventsManager, OutputDirectoryHierarchy controlerIO) {
+	RoadPricingControlerListener(RoadPricingScheme scheme, CalcPaidToll calcPaidToll, CalcAverageTolledTripLength cattl, OutputDirectoryHierarchy controlerIO) {
 		this.scheme = scheme;
 		this.calcPaidToll = calcPaidToll;
 		this.cattl = cattl;
-		this.eventsManager = eventsManager;
 		this.controlerIO = controlerIO;
 		Gbl.printBuildInfo("RoadPricing", "/org.matsim.contrib/roadpricing/revision.txt");
 	}
@@ -81,11 +74,7 @@ IterationEndsListener, ShutdownListener {
 	@Override
 	public void notifyStartup(final StartupEvent event) {}
 
-	@Override
-	public void notifyAfterMobsim(final AfterMobsimEvent event) {
-		// evaluate the final tolls paid by the agents and add them to their scores
-		this.calcPaidToll.sendMoneyEvents(Time.MIDNIGHT, eventsManager);
-	}
+	
 
 	@Override
 	public void notifyIterationEnds(final IterationEndsEvent event) {

--- a/contribs/roadpricing/src/main/java/org/matsim/roadpricing/RoadPricingWriterXMLv1.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/roadpricing/RoadPricingWriterXMLv1.java
@@ -99,10 +99,10 @@ public final class RoadPricingWriterXMLv1 extends MatsimXmlWriter {
 	
 	private void writeCost(Cost cost) throws IOException {
     this.writer.write("\t<cost ");
-    if (cost.startTime != Time.UNDEFINED_TIME) {
+    if (!Time.isUndefinedTime(cost.startTime)) {
       this.writer.write("start_time=\"" + Time.writeTime(cost.startTime) + "\" ");
     }
-    if (cost.endTime != Time.UNDEFINED_TIME 
+    if (!Time.isUndefinedTime(cost.endTime) 
     		&& cost.endTime != Double.POSITIVE_INFINITY
     		// The toll reader converts undefined time to POSITIVE_INFINITY since otherwise it does not make sense.
     		// This, however, means that we need to deal with this here as well.  kai, aug'14

--- a/contribs/roadpricing/src/test/java/org/matsim/roadpricing/CalcPaidTollTest.java
+++ b/contribs/roadpricing/src/test/java/org/matsim/roadpricing/CalcPaidTollTest.java
@@ -203,6 +203,7 @@ public class CalcPaidTollTest extends MatsimTestCase {
 
 	private void runTollSimulation(final Scenario scenario, final RoadPricingScheme toll) {
 		EventsManager events = EventsUtils.createEventsManager();
+		@SuppressWarnings("unused")
 		CalcPaidToll paidToll = new CalcPaidToll(scenario.getNetwork(), toll, events);
 		EventsToScore scoring = EventsToScore.createWithScoreUpdating(scenario, new CharyparNagelScoringFunctionFactory(scenario), events);
 		scoring.beginIteration(0);
@@ -211,7 +212,6 @@ public class CalcPaidTollTest extends MatsimTestCase {
 		Mobsim sim = QSimUtils.createDefaultQSim(scenario, events);
 		sim.run();
 
-		paidToll.sendMoneyEvents(Time.MIDNIGHT, events);
 
 		scoring.finish();
 	}


### PR DESCRIPTION
Tolls in roadpricing contrib used to be charged once per day. While this is useful for cars, it is not very useful for taxis or other modes where the driver may want to pass on the toll to the passenger.