### PR TITLE
travis increase memory and allow longer time out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
   - test
 
 # this is the script run in the "test" stage:
-script: travis_wait 15 mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
+script: mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && travis_wait 15 mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
 
 # this defines all other stages.
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ stages:
   - package
   - test
 
+# increase memory to speed up tests
+before_script:
+ - "echo $JAVA_OPTS"
+ - "export JAVA_OPTS=-Xmx4g"
+
 # this is the script run in the "test" stage:
 script: mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && travis_wait 20 mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
 
@@ -50,7 +55,7 @@ cache:
   - $HOME/.m2
 env:
   global:
-    - MAVEN_OPTS="-Xmx4g"
+    - MAVEN_OPTS="-Xmx2g"
   matrix:
     - MODULE=matsim                        
     - MODULE=contribs/accessibility        

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
   - test
 
 # this is the script run in the "test" stage:
-script: mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
+script: travis_wait 15 mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
 
 # this defines all other stages.
 jobs:
@@ -50,7 +50,7 @@ cache:
   - $HOME/.m2
 env:
   global:
-    - MAVEN_OPTS="-Xmx2g"
+    - MAVEN_OPTS="-Xmx4g"
   matrix:
     - MODULE=matsim                        
     - MODULE=contribs/accessibility        

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
   - test
 
 # this is the script run in the "test" stage:
-script: mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && travis_wait 15 mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
+script: mvn install --also-make --projects ${MODULE} -DskipTests && cd ${TRAVIS_BUILD_DIR}/${MODULE} && travis_wait 20 mvn failsafe:integration-test --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end
 
 # this defines all other stages.
 jobs:


### PR DESCRIPTION
see MATSim-769 on Atlassian
travis_wait 15 increases time until time out (due to no output received from the test, i.e. a TestClass has completed all its test methods) from 10 to 15 min
increased memory could make tests run faster, avoiding time outs