### PR TITLE
fix .gefx file export in contrib/minibus/stats

### DIFF
--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPOperatorCount.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPOperatorCount.java
@@ -181,7 +181,9 @@ final class GexfPOperatorCount extends MatsimJaxbXmlWriter implements StartupLis
 			}
 			
 			operatorIdValue.setStart(Double.toString(iteration));
-			operatorCountValue.setStart(Double.toString(iteration));			
+			operatorIdValue.setEnd(Double.toString(iteration));
+			operatorCountValue.setStart(Double.toString(iteration));		
+			operatorCountValue.setEnd(Double.toString(iteration));	
 
 			entry.getValue().getAttvalue().add(operatorIdValue);
 			entry.getValue().getAttvalue().add(operatorCountValue);

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPPaxCount.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPPaxCount.java
@@ -159,6 +159,7 @@ final class GexfPPaxCount extends MatsimJaxbXmlWriter implements StartupListener
 //			attValue.setValue(Integer.toString(Math.max(1, countForLink)));
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			entry.getValue().getAttvalue().add(attValue);
 			this.linkId2CountsFromLastIteration.put(entry.getKey(), countForLink);

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPStat.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPStat.java
@@ -208,6 +208,7 @@ final class GexfPStat extends MatsimJaxbXmlWriter implements StartupListener, It
 			attValue.setFor("weight");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2TotalCountsFromLastIteration.put(linkEntry.getKey(), countForLink);
@@ -249,7 +250,9 @@ final class GexfPStat extends MatsimJaxbXmlWriter implements StartupListener, It
 			}
 			
 			operatorIdValue.setStart(Double.toString(iteration));
+			operatorIdValue.setEnd(Double.toString(iteration));
 			operatorCountValue.setStart(Double.toString(iteration));			
+			operatorCountValue.setEnd(Double.toString(iteration));	
 
 			linkEntry.getValue().getAttvalue().add(operatorIdValue);
 			linkEntry.getValue().getAttvalue().add(operatorCountValue);
@@ -272,6 +275,7 @@ final class GexfPStat extends MatsimJaxbXmlWriter implements StartupListener, It
 			attValue.setFor("nVeh");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2VehCountsFromLastIteration.put(linkEntry.getKey(), countForLink);
@@ -300,6 +304,7 @@ final class GexfPStat extends MatsimJaxbXmlWriter implements StartupListener, It
 						attValue.setFor(lineId);
 						attValue.setValue(Integer.toString(0));
 						attValue.setStart(Double.toString(iteration));
+						attValue.setEnd(Double.toString(iteration));
 						linkEntry.getValue().getAttvalue().add(attValue);
 					}
 				}
@@ -337,6 +342,7 @@ final class GexfPStat extends MatsimJaxbXmlWriter implements StartupListener, It
 					attributeContent.setFor(lineId);
 					attributeContent.setValue(Integer.toString(countForLinkAndLineId));
 					attributeContent.setStart(Double.toString(iteration));
+					attributeContent.setEnd(Double.toString(iteration));
 
 					linkEntry.getValue().getAttvalue().add(attributeContent);
 

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPStatLight.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/GexfPStatLight.java
@@ -186,6 +186,7 @@ final class GexfPStatLight extends MatsimJaxbXmlWriter implements StartupListene
 			attValue.setFor("weight");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2TotalCountsFromLastIteration.put(linkEntry.getKey(), countForLink);
@@ -207,6 +208,7 @@ final class GexfPStatLight extends MatsimJaxbXmlWriter implements StartupListene
 			attValue.setFor("nVeh");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2VehCountsFromLastIteration.put(linkEntry.getKey(), countForLink);

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/SimpleGexfPStat.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/stats/SimpleGexfPStat.java
@@ -177,6 +177,7 @@ final class SimpleGexfPStat extends MatsimJaxbXmlWriter implements IterationEnds
 			attValue.setFor("weight");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2TotalCountsFromLastIteration.put(linkEntry.getKey(), countForLink);
@@ -198,6 +199,7 @@ final class SimpleGexfPStat extends MatsimJaxbXmlWriter implements IterationEnds
 			attValue.setFor("nVeh");
 			attValue.setValue(Integer.toString(countForLink));
 			attValue.setStart(Double.toString(iteration));
+			attValue.setEnd(Double.toString(iteration));
 
 			linkEntry.getValue().getAttvalue().add(attValue);
 			this.linkId2VehCountsFromLastIteration.put(linkEntry.getKey(), countForLink);


### PR DESCRIPTION
The previous implementation only wrote setStart (that means start time
respectively start iteration) for XMLAttvalue values, so these
dynamically changing (at PConfigGroup.WRITE_GEXF_STATS_INTERVAL) values
overlapped, because no end time was defined and more and more values
were added. This caused Gephi to complain about the overlaps and not to
load the exported gefx files.

solution:
Add corresponding setEnd(iteration) to each XMLAttvalue
setStart(iteration), so start and end time/iteration are equal and can
not overlap.

This might lead to gaps if PConfigGroup.WRITE_GEXF_STATS_INTERVAL > 1,
for example:

first value: start=1, end=1; 
next value: start=10, end=10;
...