### PR TITLE
Streaming PopulationWriter writes now V6 output by default

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
@@ -148,7 +148,8 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 			}
 			@Override
 			public Attributes getAttributes() {
-				throw new RuntimeException( "not implemented" );
+				//A stream written Population cannot contain Population Attributes, only Person Attributes.
+				return new Attributes();
 			}
 
 		} ;

--- a/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
@@ -79,7 +79,7 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 			final CoordinateTransformation coordinateTransformation,
 			final double fraction) {
 		this.write_person_fraction = fraction;
-		this.handler = new PopulationWriterHandlerImplV5(coordinateTransformation);
+		this.handler = new PopulationWriterHandlerImplV6(coordinateTransformation);
 	}
 
 	/**


### PR DESCRIPTION
Bringing StreamingPopulateionWriter in line with the ordinary population writer.