### PR TITLE
TransitSchedule v2

### DIFF
--- a/contribs/matsim4urbansim/src/main/java/org/matsim/contrib/matsim4urbansim/utils/io/converter/VISUM2TransitScheduleConverter.java
+++ b/contribs/matsim4urbansim/src/main/java/org/matsim/contrib/matsim4urbansim/utils/io/converter/VISUM2TransitScheduleConverter.java
@@ -38,17 +38,16 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.matsim4urbansim.utils.io.HeaderParser;
 import org.matsim.core.population.routes.NetworkRoute;
-import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.pt.transitSchedule.TransitScheduleFactoryImpl;
-import org.matsim.pt.transitSchedule.TransitScheduleWriterV1;
 import org.matsim.pt.transitSchedule.TransitStopFacilityImpl;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
@@ -65,7 +64,7 @@ public class VISUM2TransitScheduleConverter {
 	private BufferedReader zoneAttributeReader;
 	private BufferedReader reiseZeitenReader;
 	private BufferedReader startWarteZeitenReader;
-	private TransitScheduleWriterV1 writer;
+	private TransitScheduleWriter writer;
 	
 //	private Dijkstra dijkstra;
 	
@@ -423,8 +422,8 @@ public class VISUM2TransitScheduleConverter {
 		}
 		
 		log.info("Writing TransitSchedule ...");
-		writer = new TransitScheduleWriterV1(transitSchedule);
-		writer.write(destinationFile);
+		writer = new TransitScheduleWriter(transitSchedule);
+		writer.writeFile(destinationFile);
 		log.info("Writing done!");
 	}
 

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/ana/TrbAna.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/ana/TrbAna.java
@@ -40,8 +40,8 @@ import org.matsim.core.events.EventsReaderXMLv1;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.pt.transitSchedule.TransitScheduleReaderV1;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
@@ -124,7 +124,7 @@ final class TrbAna implements PersonEntersVehicleEventHandler, PersonLeavesVehic
 		
 		Scenario sc = ScenarioUtils.createScenario(c);
 		new MatsimNetworkReader(sc.getNetwork()).readFile("F:/p_runs/txl/network.final.xml.gz");
-		new TransitScheduleReaderV1(sc).readFile(transitSchedule);
+		new TransitScheduleReader(sc).readFile(transitSchedule);
 		
 		TrbAna ana = new TrbAna("para_", "tr_", sc.getNetwork(), sc.getTransitSchedule(), c);
 		EventsManager manager = EventsUtils.createEventsManager();

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/hook/PBox.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/hook/PBox.java
@@ -47,8 +47,8 @@ import org.matsim.core.controler.events.IterationStartsEvent;
 import org.matsim.core.controler.events.ScoringEvent;
 import org.matsim.core.controler.events.StartupEvent;
 import org.matsim.pt.transitSchedule.TransitScheduleFactoryImpl;
-import org.matsim.pt.transitSchedule.TransitScheduleWriterV1;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
@@ -259,7 +259,7 @@ public final class PBox implements POperators {
 	}
 
 	private void writeScheduleToFile(TransitSchedule schedule, String iterationFilename) {
-		TransitScheduleWriterV1 writer = new TransitScheduleWriterV1(schedule);
-		writer.write(iterationFilename);		
+		TransitScheduleWriter writer = new TransitScheduleWriter(schedule);
+		writer.writeFile(iterationFilename);
 	}
 }

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/hook/PControlerListener.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/hook/PControlerListener.java
@@ -39,9 +39,9 @@ import org.matsim.core.population.algorithms.AbstractPersonAlgorithm;
 import org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils;
 import org.matsim.core.router.PlanRouter;
 import org.matsim.core.scenario.MutableScenario;
-import org.matsim.pt.transitSchedule.TransitScheduleWriterV1;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -187,9 +187,9 @@ final class PControlerListener implements IterationStartsListener, StartupListen
 	}
 
 	private void dumpTransitScheduleAndVehicles(MatsimServices controler, int iteration){
-		TransitScheduleWriterV1 writer = new TransitScheduleWriterV1(controler.getScenario().getTransitSchedule());
+		TransitScheduleWriter writer = new TransitScheduleWriter(controler.getScenario().getTransitSchedule());
 		VehicleWriterV1 writer2 = new VehicleWriterV1(controler.getScenario().getTransitVehicles());
-		writer.write(controler.getControlerIO().getIterationFilename(iteration, "transitSchedule.xml.gz"));
+		writer.writeFile(controler.getControlerIO().getIterationFilename(iteration, "transitSchedule.xml.gz"));
 		writer2.writeFile(controler.getControlerIO().getIterationFilename(iteration, "vehicles.xml.gz"));
 	}
 }

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/operator/CreateOperatorFromTransitSchedule.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/operator/CreateOperatorFromTransitSchedule.java
@@ -28,7 +28,6 @@ import org.matsim.contrib.minibus.routeProvider.PRouteProvider;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.pt.transitSchedule.TransitScheduleReaderV1;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.vehicles.Vehicle;
 
@@ -176,7 +175,7 @@ public final class CreateOperatorFromTransitSchedule implements PStrategy {
 		MutableScenario sc = (MutableScenario) ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		sc.getConfig().transit().setUseTransit(true);
 		log.info("Reading " + transitScheduleToStartWith);
-		new TransitScheduleReaderV1(sc).readFile(transitScheduleToStartWith);
+		new TransitScheduleReader(sc).readFile(transitScheduleToStartWith);
 		return sc.getTransitSchedule();
 	}
 

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PTransitLineMerger.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PTransitLineMerger.java
@@ -28,7 +28,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.pt.transitSchedule.TransitScheduleFactoryImpl;
-import org.matsim.pt.transitSchedule.TransitScheduleReaderV1;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.vehicles.VehicleReaderV1;
 
@@ -167,7 +166,7 @@ public class PTransitLineMerger {
 		
 		VehicleReaderV1 vehicleReader = new VehicleReaderV1(scenario.getTransitVehicles());
 		vehicleReader.readFile(vehicleFile);
-		TransitScheduleReaderV1 scheduleReader = new TransitScheduleReaderV1(scenario);
+		TransitScheduleReader scheduleReader = new TransitScheduleReader(scenario);
 		scheduleReader.readFile(transitScheduleInFile);
 		
 		PTransitLineMerger.mergeSimilarRoutes(scenario.getTransitSchedule());

--- a/contribs/wagonSim/src/main/java/org/matsim/contrib/wagonSim/schedule/mapping/NetworkAdaption.java
+++ b/contribs/wagonSim/src/main/java/org/matsim/contrib/wagonSim/schedule/mapping/NetworkAdaption.java
@@ -23,12 +23,12 @@ import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.misc.Time;
-import org.matsim.pt.transitSchedule.TransitScheduleReaderV1;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.vehicles.VehicleReaderV1;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleWriterV1;
@@ -260,7 +260,7 @@ public class NetworkAdaption {
 		sc.getConfig().transit().setUseTransit(true);
 		sc.getConfig().scenario().setUseVehicles(true);
 		new MatsimNetworkReader(sc.getNetwork()).readFile(networkFile);
-		new TransitScheduleReaderV1(sc).readFile(transitScheduleFile);
+		new TransitScheduleReader(sc).readFile(transitScheduleFile);
 		new VehicleReaderV1(sc.getTransitVehicles()).readFile(transitVehiclesFile);
 		log.info("done. (parsing)");
 

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/Constants.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/Constants.java
@@ -56,6 +56,9 @@ abstract class Constants {
 	static final String STOP_AREA_ID = "stopAreaId";
 	static final String ATTRIBUTES = "attributes";
 	static final String ATTRIBUTE = "attribute";
-	static final String CLASS = "class";
-
+	static final String MINIMAL_TRANSFER_TIMES = "minimalTransferTimes";
+	static final String RELATION = "relation";
+	static final String FROM_STOP = "fromStop";
+	static final String TO_STOP = "toStop";
+	static final String TRANSFER_TIME = "transferTime";
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/Constants.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/Constants.java
@@ -26,31 +26,36 @@ package org.matsim.pt.transitSchedule;
  *
  * @author mrieser
  */
-/*package*/ abstract class Constants {
-	/*package*/ static final String TRANSIT_STOPS = "transitStops";
-	/*package*/ static final String STOP_FACILITY = "stopFacility";
-	/*package*/ static final String TRANSIT_SCHEDULE = "transitSchedule";
-	/*package*/ static final String TRANSIT_LINE = "transitLine";
-	/*package*/ static final String TRANSIT_ROUTE = "transitRoute";
-	/*package*/ static final String DESCRIPTION = "description";
-	/*package*/ static final String ROUTE_PROFILE = "routeProfile";
-	/*package*/ static final String STOP = "stop";
-	/*package*/ static final String ROUTE = "route";
-	/*package*/ static final String LINK = "link";
-	/*package*/ static final String DEPARTURES = "departures";
-	/*package*/ static final String DEPARTURE = "departure";
-	/*package*/ static final String ID = "id";
-	/*package*/ static final String X = "x";
-	/*package*/ static final String Y = "y";
-	/*package*/ static final String NAME = "name";
-	/*package*/ static final String REF_ID = "refId";
-	/*package*/ static final String LINK_REF_ID = "linkRefId";
-	/*package*/ static final String TRANSPORT_MODE = "transportMode";
-	/*package*/ static final String DEPARTURE_TIME = "departureTime";
-	/*package*/ static final String VEHICLE_REF_ID = "vehicleRefId";
-	/*package*/ static final String DEPARTURE_OFFSET = "departureOffset";
-	/*package*/ static final String ARRIVAL_OFFSET = "arrivalOffset";
-	/*package*/ static final String AWAIT_DEPARTURE = "awaitDeparture";
-	/*package*/ static final String IS_BLOCKING = "isBlocking";
+abstract class Constants {
+	static final String TRANSIT_STOPS = "transitStops";
+	static final String STOP_FACILITY = "stopFacility";
+	static final String TRANSIT_SCHEDULE = "transitSchedule";
+	static final String TRANSIT_LINE = "transitLine";
+	static final String TRANSIT_ROUTE = "transitRoute";
+	static final String DESCRIPTION = "description";
+	static final String ROUTE_PROFILE = "routeProfile";
+	static final String STOP = "stop";
+	static final String ROUTE = "route";
+	static final String LINK = "link";
+	static final String DEPARTURES = "departures";
+	static final String DEPARTURE = "departure";
+	static final String ID = "id";
+	static final String X = "x";
+	static final String Y = "y";
+	static final String Z = "z";
+	static final String NAME = "name";
+	static final String REF_ID = "refId";
+	static final String LINK_REF_ID = "linkRefId";
+	static final String TRANSPORT_MODE = "transportMode";
+	static final String DEPARTURE_TIME = "departureTime";
+	static final String VEHICLE_REF_ID = "vehicleRefId";
+	static final String DEPARTURE_OFFSET = "departureOffset";
+	static final String ARRIVAL_OFFSET = "arrivalOffset";
+	static final String AWAIT_DEPARTURE = "awaitDeparture";
+	static final String IS_BLOCKING = "isBlocking";
+	static final String STOP_AREA_ID = "stopAreaId";
+	static final String ATTRIBUTES = "attributes";
+	static final String ATTRIBUTE = "attribute";
+	static final String CLASS = "class";
 
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/DepartureImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/DepartureImpl.java
@@ -22,6 +22,7 @@ package org.matsim.pt.transitSchedule;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 
@@ -35,6 +36,7 @@ public class DepartureImpl implements Departure {
 	private final Id<Departure> id;
 	private final double departureTime;
 	private Id<Vehicle> vehicleId = null;
+	private final Attributes attributes = new Attributes();
 	
 	protected DepartureImpl(final Id<Departure> id, final double departureTime) {
 		this.id = id;
@@ -59,6 +61,11 @@ public class DepartureImpl implements Departure {
 	@Override
 	public Id<Vehicle> getVehicleId() {
 		return this.vehicleId;
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImpl.java
@@ -1,0 +1,162 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of {@link org.matsim.pt.transitSchedule.api.MinimalTransferTimes}
+ *
+ * @author mrieser / SBB
+ */
+class MinimalTransferTimesImpl implements MinimalTransferTimes {
+
+	private Map<Id<TransitStopFacility>, Map<Id<TransitStopFacility>, Double>> minimalTransferTimes = new ConcurrentHashMap<>();
+
+	@Override
+	public double set(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop, double seconds) {
+		if (Double.isNaN(seconds) || Time.isUndefinedTime(seconds)) {
+			return remove(fromStop, toStop);
+		}
+		Map<Id<TransitStopFacility>, Double> innerMap = this.minimalTransferTimes.computeIfAbsent(fromStop, key -> new ConcurrentHashMap<>());
+		Double value = innerMap.put(toStop, seconds);
+		if (value == null) {
+			return Double.NaN;
+		}
+		return 0;
+	}
+
+	@Override
+	public double get(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop) {
+		return get(fromStop, toStop, Double.NaN);
+	}
+
+	@Override
+	public double get(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop, double defaultSeconds) {
+		Map<Id<TransitStopFacility>, Double> innerMap = this.minimalTransferTimes.get(fromStop);
+		if (innerMap == null) {
+			return defaultSeconds;
+		}
+		Double value = innerMap.get(toStop);
+		if (value == null) {
+			return defaultSeconds;
+		}
+		return value;
+	}
+
+	@Override
+	public double remove(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop) {
+		Map<Id<TransitStopFacility>, Double> innerMap = this.minimalTransferTimes.get(fromStop);
+		if (innerMap == null) {
+			return Double.NaN;
+		}
+		Double value = innerMap.remove(toStop);
+		if (value == null) {
+			return Double.NaN;
+		}
+		return value;
+	}
+
+	@Override
+	public MinimalTransferTimesIterator iterator() {
+		return new MinimalTransferTimesIteratorImpl(this.minimalTransferTimes);
+	}
+
+	private static class MinimalTransferTimesIteratorImpl implements  MinimalTransferTimesIterator {
+
+		private Id<TransitStopFacility> nextFromStopId = null;
+		private Id<TransitStopFacility> fromStopId = null;
+		private Id<TransitStopFacility> toStopId = null;
+		private double seconds = Double.NaN;
+		private boolean hasElement = false;
+
+		private Iterator<Map.Entry<Id<TransitStopFacility>, Map<Id<TransitStopFacility>, Double>>> outerIterator;
+		private Iterator<Map.Entry<Id<TransitStopFacility>, Double>> innerIterator;
+
+		MinimalTransferTimesIteratorImpl(Map<Id<TransitStopFacility>, Map<Id<TransitStopFacility>, Double>> values) {
+			this.outerIterator = values.entrySet().iterator();
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (this.innerIterator != null && this.innerIterator.hasNext()) {
+				return true;
+			}
+			while (this.outerIterator.hasNext()) {
+				Map.Entry<Id<TransitStopFacility>, Map<Id<TransitStopFacility>, Double>> outerEntry = this.outerIterator.next();
+				Map<Id<TransitStopFacility>, Double> innerMap = outerEntry.getValue();
+				this.innerIterator = innerMap.entrySet().iterator();
+				if (this.innerIterator.hasNext()) {
+					this.nextFromStopId = outerEntry.getKey();
+					return true;
+				}
+			}
+
+			this.nextFromStopId = null;
+			return false;
+		}
+
+		@Override
+		public void next() {
+			if (this.innerIterator != null && this.innerIterator.hasNext()) {
+				Map.Entry<Id<TransitStopFacility>, Double> e = this.innerIterator.next();
+				this.fromStopId = this.nextFromStopId;
+				this.toStopId = e.getKey();
+				this.seconds = e.getValue();
+				this.hasElement = true;
+			} else {
+				this.hasElement = false;
+				throw new NoSuchElementException();
+			}
+		}
+
+		@Override
+		public Id<TransitStopFacility> getFromStopId() {
+			if (this.hasElement) {
+				return this.fromStopId;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public Id<TransitStopFacility> getToStopId() {
+			if (this.hasElement) {
+				return this.toStopId;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public double getSeconds() {
+			if (this.hasElement) {
+				return this.seconds;
+			}
+			throw new NoSuchElementException();
+		}
+	}
+}

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitLineImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitLineImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 
 /**
@@ -38,7 +39,8 @@ public class TransitLineImpl implements TransitLine {
 
 	private final Id<TransitLine> lineId;
 	private String name = null;
-	private final Map<Id<TransitRoute>, TransitRoute> transitRoutes = new LinkedHashMap<Id<TransitRoute>, TransitRoute>(5);
+	private final Map<Id<TransitRoute>, TransitRoute> transitRoutes = new LinkedHashMap<>(5);
+	private final Attributes attributes = new Attributes();
 
 	protected TransitLineImpl(final Id<TransitLine> id) {
 		this.lineId = id;
@@ -76,6 +78,11 @@ public class TransitLineImpl implements TransitLine {
 	@Override
 	public boolean removeRoute(final TransitRoute route) {
 		return null != this.transitRoutes.remove(route.getId());
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitRouteImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitRouteImpl.java
@@ -32,6 +32,7 @@ import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 
 /**
@@ -43,12 +44,12 @@ public class TransitRouteImpl implements TransitRoute {
 
 	private final Id<TransitRoute> routeId;
 	private NetworkRoute route;
-	private final List<TransitRouteStop> stops = new ArrayList<TransitRouteStop>(8);
+	private final List<TransitRouteStop> stops = new ArrayList<>(8);
 	private String description = null;
-	private final Map<Id<Departure>, Departure> departures = new TreeMap<Id<Departure>, Departure>();
+	private final Map<Id<Departure>, Departure> departures = new TreeMap<>();
 	private String transportMode;
-	private String lineRouteName;
 	private String direction;
+	private final Attributes attributes = new Attributes();
 
 	protected TransitRouteImpl(final Id<TransitRoute> id, final NetworkRoute route, final List<TransitRouteStop> stops, final String transportMode) {
 		this.routeId = id;
@@ -132,20 +133,17 @@ public class TransitRouteImpl implements TransitRoute {
 		return null;
 	}
 
-	public String getLineRouteName() {
-		return lineRouteName;
-	}
-
 	public String getDirection() {
-		return direction;
-	}
-
-	public void setLineRouteName(String lineRouteName) {
-		this.lineRouteName = lineRouteName;
+		return this.direction;
 	}
 
 	public void setDirection(String direction) {
 		this.direction = direction;
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
@@ -48,6 +49,7 @@ public class TransitScheduleImpl implements TransitSchedule {
 	private final ObjectAttributes transitLinesAttributes = new ObjectAttributes();
 	private final ObjectAttributes transitStopsAttributes = new ObjectAttributes();
 	private final Attributes attributes = new Attributes();
+	private final MinimalTransferTimes minimalTransferTimes = new MinimalTransferTimesImpl();
 
 	protected TransitScheduleImpl(final TransitScheduleFactory builder) {
 		this.factory = builder;
@@ -125,5 +127,10 @@ public class TransitScheduleImpl implements TransitSchedule {
 	@Override
 	public Attributes getAttributes() {
 		return this.attributes;
+	}
+
+	@Override
+	public MinimalTransferTimes getMinimalTransferTimes() {
+		return this.minimalTransferTimes;
 	}
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleImpl.java
@@ -30,6 +30,7 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.utils.objectattributes.ObjectAttributes;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 
 /**
@@ -41,12 +42,13 @@ import org.matsim.utils.objectattributes.ObjectAttributes;
  */
 public class TransitScheduleImpl implements TransitSchedule {
 
-	private final Map<Id<TransitLine>, TransitLine> transitLines = new TreeMap<Id<TransitLine>, TransitLine>();
-	private final Map<Id<TransitStopFacility>, TransitStopFacility> stopFacilities = new TreeMap<Id<TransitStopFacility>, TransitStopFacility>();
+	private final Map<Id<TransitLine>, TransitLine> transitLines = new TreeMap<>();
+	private final Map<Id<TransitStopFacility>, TransitStopFacility> stopFacilities = new TreeMap<>();
 	private final TransitScheduleFactory factory;
 	private final ObjectAttributes transitLinesAttributes = new ObjectAttributes();
 	private final ObjectAttributes transitStopsAttributes = new ObjectAttributes();
-	
+	private final Attributes attributes = new Attributes();
+
 	protected TransitScheduleImpl(final TransitScheduleFactory builder) {
 		this.factory = builder;
 	}
@@ -119,5 +121,9 @@ public class TransitScheduleImpl implements TransitSchedule {
 	public ObjectAttributes getTransitStopsAttributes() {
 		return this.transitStopsAttributes;
 	}
-	
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
+	}
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV1.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV1.java
@@ -64,17 +64,7 @@ public class TransitScheduleReaderV1 extends MatsimXmlParser {
 	private TempRoute currentRouteProfile = null;
 
 	private final CoordinateTransformation coordinateTransformation;
-	private final StringCache cache = new StringCache(); 
-
-	/**
-	 * @param schedule
-	 * @param network
-	 * @deprecated use {@link #TransitScheduleReaderV1(TransitSchedule, RouteFactories)}
-	 */
-	@Deprecated
-	public TransitScheduleReaderV1(final TransitSchedule schedule, final Network network) {
-		this(schedule, new RouteFactories());
-	}
+	private final StringCache cache = new StringCache();
 
 	public TransitScheduleReaderV1(final TransitSchedule schedule, final RouteFactories routeFactory) {
 		this( new IdentityTransformation() , schedule , routeFactory );
@@ -82,7 +72,7 @@ public class TransitScheduleReaderV1 extends MatsimXmlParser {
 
 	public TransitScheduleReaderV1(final Scenario scenario) {
 		this( scenario.getTransitSchedule(),
-				((PopulationFactory) (scenario.getPopulation().getFactory())).getRouteFactories() );
+				scenario.getPopulation().getFactory().getRouteFactories() );
 	}
 
 	public TransitScheduleReaderV1(
@@ -90,7 +80,7 @@ public class TransitScheduleReaderV1 extends MatsimXmlParser {
 			final Scenario scenario) {
 		this( coordinateTransformation,
 				scenario.getTransitSchedule(),
-				((PopulationFactory) (scenario.getPopulation().getFactory())).getRouteFactories() );
+				scenario.getPopulation().getFactory().getRouteFactories() );
 	}
 
 	public TransitScheduleReaderV1(

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV2.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV2.java
@@ -169,6 +169,11 @@ public class TransitScheduleReaderV2 extends MatsimXmlParser {
 			}
 			stop.awaitDeparture = Boolean.parseBoolean(atts.getValue(Constants.AWAIT_DEPARTURE));
 			this.currentTransitRoute.stops.add(stop);
+		} else if (Constants.RELATION.equals(name)) {
+			Id<TransitStopFacility> fromStop = Id.create(atts.getValue(Constants.FROM_STOP), TransitStopFacility.class);
+			Id<TransitStopFacility> toStop = Id.create(atts.getValue(Constants.TO_STOP), TransitStopFacility.class);
+			double transferTime = Time.parseTime(atts.getValue(Constants.TRANSFER_TIME));
+			this.schedule.getMinimalTransferTimes().set(fromStop, toStop, transferTime);
 		} else if (Constants.ATTRIBUTE.equals(name)) {
 			this.attributesDelegate.startTag(name, atts, context, this.currentAttributes);
 		} else if (Constants.ATTRIBUTES.equals(name)) {

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV2.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV2.java
@@ -1,0 +1,293 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
+import org.matsim.core.utils.io.MatsimXmlParser;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitStopArea;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
+import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
+import org.matsim.vehicles.Vehicle;
+import org.xml.sax.Attributes;
+
+/**
+ * Reads a transit schedule from a XML file in the format described by <code>transitSchedule_v1.dtd</code>.
+ *
+ * @author mrieser
+ */
+public class TransitScheduleReaderV2 extends MatsimXmlParser {
+
+	private final TransitSchedule schedule;
+	private final RouteFactories routeFactory;
+
+	private TransitLine currentTransitLine = null;
+	private TempTransitRoute currentTransitRoute = null;
+	private TempRoute currentRouteProfile = null;
+	private Departure currentDeparture = null;
+
+	private final AttributesXmlReaderDelegate attributesDelegate = new AttributesXmlReaderDelegate();
+	private org.matsim.utils.objectattributes.attributable.Attributes currentAttributes = null;
+
+	private final CoordinateTransformation coordinateTransformation;
+	private final StringCache cache = new StringCache();
+
+	public TransitScheduleReaderV2(final TransitSchedule schedule, final RouteFactories routeFactory) {
+		this( new IdentityTransformation() , schedule , routeFactory );
+	}
+
+	public TransitScheduleReaderV2(final Scenario scenario) {
+		this( scenario.getTransitSchedule(),
+				scenario.getPopulation().getFactory().getRouteFactories() );
+	}
+
+	public TransitScheduleReaderV2(
+			final CoordinateTransformation coordinateTransformation,
+			final Scenario scenario) {
+		this( coordinateTransformation,
+				scenario.getTransitSchedule(),
+				scenario.getPopulation().getFactory().getRouteFactories() );
+	}
+
+	public TransitScheduleReaderV2(
+			CoordinateTransformation coordinateTransformation,
+			TransitSchedule schedule,
+			RouteFactories routeFactory) {
+		this.coordinateTransformation = coordinateTransformation;
+		this.schedule = schedule;
+		this.routeFactory = routeFactory;
+	}
+
+	@Override
+	public void startTag(final String name, final Attributes atts, final Stack<String> context) {
+		if (Constants.STOP_FACILITY.equals(name)) {
+			boolean isBlocking = Boolean.parseBoolean(atts.getValue(Constants.IS_BLOCKING));
+			Coord coord = atts.getValue(Constants.Z) == null ?
+					new Coord(Double.parseDouble(atts.getValue(Constants.X)), Double.parseDouble(atts.getValue(Constants.Y))) :
+					new Coord(Double.parseDouble(atts.getValue(Constants.X)), Double.parseDouble(atts.getValue(Constants.Y)), Double.parseDouble(atts.getValue(Constants.Z)));
+			TransitStopFacility stop =
+					this.schedule.getFactory().createTransitStopFacility(
+							Id.create(atts.getValue(Constants.ID), TransitStopFacility.class),
+							this.coordinateTransformation.transform(coord),
+							isBlocking);
+			this.currentAttributes = stop.getAttributes();
+			if (atts.getValue(Constants.LINK_REF_ID) != null) {
+				Id<Link> linkId = Id.create(atts.getValue(Constants.LINK_REF_ID), Link.class);
+				stop.setLinkId(linkId);
+			}
+			if (atts.getValue(Constants.NAME) != null) {
+				stop.setName(this.cache.get(atts.getValue(Constants.NAME)));
+			}
+			if (atts.getValue(Constants.STOP_AREA_ID) != null) {
+				stop.setStopAreaId(Id.create(atts.getValue(Constants.STOP_AREA_ID), TransitStopArea.class));
+			}
+			this.schedule.addStopFacility(stop);
+		} else if (Constants.TRANSIT_LINE.equals(name)) {
+			Id<TransitLine> id = Id.create(atts.getValue(Constants.ID), TransitLine.class);
+			this.currentTransitLine = this.schedule.getFactory().createTransitLine(id);
+			this.currentAttributes = this.currentTransitLine.getAttributes();
+			if (atts.getValue(Constants.NAME) != null) {
+				this.currentTransitLine.setName(atts.getValue(Constants.NAME));
+			}
+			this.schedule.addTransitLine(this.currentTransitLine);
+		} else if (Constants.TRANSIT_ROUTE.equals(name)) {
+			Id<TransitRoute> id = Id.create(atts.getValue(Constants.ID), TransitRoute.class);
+			this.currentTransitRoute = new TempTransitRoute(id);
+			this.currentAttributes = this.currentTransitRoute.attributes;
+		} else if (Constants.DEPARTURE.equals(name)) {
+			Id<Departure> id = Id.create(atts.getValue(Constants.ID), Departure.class);
+			this.currentDeparture = new DepartureImpl(id, Time.parseTime(atts.getValue("departureTime")));
+			this.currentAttributes = this.currentDeparture.getAttributes();
+			String vehicleRefId = atts.getValue(Constants.VEHICLE_REF_ID);
+			if (vehicleRefId != null) {
+				this.currentDeparture.setVehicleId(Id.create(vehicleRefId, Vehicle.class));
+			}
+			this.currentTransitRoute.departures.put(id, this.currentDeparture);
+		} else if (Constants.ROUTE_PROFILE.equals(name)) {
+			this.currentRouteProfile = new TempRoute();
+		} else if (Constants.LINK.equals(name)) {
+			String linkStr = atts.getValue(Constants.REF_ID);
+			if (!linkStr.contains(" ")) {
+				this.currentRouteProfile.addLink(Id.create(linkStr, Link.class));
+			} else {
+				String[] links = linkStr.split(" ");
+				for (int i = 0; i < links.length; i++) {
+					this.currentRouteProfile.addLink(Id.create(links[i], Link.class));
+				}
+			}
+		} else if (Constants.STOP.equals(name)) {
+			Id<TransitStopFacility> id = Id.create(atts.getValue(Constants.REF_ID), TransitStopFacility.class);
+			TransitStopFacility facility = this.schedule.getFacilities().get(id);
+			if (facility == null) {
+				throw new RuntimeException("no stop/facility with id " + atts.getValue(Constants.REF_ID));
+			}
+			TempStop stop = new TempStop(facility);
+			String arrival = atts.getValue(Constants.ARRIVAL_OFFSET);
+			String departure = atts.getValue(Constants.DEPARTURE_OFFSET);
+			if (arrival != null) {
+				stop.arrival = Time.parseTime(arrival);
+			}
+			if (departure != null) {
+				stop.departure = Time.parseTime(departure);
+			}
+			stop.awaitDeparture = Boolean.parseBoolean(atts.getValue(Constants.AWAIT_DEPARTURE));
+			this.currentTransitRoute.stops.add(stop);
+		} else if (Constants.ATTRIBUTE.equals(name)) {
+			this.attributesDelegate.startTag(name, atts, context, this.currentAttributes);
+		} else if (Constants.ATTRIBUTES.equals(name)) {
+			this.attributesDelegate.startTag(name, atts, context, this.currentAttributes);
+		} else if (Constants.TRANSIT_SCHEDULE.equals(name)) {
+			this.currentAttributes = this.schedule.getAttributes();
+		}
+	}
+
+	@Override
+	public void endTag(final String name, final String content, final Stack<String> context) {
+		if (Constants.DEPARTURE.equals(name)) {
+			this.currentDeparture = null;
+		}
+		if (Constants.DESCRIPTION.equals(name) && Constants.TRANSIT_ROUTE.equals(context.peek())) {
+			this.currentTransitRoute.description = content;
+		} else if (Constants.TRANSPORT_MODE.equals(name)) {
+			this.currentTransitRoute.mode = content.intern();
+		} else if (Constants.DEPARTURE.equals(name)) {
+			this.currentDeparture = null;
+		} else if (Constants.TRANSIT_ROUTE.equals(name)) {
+			List<TransitRouteStop> stops = new ArrayList<>(this.currentTransitRoute.stops.size());
+			for (TempStop tStop : this.currentTransitRoute.stops) {
+				TransitRouteStopImpl routeStop = new TransitRouteStopImpl(tStop.stop, tStop.arrival, tStop.departure);
+				stops.add(routeStop);
+				routeStop.setAwaitDepartureTime(tStop.awaitDeparture);
+			}
+			NetworkRoute route = null;
+			if (this.currentRouteProfile.firstLinkId != null) {
+				if (this.currentRouteProfile.lastLinkId == null) {
+					this.currentRouteProfile.lastLinkId = this.currentRouteProfile.firstLinkId;
+				}
+				route = this.routeFactory.createRoute(NetworkRoute.class, this.currentRouteProfile.firstLinkId, this.currentRouteProfile.lastLinkId);
+				route.setLinkIds(this.currentRouteProfile.firstLinkId, this.currentRouteProfile.linkIds, this.currentRouteProfile.lastLinkId);
+			}
+			TransitRoute transitRoute = this.schedule.getFactory().createTransitRoute(this.currentTransitRoute.id, route, stops, this.currentTransitRoute.mode);
+			transitRoute.setDescription(this.currentTransitRoute.description);
+			for (Departure departure : this.currentTransitRoute.departures.values()) {
+				transitRoute.addDeparture(departure);
+			}
+			AttributesUtils.copyTo(this.currentTransitRoute.attributes, transitRoute.getAttributes());
+			this.currentTransitLine.addRoute(transitRoute);
+			this.currentTransitRoute = null;
+		} else if (Constants.TRANSIT_LINE.equals(name)) {
+			this.currentTransitLine = null;
+		} else if (Constants.ATTRIBUTE.equals(name)) {
+			this.attributesDelegate.endTag(name, content, context);
+		} else if (Constants.ATTRIBUTES.equals(name)) {
+			this.currentAttributes = null;
+		}
+	}
+
+	private static class TempTransitRoute {
+		protected final Id<TransitRoute> id;
+		protected final org.matsim.utils.objectattributes.attributable.Attributes attributes = new org.matsim.utils.objectattributes.attributable.Attributes();
+		protected String description = null;
+		protected Map<Id<Departure>, Departure> departures = new LinkedHashMap<>();
+		/*package*/ List<TempStop> stops = new ArrayList<>();
+		/*package*/ String mode = null;
+
+		protected TempTransitRoute(final Id<TransitRoute> id) {
+			this.id = id;
+		}
+	}
+
+	private static class TempStop {
+		protected final TransitStopFacility stop;
+		protected double departure = Time.UNDEFINED_TIME;
+		protected double arrival = Time.UNDEFINED_TIME;
+		protected boolean awaitDeparture = false;
+
+		protected TempStop(final TransitStopFacility stop) {
+			this.stop = stop;
+		}
+	}
+
+	private static class TempRoute {
+		/*package*/ List<Id<Link>> linkIds = new ArrayList<>();
+		/*package*/ Id<Link> firstLinkId = null;
+		/*package*/ Id<Link> lastLinkId = null;
+
+		protected TempRoute() {
+			// public constructor for private inner class
+		}
+
+		protected void addLink(final Id<Link> linkId) {
+			if (this.firstLinkId == null) {
+				this.firstLinkId = linkId;
+			} else if (this.lastLinkId == null) {
+				this.lastLinkId = linkId;
+			} else {
+				this.linkIds.add(this.lastLinkId);
+				this.lastLinkId = linkId;
+			}
+		}
+
+	}
+
+	private static class StringCache {
+
+		private ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>(10000);
+
+		/**
+		 * Returns the cached version of the given String. If the strings was
+		 * not yet in the cache, it is added and returned as well.
+		 *
+		 * @param string
+		 * @return cached version of string
+		 */
+		public String get(final String string) {
+			if (string == null) {
+				return null;
+			}
+			String s = this.cache.putIfAbsent(string, string);
+			if (s == null) {
+				return string;
+			}
+			return s;
+		}
+	}
+
+}

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleWriterV2.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleWriterV2.java
@@ -37,6 +37,7 @@ import org.matsim.core.utils.io.MatsimXmlWriter;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
@@ -93,6 +94,7 @@ public class TransitScheduleWriterV2 extends MatsimXmlWriter implements MatsimSo
 		this.attributesWriter.writeAttributes( "\t" , this.writer , this.schedule.getAttributes() );
 
 		this.writeTransitStops();
+		this.writeMinimalTransferTimes();
 		for (TransitLine line : this.schedule.getTransitLines().values()) {
 			writeTransitLine(line);
 		}
@@ -137,6 +139,23 @@ public class TransitScheduleWriterV2 extends MatsimXmlWriter implements MatsimSo
 		}
 
 		this.writeEndTag(Constants.TRANSIT_STOPS);
+	}
+
+	private void writeMinimalTransferTimes() {
+		List<Tuple<String, String>> attributes = new ArrayList<>(5);
+		MinimalTransferTimes.MinimalTransferTimesIterator iter = this.schedule.getMinimalTransferTimes().iterator();
+		if (iter.hasNext()) {
+			this.writeStartTag(Constants.MINIMAL_TRANSFER_TIMES, attributes);
+			while (iter.hasNext()) {
+				iter.next();
+				attributes.clear();
+				attributes.add(createTuple(Constants.FROM_STOP, iter.getFromStopId().toString()));
+				attributes.add(createTuple(Constants.TO_STOP, iter.getToStopId().toString()));
+				attributes.add(createTuple(Constants.TRANSFER_TIME, iter.getSeconds()));
+				this.writeStartTag(Constants.RELATION, attributes, true);
+			}
+			this.writeEndTag(Constants.MINIMAL_TRANSFER_TIMES);
+		}
 	}
 
 	private void writeTransitLine(final TransitLine line) throws IOException,  UncheckedIOException {

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleWriterV2.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleWriterV2.java
@@ -1,0 +1,258 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.api.internal.MatsimSomeWriter;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.utils.collections.Tuple;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
+import org.matsim.core.utils.io.MatsimXmlWriter;
+import org.matsim.core.utils.io.UncheckedIOException;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
+import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
+
+/**
+ * Writes a transit schedule to a XML file in the format described by <code>transitSchedule_v2.dtd</code>.
+ *
+ * @author mrieser
+ */
+public class TransitScheduleWriterV2 extends MatsimXmlWriter implements MatsimSomeWriter {
+
+	private final CoordinateTransformation coordinateTransformation;
+	private final TransitSchedule schedule;
+	private final AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
+
+	public TransitScheduleWriterV2(final TransitSchedule schedule) {
+		this(new IdentityTransformation() , schedule);
+	}
+
+	public TransitScheduleWriterV2(
+			final CoordinateTransformation coordinateTransformation,
+			final TransitSchedule schedule) {
+		this.coordinateTransformation = coordinateTransformation;
+		this.schedule = schedule;
+	}
+
+	public void write(OutputStream stream) throws UncheckedIOException {
+		this.openOutputStream(stream);
+		try {
+			writeData();
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	public void write(final String filename) throws UncheckedIOException {
+		this.openFile(filename);
+		try {
+			writeData();
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void writeData() throws IOException, UncheckedIOException {
+		this.writeXmlHead();
+		this.writeDoctype(Constants.TRANSIT_SCHEDULE, "http://www.matsim.org/files/dtd/transitSchedule_v2.dtd");
+		this.writeStartTag(Constants.TRANSIT_SCHEDULE, null);
+		this.writer.write(NL);
+		this.attributesWriter.writeAttributes( "\t" , this.writer , this.schedule.getAttributes() );
+
+		this.writeTransitStops();
+		for (TransitLine line : this.schedule.getTransitLines().values()) {
+			writeTransitLine(line);
+		}
+		this.writeEndTag(Constants.TRANSIT_SCHEDULE);
+		this.close();
+	}
+
+	private void writeTransitStops() throws IOException, UncheckedIOException {
+		this.writeStartTag(Constants.TRANSIT_STOPS, null);
+
+		List<Tuple<String, String>> attributes = new ArrayList<>(5);
+		for (TransitStopFacility stop : this.schedule.getFacilities().values()) {
+			attributes.clear();
+			attributes.add(createTuple(Constants.ID, stop.getId().toString()));
+			final Coord coord = this.coordinateTransformation.transform( stop.getCoord() );
+			attributes.add(createTuple("x", coord.getX()));
+			attributes.add(createTuple("y", coord.getY()));
+			if (coord.hasZ()) {
+				attributes.add(createTuple("z", coord.getZ()));
+			}
+			if (stop.getLinkId() != null) {
+				attributes.add(createTuple("linkRefId", stop.getLinkId().toString()));
+			}
+			if (stop.getName() != null) {
+				attributes.add(createTuple("name", stop.getName()));
+			}
+			if (stop.getStopAreaId() != null) {
+				attributes.add(createTuple(Constants.STOP_AREA_ID, stop.getStopAreaId().toString()));
+			}
+			attributes.add(createTuple("isBlocking", stop.getIsBlockingLane()));
+			if (AttributesUtils.isEmpty(stop.getAttributes())) {
+				this.writeStartTag(Constants.STOP_FACILITY, attributes, true);
+			} else {
+				this.writeStartTag(Constants.STOP_FACILITY, attributes, false);
+				if (!AttributesUtils.isEmpty(stop.getAttributes())) {
+					this.writer.write(NL);
+					this.attributesWriter.writeAttributes("\t\t\t", this.writer, stop.getAttributes());
+				}
+				this.writeEndTag(Constants.STOP_FACILITY);
+
+			}
+		}
+
+		this.writeEndTag(Constants.TRANSIT_STOPS);
+	}
+
+	private void writeTransitLine(final TransitLine line) throws IOException,  UncheckedIOException {
+		List<Tuple<String, String>> attributes = new ArrayList<>(1);
+		attributes.add(createTuple(Constants.ID, line.getId().toString()));
+		if (line.getName() != null) {
+			attributes.add(createTuple(Constants.NAME, line.getName()));
+		}
+		this.writeStartTag(Constants.TRANSIT_LINE, attributes);
+		if (!AttributesUtils.isEmpty(line.getAttributes())) {
+			this.writer.write(NL);
+			this.attributesWriter.writeAttributes("\t\t", this.writer, line.getAttributes());
+		}
+
+		for (TransitRoute route : line.getRoutes().values()) {
+			writeTransitRoute(route);
+		}
+
+		this.writeEndTag(Constants.TRANSIT_LINE);
+	}
+
+	private void writeTransitRoute(final TransitRoute route) throws IOException, UncheckedIOException {
+		List<Tuple<String, String>> attributes = new ArrayList<>(1);
+		attributes.add(createTuple(Constants.ID, route.getId().toString()));
+		this.writeStartTag(Constants.TRANSIT_ROUTE, attributes);
+
+		if (!AttributesUtils.isEmpty(route.getAttributes())) {
+			this.writer.write(NL);
+			this.attributesWriter.writeAttributes("\t\t\t", this.writer, route.getAttributes());
+		}
+
+		if (route.getDescription() != null) {
+			this.writeStartTag(Constants.DESCRIPTION, null);
+			this.writeContent(route.getDescription(), false);
+			this.writeEndTag(Constants.DESCRIPTION);
+		}
+
+		this.writeStartTag(Constants.TRANSPORT_MODE, null);
+		this.writeContent(route.getTransportMode(), false);
+		this.writeEndTag(Constants.TRANSPORT_MODE);
+
+		this.writeRouteProfile(route.getStops());
+		this.writeRoute(route.getRoute());
+		this.writeDepartures(route.getDepartures());
+
+		this.writeEndTag(Constants.TRANSIT_ROUTE);
+	}
+
+	private void writeRouteProfile(final List<TransitRouteStop> stops) throws UncheckedIOException {
+		this.writeStartTag(Constants.ROUTE_PROFILE, null);
+
+		// optimization: only create one List for multiple departures
+		List<Tuple<String, String>> attributes = new ArrayList<>(4);
+		for (TransitRouteStop stop : stops) {
+			attributes.clear();
+			attributes.add(createTuple(Constants.REF_ID, stop.getStopFacility().getId().toString()));
+			if (stop.getArrivalOffset() != Time.UNDEFINED_TIME) {
+				attributes.add(createTimeTuple(Constants.ARRIVAL_OFFSET, stop.getArrivalOffset()));
+			}
+			if (stop.getDepartureOffset() != Time.UNDEFINED_TIME) {
+				attributes.add(createTimeTuple(Constants.DEPARTURE_OFFSET, stop.getDepartureOffset()));
+			}
+			attributes.add(createTuple(Constants.AWAIT_DEPARTURE, String.valueOf(stop.isAwaitDepartureTime())));
+			this.writeStartTag(Constants.STOP, attributes, true);
+		}
+
+		this.writeEndTag(Constants.ROUTE_PROFILE);
+	}
+
+	private void writeRoute(final NetworkRoute route) throws UncheckedIOException {
+		if (route != null) {
+			this.writeStartTag(Constants.ROUTE, null);
+
+			// optimization: only create one List for multiple departures
+			List<Tuple<String, String>> attributes = new ArrayList<>(1);
+			attributes.add(createTuple(Constants.REF_ID, route.getStartLinkId().toString()));
+			this.writeStartTag(Constants.LINK, attributes, true);
+
+			for (Id<Link> linkId : route.getLinkIds()) {
+				attributes.clear();
+				attributes.add(createTuple(Constants.REF_ID, linkId.toString()));
+				this.writeStartTag(Constants.LINK, attributes, true);
+			}
+
+			attributes.clear();
+			attributes.add(createTuple(Constants.REF_ID, route.getEndLinkId().toString()));
+			this.writeStartTag(Constants.LINK, attributes, true);
+
+			this.writeEndTag(Constants.ROUTE);
+		}
+	}
+
+	private void writeDepartures(final Map<Id<Departure>, Departure> departures) throws IOException, UncheckedIOException {
+		this.writeStartTag(Constants.DEPARTURES, null);
+
+		// optimization: only create one List for multiple departures
+		List<Tuple<String, String>> attributes = new ArrayList<>(3);
+
+		for (Departure dep : departures.values()) {
+			attributes.clear();
+			attributes.add(createTuple(Constants.ID, dep.getId().toString()));
+			attributes.add(createTimeTuple(Constants.DEPARTURE_TIME, dep.getDepartureTime()));
+			if (dep.getVehicleId() != null) {
+				attributes.add(createTuple(Constants.VEHICLE_REF_ID, dep.getVehicleId().toString()));
+			}
+			if (AttributesUtils.isEmpty(dep.getAttributes())) {
+				this.writeStartTag(Constants.DEPARTURE, attributes, true);
+			} else {
+				this.writeStartTag(Constants.DEPARTURE, attributes, false);
+				this.writer.write(NL);
+				this.attributesWriter.writeAttributes("\t\t\t\t\t", this.writer, dep.getAttributes());
+				this.writeEndTag(Constants.DEPARTURE);
+			}
+
+		}
+
+		this.writeEndTag(Constants.DEPARTURES);
+	}
+}

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitStopFacilityImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitStopFacilityImpl.java
@@ -27,7 +27,9 @@ import org.matsim.api.core.v01.Customizable;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.scenario.CustomizableUtils;
+import org.matsim.pt.transitSchedule.api.TransitStopArea;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * A facility (infrastructure) describing a public transport stop.
@@ -37,18 +39,18 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 public class TransitStopFacilityImpl implements TransitStopFacility {
 	
 	private final Id<TransitStopFacility> id;
-	private String stopPostAreaId;
+	private Id<TransitStopArea> stopAreaId;
 	private Coord coord;
 	private Id<Link> linkId = null;
 	private final boolean isBlockingLane;
 	private String name = null;
 	private Customizable customizableDelegate;
+	private final Attributes attributes = new Attributes();
 
 	protected TransitStopFacilityImpl(final Id<TransitStopFacility> id, final Coord coord, final boolean isBlockingLane) {
 		this.id = id;
 		this.coord = coord;
 		this.isBlockingLane = isBlockingLane;
-		this.stopPostAreaId = id.toString();
 	}
 
 	@Override
@@ -97,13 +99,13 @@ public class TransitStopFacilityImpl implements TransitStopFacility {
 	}
 
 	@Override
-	public String getStopPostAreaId() {
-		return stopPostAreaId;
+	public Id<TransitStopArea> getStopAreaId() {
+		return this.stopAreaId;
 	}
 
 	@Override
-	public void setStopPostAreaId(String stopPostAreaId) {
-		this.stopPostAreaId = stopPostAreaId;
+	public void setStopAreaId(Id<TransitStopArea> stopAreaId) {
+		this.stopAreaId = stopAreaId;
 	}
 	
 	@Override
@@ -114,5 +116,8 @@ public class TransitStopFacilityImpl implements TransitStopFacility {
 		return this.customizableDelegate.getCustomAttributes();
 	}
 
-
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
+	}
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/MinimalTransferTimes.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/MinimalTransferTimes.java
@@ -1,0 +1,98 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule.api;
+
+import org.matsim.api.core.v01.Id;
+
+/**
+ * Container class to manage minimal transfer times between two {@link TransitStopFacility}.
+ * Transfer times are *not* bidirectional and *not* transitive. This means:
+ * <ul>
+ *     <li>A transfer time defined from stop A to stop B does not define a transfer time from stop B to stop A.</li>
+ *     <li>A transfer time defined from stop A to stop B, and another defined from stop B to stop C, does not define a transfer time from stop A to stop C.</li>
+ * </ul>
+ * Both cases, the reverse transfer from stop B to stop A, and the indirect transfer from stop A to stop C via stop B,
+ * must explicitly be set in order to be returned in {@link #get(Id, Id)}.
+ *
+ * @author mrieser / SBB
+ */
+public interface MinimalTransferTimes {
+
+	/**
+	 * Sets the minimal transfer time in seconds needed to transfer from <code>fromStop</code> to <code>toStop</code>.
+	 * @param fromStop
+	 * @param toStop
+	 * @param seconds the minimal transfer time, in seconds
+	 * @return the minimal transfer time previously assigned between the two stops, <code>Double.NaN</code> if none was specified.
+	 */
+	double set(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop, double seconds);
+
+	/**
+	 * @param fromStop
+	 * @param toStop
+	 * @return the minimal transfer time between the two stops if defined, <code>Double.NaN</code> if none is set.
+	 */
+	double get(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop);
+
+	/**
+	 * @param fromStop
+	 * @param toStop
+	 * @param defaultSeconds
+	 * @return the minimal transfer time between the two stops if defined, <code>defaultSeconds</code> if none is set.
+	 */
+	double get(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop, double defaultSeconds);
+
+	/**
+	 * Removes the minimal transfer time between the two stops if there was one set.
+	 * @param fromStop
+	 * @param toStop
+	 * @return the previously set minimal transfer time, or <code>Double.NaN</code> if none was set.
+	 */
+	double remove(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop);
+
+	/**
+	 * @return an iterator to iterate over all minimal transfer times set.
+	 */
+	MinimalTransferTimesIterator iterator();
+
+	interface MinimalTransferTimesIterator {
+		boolean hasNext();
+
+		/**
+		 * advances the iterator to the next element
+		 */
+		void next();
+
+		/**
+		 * @return the Id of the fromStop of the current iterator element.
+		 */
+		Id<TransitStopFacility> getFromStopId();
+
+		/**
+		 * @return the Id of the toStop of the current iterator element.
+		 */
+		Id<TransitStopFacility> getToStopId();
+
+		/**
+		 * @return the minimal transfer time in seconds of the current iterator element.
+		 */
+		double getSeconds();
+	}
+}

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitLine.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitLine.java
@@ -24,13 +24,14 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * Description of a single transit line. Can have multiple routes (e.g. from A to B and from B to A).
  * 
  * @author mrieser
  */
-public interface TransitLine extends Identifiable<TransitLine> {
+public interface TransitLine extends Identifiable<TransitLine>, Attributable {
 
 	/**
 	 * Adds the specified transit route to this line.
@@ -38,23 +39,23 @@ public interface TransitLine extends Identifiable<TransitLine> {
 	 * @param transitRoute
 	 * @throws IllegalArgumentException if there is already a route with the same Id
 	 */
-	public abstract void addRoute(final TransitRoute transitRoute);
+	void addRoute(final TransitRoute transitRoute);
 
 	
 	/**
 	 * @return immutable Map containing all transit routes assigned to this transit line
 	 */
-	public abstract Map<Id<TransitRoute>, TransitRoute> getRoutes();
+	Map<Id<TransitRoute>, TransitRoute> getRoutes();
 
 	/**
 	 * Removes the specified transit route from this transit line.
 	 * @param route
 	 * @return <code>true</code> if this line contained the specified route.
 	 */
-	public abstract boolean removeRoute(final TransitRoute route);
+	boolean removeRoute(final TransitRoute route);
 
-	public void setName(final String name);
+	void setName(final String name);
 	
-	public String getName();
+	String getName();
 	
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitRoute.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitRoute.java
@@ -26,17 +26,18 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * Describes a route of a transit line, including its stops and the departures along this route.
  *
  * @author mrieser
  */
-public interface TransitRoute extends Identifiable<TransitRoute> {
+public interface TransitRoute extends Identifiable<TransitRoute>, Attributable {
 
-	public abstract void setDescription(final String description);
+	void setDescription(final String description);
 
-	public abstract String getDescription();
+	String getDescription();
 
 	/**
 	 * Sets the transport mode with which this transit route is handled, e.g.
@@ -44,27 +45,27 @@ public interface TransitRoute extends Identifiable<TransitRoute> {
 	 *
 	 * @param mode
 	 */
-	public abstract void setTransportMode(final String mode);
+	void setTransportMode(final String mode);
 
-	public abstract String getTransportMode();
+	String getTransportMode();
 
-	public abstract void addDeparture(final Departure departure);
+	void addDeparture(final Departure departure);
 
-	public abstract boolean removeDeparture(final Departure departure);
+	boolean removeDeparture(final Departure departure);
 
 	/**
 	 * @return an immutable Map of all departures assigned to this route
 	 */
-	public abstract Map<Id<Departure>, Departure> getDepartures();
+	Map<Id<Departure>, Departure> getDepartures();
 
-	public abstract NetworkRoute getRoute();
+	NetworkRoute getRoute();
 
-	public abstract void setRoute(final NetworkRoute route);
+	void setRoute(final NetworkRoute route);
 
 	/**
 	 * @return an immutable list of all stops of this route in the order along the route
 	 */
-	public abstract List<TransitRouteStop> getStops();
+	List<TransitRouteStop> getStops();
 
 	/**
 	 * @param stop
@@ -72,6 +73,6 @@ public interface TransitRoute extends Identifiable<TransitRoute> {
 	 * {@link TransitStopFacility}. <code>null</code> if this route does not stop at the
 	 * specified location.
 	 */
-	public abstract TransitRouteStop getStop(final TransitStopFacility stop);
+	TransitRouteStop getStop(final TransitStopFacility stop);
 
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitSchedule.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitSchedule.java
@@ -62,4 +62,5 @@ public interface TransitSchedule extends MatsimToplevelContainer, Attributable {
 	
 	ObjectAttributes getTransitStopsAttributes();
 
+	MinimalTransferTimes getMinimalTransferTimes();
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitSchedule.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitSchedule.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.api.internal.MatsimToplevelContainer;
 import org.matsim.utils.objectattributes.ObjectAttributes;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * Stores a complete transit schedules with multiple lines, multiple routes per line, all the time data
@@ -32,33 +33,33 @@ import org.matsim.utils.objectattributes.ObjectAttributes;
  * 
  * @author mrieser
  */
-public interface TransitSchedule extends MatsimToplevelContainer {
+public interface TransitSchedule extends MatsimToplevelContainer, Attributable {
 
-	public abstract void addTransitLine(final TransitLine line);
+	void addTransitLine(final TransitLine line);
 	
 	/**
-	 * @param line
+	 * @param line the transit line to be removed
 	 * @return <code>true</code> if the transit line was successfully removed from the transit schedule.
 	 */
-	public abstract boolean removeTransitLine(final TransitLine line);
+	boolean removeTransitLine(final TransitLine line);
 
-	public abstract void addStopFacility(final TransitStopFacility stop);
+	void addStopFacility(final TransitStopFacility stop);
 
-	public abstract Map<Id<TransitLine>, TransitLine> getTransitLines();
+	Map<Id<TransitLine>, TransitLine> getTransitLines();
 
-	public abstract Map<Id<TransitStopFacility>, TransitStopFacility> getFacilities();
+	Map<Id<TransitStopFacility>, TransitStopFacility> getFacilities();
 	
 	/**
-	 * @param route
+	 * @param stop the stop facility to be removed
 	 * @return <code>true</code> if the transit stop facility was successfully removed from the transit schedule.
 	 */
-	public abstract boolean removeStopFacility(final TransitStopFacility stop);
+	boolean removeStopFacility(final TransitStopFacility stop);
 	
 	@Override
-	public abstract TransitScheduleFactory getFactory();
+	TransitScheduleFactory getFactory();
 
-	public abstract ObjectAttributes getTransitLinesAttributes();
+	ObjectAttributes getTransitLinesAttributes();
 	
-	public abstract ObjectAttributes getTransitStopsAttributes();
-	
+	ObjectAttributes getTransitStopsAttributes();
+
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitScheduleWriter.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitScheduleWriter.java
@@ -25,6 +25,7 @@ import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.pt.transitSchedule.TransitScheduleWriterV1;
+import org.matsim.pt.transitSchedule.TransitScheduleWriterV2;
 
 /**
  * Writes {@link TransitSchedule}s to file in one of the
@@ -50,14 +51,14 @@ public class TransitScheduleWriter implements MatsimSomeWriter {
 
 	/**
 	 * Writes the transit schedule to the specified file in the most
-	 * current file format (currently V1).
+	 * current file format (currently V2).
 	 *
 	 * @param filename
 	 * @throws UncheckedIOException
-	 * @see {@link #writeV1(String)}
+	 * @see {@link #writeFileV2(String)}
 	 */
 	public void writeFile(final String filename) throws UncheckedIOException {
-		writeFileV1(filename);
+		writeFileV2(filename);
 	}
 
 	/**
@@ -68,6 +69,17 @@ public class TransitScheduleWriter implements MatsimSomeWriter {
 	 * @throws UncheckedIOException
 	 */
 	public void writeFileV1(final String filename) throws UncheckedIOException {
-		new TransitScheduleWriterV1( transformation , this.schedule).write(filename);
+		new TransitScheduleWriterV1(this.transformation, this.schedule).write(filename);
+	}
+
+	/**
+	 * Writes the transit schedule to the specified file in the file
+	 * format specified by <tt>transitSchedule_v2.dtd</tt>
+	 *
+	 * @param filename
+	 * @throws UncheckedIOException
+	 */
+	public void writeFileV2(final String filename) throws UncheckedIOException {
+		new TransitScheduleWriterV2(this.transformation, this.schedule).write(filename);
 	}
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitStopArea.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitStopArea.java
@@ -1,10 +1,9 @@
 /* *********************************************************************** *
  * project: org.matsim.*
- * Departure.java
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2009 by the members listed in the COPYING,        *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -20,28 +19,10 @@
 
 package org.matsim.pt.transitSchedule.api;
 
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.Identifiable;
-import org.matsim.utils.objectattributes.attributable.Attributable;
-import org.matsim.vehicles.Vehicle;
-
 /**
- * Describes a single departure along a route in a transit line.
+ * This interface is currently only used to provided a typed Id: <code>Id&lt;TransitStopArea&gt;</code>
  *
- * @author mrieser
- */
-public interface Departure extends Identifiable<Departure>, Attributable {
-
-	double getDepartureTime();
-
-	/**
-	 * @param vehicleId the id of the vehicle to be used for this departure, may be <code>null</code>
-	 */
-	void setVehicleId(final Id<Vehicle> vehicleId);
-
-	/**
-	 * @return The id of the vehicle to be used for this departure, may be <code>null</code>
-	 */
-	Id<Vehicle> getVehicleId();
-
+ * @author mrieser / SBB
+ **/
+public interface TransitStopArea {
 }

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitStopFacility.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitStopFacility.java
@@ -24,17 +24,18 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * A facility (infrastructure) describing a public transport stop.
  *
  * @author mrieser
  */
-public interface TransitStopFacility extends Facility<TransitStopFacility> {
+public interface TransitStopFacility extends Facility<TransitStopFacility>, Attributable {
 
 	boolean getIsBlockingLane();
 
-	public void setLinkId(final Id<Link> linkId);
+	void setLinkId(final Id<Link> linkId);
 
 	/**
 	 * Sets a human name for the stop facility, e.g. to be displayed
@@ -43,17 +44,17 @@ public interface TransitStopFacility extends Facility<TransitStopFacility> {
 	 *
 	 * @param name
 	 */
-	public void setName(final String name);
+	void setName(final String name);
 
 	/**
 	 * @return name of the stop facility. Can be <code>null</code>.
 	 */
-	public String getName();
+	String getName();
 
-	public String getStopPostAreaId();
+	Id<TransitStopArea> getStopAreaId();
 
-	public void setStopPostAreaId(String stopPostAreaId);
+	void setStopAreaId(Id<TransitStopArea> stopAreaId);
 
-	public void setCoord(Coord coord);
+	void setCoord(Coord coord);
 	
 }

--- a/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
@@ -41,6 +41,7 @@ import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitStopArea;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 /**
@@ -135,7 +136,7 @@ public class CreatePseudoNetwork {
 				}
 				Id<TransitStopFacility> newId = Id.create(toFacility.getId().toString() + "." + Integer.toString(copies.size() + 1), TransitStopFacility.class);
 				TransitStopFacility newFacility = this.schedule.getFactory().createTransitStopFacility(newId, toFacility.getCoord(), toFacility.getIsBlockingLane());
-				newFacility.setStopPostAreaId(toFacility.getId().toString());
+				newFacility.setStopAreaId(Id.create(toFacility.getId(), TransitStopArea.class));
 				newFacility.setLinkId(link.getId());
 				newFacility.setName(toFacility.getName());
 				copies.add(newFacility);

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesUtils.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesUtils.java
@@ -25,4 +25,12 @@ public class AttributesUtils {
 	public static <T extends Attributable> void copyAttributesFromTo( T from , T to ) {
 		copyTo( from.getAttributes() , to.getAttributes() );
 	}
+
+	/**
+	 * @param attributes collection of attributes
+	 * @return <code>true</code> if the attributes collection does not contain any attribute
+	 */
+	public static boolean isEmpty(Attributes attributes) {
+		return attributes.size() == 0;
+	}
 }

--- a/matsim/src/main/resources/dtd/transitSchedule_v2.dtd
+++ b/matsim/src/main/resources/dtd/transitSchedule_v2.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!ELEMENT transitSchedule  (attributes?,transitStops?,transitLine*)>
+<!ELEMENT transitSchedule  (attributes?,transitStops?,minimalTransferTimes?,transitLine*)>
 
 
 <!ELEMENT attributes    (attribute*)>
@@ -22,6 +22,15 @@
           name             CDATA   #IMPLIED
           stopAreaId       CDATA   #IMPLIED
           isBlocking       (true|false)  "false">
+
+<!ELEMENT minimalTransferTimes    (relation*)>
+
+<!ELEMENT relation         EMPTY>
+<!ATTLIST relation
+          fromStop         CDATA   #REQUIRED
+          toStop           CDATA   #REQUIRED
+          transferTime     CDATA   #REQUIRED>
+<!-- relations specify the transferTime in seconds between two stop facilities in the specified direction -->
 
 <!ELEMENT transitLine      (attributes?,transitRoute*)>
 <!ATTLIST transitLine

--- a/matsim/src/main/resources/dtd/transitSchedule_v2.dtd
+++ b/matsim/src/main/resources/dtd/transitSchedule_v2.dtd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!ELEMENT transitSchedule  (attributes?,transitStops?,transitLine*)>
+
+
+<!ELEMENT attributes    (attribute*)>
+
+<!ELEMENT attribute       (#PCDATA)>
+<!ATTLIST attribute
+          name             CDATA #REQUIRED
+          class            CDATA #REQUIRED>
+
+<!ELEMENT transitStops     (stopFacility)*>
+
+<!ELEMENT stopFacility     (attributes?)>
+<!ATTLIST stopFacility
+          id               CDATA   #REQUIRED
+          x                CDATA   #REQUIRED
+          y                CDATA   #REQUIRED
+          z                CDATA   #IMPLIED
+          linkRefId        CDATA   #IMPLIED
+          name             CDATA   #IMPLIED
+          stopAreaId       CDATA   #IMPLIED
+          isBlocking       (true|false)  "false">
+
+<!ELEMENT transitLine      (attributes?,transitRoute*)>
+<!ATTLIST transitLine
+          id               CDATA   #REQUIRED
+          name             CDATA   #IMPLIED>
+
+<!ELEMENT transitRoute     (attributes?,description?,transportMode,routeProfile,route?,departures)>
+<!ATTLIST transitRoute
+          id               CDATA   #REQUIRED>
+<!-- transitRoute.id must be unique within a transitLine only. -->
+
+<!ELEMENT description      (#PCDATA)>
+
+<!ELEMENT transportMode    (#PCDATA)>
+<!-- describes the mode of which vehicles are that serve that line/route -->
+
+<!ELEMENT routeProfile     (stop)*>
+
+<!ELEMENT stop             EMPTY>
+<!ATTLIST stop
+          refId            CDATA   #REQUIRED
+          departureOffset  CDATA   #IMPLIED
+          arrivalOffset    CDATA   #IMPLIED
+          awaitDeparture   (true|false)  "false">
+<!--
+ * stop.departureOffset is required for all stops but the last.
+   The offsets are to be added to the departure times of the single
+   departures listed in the transitRoute.
+ * stop.refId are id-references to facilities. -->
+
+<!ELEMENT route            (link)*>
+
+<!ELEMENT link             EMPTY>
+<!ATTLIST link
+          refId            CDATA   #REQUIRED>
+
+<!ELEMENT departures       (departure*)>
+<!-- the single departures along that transitRoute -->
+
+<!ELEMENT departure        (attributes?)>
+<!ATTLIST departure
+          id               CDATA   #REQUIRED
+          departureTime    CDATA   #REQUIRED
+          vehicleRefId     CDATA   #IMPLIED>
+<!-- the departure.id must be unique within a transitLine only -->

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImplTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImplTest.java
@@ -1,0 +1,262 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.NoSuchElementException;
+
+/**
+ * @author mrieser / SBB
+ */
+public class MinimalTransferTimesImplTest {
+
+	private Id<TransitStopFacility> stopId1 = Id.create(1, TransitStopFacility.class);
+	private Id<TransitStopFacility> stopId2 = Id.create(2, TransitStopFacility.class);
+	private Id<TransitStopFacility> stopId3 = Id.create(3, TransitStopFacility.class);
+	private Id<TransitStopFacility> stopId4 = Id.create(4, TransitStopFacility.class);
+	private Id<TransitStopFacility> stopId5 = Id.create(5, TransitStopFacility.class);
+
+	@Test
+	public void testSetGet() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId2), 0.0);
+		mtt.set(this.stopId1, this.stopId2, 180.0);
+		mtt.set(this.stopId1, this.stopId3, 240.0);
+
+		Assert.assertEquals(180.0, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+
+		// overwrite a value
+		mtt.set(this.stopId1, this.stopId2, 300.0);
+		Assert.assertEquals(300.0, mtt.get(this.stopId1, this.stopId2), 0.0);
+
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId4), 0.0);
+	}
+
+	@Test
+	public void testGetWithDefault() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		double defaultSeconds = 60.0;
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(60.0,  mtt.get(this.stopId1, this.stopId2, defaultSeconds), 0.0);
+		mtt.set(this.stopId1, this.stopId2, 180.0);
+		mtt.set(this.stopId1, this.stopId3, 240.0);
+
+		Assert.assertEquals(180.0, mtt.get(this.stopId1, this.stopId2, defaultSeconds), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3, defaultSeconds), 0.0);
+
+		Assert.assertEquals(defaultSeconds, mtt.get(this.stopId1, this.stopId4, defaultSeconds), 0.0);
+	}
+
+	@Test
+	public void testRemove() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId2), 0.0);
+		mtt.set(this.stopId1, this.stopId2, 180.0);
+		mtt.set(this.stopId1, this.stopId3, 240.0);
+
+		Assert.assertEquals(180.0, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+
+		Assert.assertEquals(180.0, mtt.remove(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+
+		Assert.assertEquals(Double.NaN, mtt.remove(this.stopId1, this.stopId4), 0.0); // we never set it, let's not throw an exception
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId4), 0.0);
+	}
+
+	@Test
+	public void testNotBidirection() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		mtt.set(this.stopId1, this.stopId2, 180.0);
+		mtt.set(this.stopId1, this.stopId3, 240.0);
+
+		Assert.assertEquals(180.0, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId2, this.stopId1), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId3, this.stopId1), 0.0);
+
+		mtt.set(this.stopId3, this.stopId1, 120.0);
+		Assert.assertEquals(120.0, mtt.get(this.stopId3, this.stopId1), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+	}
+
+	@Test
+	public void testNotTransitive() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		mtt.set(this.stopId1, this.stopId2, 180.0);
+		mtt.set(this.stopId2, this.stopId3, 240.0);
+
+		Assert.assertEquals(180.0, mtt.get(this.stopId1, this.stopId2), 0.0);
+		Assert.assertEquals(240.0, mtt.get(this.stopId2, this.stopId3), 0.0);
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId1, this.stopId3), 0.0);
+		Assert.assertEquals(Double.NaN, mtt.get(this.stopId3, this.stopId1), 0.0);
+
+		mtt.set(this.stopId1, this.stopId3, 480.0);
+		Assert.assertEquals(480.0, mtt.get(this.stopId1, this.stopId3), 0.0);
+	}
+
+	@Test
+	public void testIterator_empty() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+
+		MinimalTransferTimes.MinimalTransferTimesIterator iter = mtt.iterator();
+
+		Assert.assertFalse(iter.hasNext());
+		try {
+			iter.getFromStopId();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		try {
+			iter.getToStopId();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		try {
+			iter.getSeconds();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		try {
+			iter.next();
+			Assert.fail("expected Exception");
+		} catch (NoSuchElementException expected) {}
+
+		try {
+			iter.getFromStopId(); // there should still be an exception after calling next()
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+	}
+
+	@Test
+	public void testIterator() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+
+		MinimalTransferTimes.MinimalTransferTimesIterator iter = mtt.iterator();
+		Assert.assertFalse(iter.hasNext());
+
+		mtt.set(this.stopId1, this.stopId2, 120.0);
+
+		iter = mtt.iterator();
+		Assert.assertTrue(iter.hasNext());
+		try {
+			iter.getFromStopId();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		iter.next();
+		Assert.assertEquals(this.stopId1, iter.getFromStopId());
+		Assert.assertEquals(this.stopId2, iter.getToStopId());
+		Assert.assertEquals(120, iter.getSeconds(), 0.0);
+
+		Assert.assertFalse(iter.hasNext());
+
+		try {
+			iter.next();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		try {
+			iter.getFromStopId();
+			Assert.fail("expected Exception, got none.");
+		} catch (NoSuchElementException expected) {}
+
+		mtt.set(this.stopId1, this.stopId3, 180);
+		mtt.set(this.stopId2, this.stopId3, 240);
+		mtt.set(this.stopId1, this.stopId2, 300); // overwrite an existing entry
+
+		// there should be a total of 3 entries now
+		iter = mtt.iterator();
+		int count = 0;
+		boolean found1to2 = false;
+		boolean found1to3 = false;
+		boolean found2to3 = false;
+		while (iter.hasNext()) {
+			count++;
+			iter.next();
+			Id<TransitStopFacility> fromStopId = iter.getFromStopId();
+			Id<TransitStopFacility> toStopId = iter.getToStopId();
+			double seconds = iter.getSeconds();
+			if (fromStopId == this.stopId1 && toStopId == this.stopId2 && seconds == 300) {
+				found1to2 = true;
+			} else if (fromStopId == this.stopId1 && toStopId == this.stopId3 && seconds == 180) {
+				found1to3 = true;
+			} else if (fromStopId == this.stopId2 && toStopId == this.stopId3 && seconds == 240) {
+				found2to3 = true;
+			} else {
+				Assert.fail("found unexcpected minimal transfer time: " + fromStopId + " / " + toStopId + " / " + seconds);
+			}
+			if (count > 3) {
+				Assert.fail("too many elements in iterator.");
+			}
+		}
+		Assert.assertTrue(found1to2);
+		Assert.assertTrue(found1to3);
+		Assert.assertTrue(found2to3);
+
+
+	}
+
+	@Test
+	public void testIterator_withRemove() {
+		MinimalTransferTimes mtt = new MinimalTransferTimesImpl();
+		mtt.set(this.stopId1, this.stopId2, 180);
+		mtt.set(this.stopId2, this.stopId3, 240);
+		mtt.set(this.stopId3, this.stopId1, 300);
+
+		MinimalTransferTimes.MinimalTransferTimesIterator iter = mtt.iterator();
+		int count = 0;
+		while (iter.hasNext()) {
+			count++;
+			iter.next();
+		}
+		Assert.assertEquals(3, count);
+
+		mtt.remove(this.stopId2, this.stopId3);
+		count = 0;
+		iter = mtt.iterator();
+		while (iter.hasNext()) {
+			count++;
+			iter.next();
+		}
+		Assert.assertEquals(2, count);
+
+		mtt.remove(this.stopId1, this.stopId2);
+		count = 0;
+		iter = mtt.iterator();
+		while (iter.hasNext()) {
+			count++;
+			iter.next();
+		}
+		Assert.assertEquals(1, count);
+
+		mtt.remove(this.stopId3, this.stopId1);
+		iter = mtt.iterator();
+		Assert.assertFalse(iter.hasNext());
+	}
+}

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleFormatV1Test.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleFormatV1Test.java
@@ -34,6 +34,7 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteFactories;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.Departure;
@@ -123,7 +124,7 @@ public class TransitScheduleFormatV1Test extends MatsimTestCase {
 		new TransitScheduleWriterV1(schedule1).write(filename);
 		TransitScheduleFactory builder2 = new TransitScheduleFactoryImpl();
 		TransitSchedule schedule2 = builder2.createTransitSchedule();
-		new TransitScheduleReaderV1(schedule2, network).readFile(filename);
+		new TransitScheduleReaderV1(schedule2, new RouteFactories()).readFile(filename);
 
 		// first test, without network-route
 		assertEquals(schedule1, schedule2);
@@ -143,7 +144,7 @@ public class TransitScheduleFormatV1Test extends MatsimTestCase {
 		new TransitScheduleWriterV1(schedule1).write(filename);
 		TransitScheduleFactory builder3 = new TransitScheduleFactoryImpl();
 		TransitSchedule schedule3 = builder3.createTransitSchedule();
-		new TransitScheduleReaderV1(schedule3, network).readFile(filename);
+		new TransitScheduleReaderV1(schedule3, new RouteFactories()).readFile(filename);
 
 		assertEquals(schedule1, schedule3);
 	}

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
@@ -37,6 +37,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+import org.matsim.pt.transitSchedule.api.TransitStopArea;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 
@@ -61,6 +62,7 @@ public class TransitScheduleIOTest {
 			TransitStopFacility stop1 = f.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(123, 234), true);
 			TransitStopFacility stop2 = f.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(987, 876, 98765), false);
 			stop2.getAttributes().putAttribute("air", "thin");
+			stop2.setStopAreaId(Id.create("GZ", TransitStopArea.class));
 
 			schedule.addStopFacility(stop1);
 			schedule.addStopFacility(stop2);
@@ -121,6 +123,7 @@ public class TransitScheduleIOTest {
 		Assert.assertEquals("thin", stop2.getAttributes().getAttribute("air"));
 		Assert.assertTrue(stop2.getCoord().hasZ());
 		Assert.assertEquals(98765.0, stop2.getCoord().getZ(), 0.0);
+		Assert.assertEquals("GZ", stop2.getStopAreaId().toString());
 
 		// assert minmal transfer times
 		Assert.assertEquals(300, schedule2.getMinimalTransferTimes().get(stop1.getId(), stop2.getId()), 0.0);

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
@@ -1,0 +1,144 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.pt.transitSchedule;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author mrieser / SBB
+ */
+public class TransitScheduleIOTest {
+
+	@Test
+	public void testWriteRead_V2() {
+		TransitScheduleFactory f = new TransitScheduleFactoryImpl();
+		TransitSchedule schedule = new TransitScheduleImpl(f);
+		{ // prepare data
+
+			schedule.getAttributes().putAttribute("source", "myImagination");
+
+			TransitStopFacility stop1 = f.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(123, 234), true);
+			TransitStopFacility stop2 = f.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(987, 876, 98765), false);
+			stop2.getAttributes().putAttribute("air", "thin");
+
+			schedule.addStopFacility(stop1);
+			schedule.addStopFacility(stop2);
+
+			TransitLine line1 = f.createTransitLine(Id.create("blue", TransitLine.class));
+			line1.getAttributes().putAttribute("color", "like the sky");
+			line1.getAttributes().putAttribute("operator", "higher being");
+
+			NetworkRoute netRoute = RouteUtils.createLinkNetworkRouteImpl(
+					Id.create("group", Link.class),
+					new Id[]{Id.create("aboveGround", Link.class), Id.create("belowSky", Link.class)},
+					Id.create("sky", Link.class));
+			List<TransitRouteStop> stops = new ArrayList<>();
+			TransitRouteStop rStop1 = f.createTransitRouteStop(stop1, Time.UNDEFINED_TIME, 0.0);
+			TransitRouteStop rStop2 = f.createTransitRouteStop(stop1, 9999.9, Time.UNDEFINED_TIME);
+			stops.add(rStop1);
+			stops.add(rStop2);
+			TransitRoute route1a = f.createTransitRoute(Id.create("upwards", TransitRoute.class), netRoute, stops, "elevator");
+
+			route1a.getAttributes().putAttribute("bidirectional", false);
+
+			Departure dep1 = f.createDeparture(Id.create("first", Departure.class), 100);
+			Departure dep2 = f.createDeparture(Id.create("last", Departure.class), 86300);
+			route1a.addDeparture(dep1);
+			route1a.addDeparture(dep2);
+
+			dep1.getAttributes().putAttribute("early", "yes");
+
+			line1.addRoute(route1a);
+			schedule.addTransitLine(line1);
+		}
+
+		// write data
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		new TransitScheduleWriterV2(schedule).write(outputStream);
+
+		String dataWritten = new String(outputStream.toByteArray());
+		System.out.println(dataWritten);
+
+		// read data
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		new TransitScheduleReader(scenario).readStream(inputStream);
+
+		TransitSchedule schedule2 = scenario.getTransitSchedule();
+		// assert schedule
+		Assert.assertEquals("myImagination", schedule2.getAttributes().getAttribute("source"));
+
+		// assert stop facilities
+		Assert.assertTrue(AttributesUtils.isEmpty(schedule2.getFacilities().get(Id.create(1, TransitStopFacility.class)).getAttributes()));
+		TransitStopFacility stop2 = schedule2.getFacilities().get(Id.create(2, TransitStopFacility.class));
+		Assert.assertFalse(AttributesUtils.isEmpty(stop2.getAttributes()));
+		Assert.assertEquals("thin", stop2.getAttributes().getAttribute("air"));
+		Assert.assertTrue(stop2.getCoord().hasZ());
+		Assert.assertEquals(98765.0, stop2.getCoord().getZ(), 0.0);
+
+		// assert transit lines
+		TransitLine line1 = schedule2.getTransitLines().get(Id.create("blue", TransitLine.class));
+		Assert.assertNotNull(line1);
+		Assert.assertFalse(AttributesUtils.isEmpty(line1.getAttributes()));
+		Assert.assertEquals("like the sky", line1.getAttributes().getAttribute("color"));
+		Assert.assertEquals("higher being", line1.getAttributes().getAttribute("operator"));
+
+		// assert transit routes
+		TransitRoute route1 = line1.getRoutes().get(Id.create("upwards", TransitRoute.class));
+		Assert.assertNotNull(route1);
+		Assert.assertFalse(AttributesUtils.isEmpty(route1.getAttributes()));
+		Assert.assertTrue(route1.getAttributes().getAttribute("bidirectional") instanceof Boolean);
+		Assert.assertFalse((Boolean) route1.getAttributes().getAttribute("bidirectional"));
+
+		// assert departures
+		Departure dep1 = route1.getDepartures().get(Id.create("first", Departure.class));
+		Assert.assertNotNull(dep1);
+		Assert.assertFalse(AttributesUtils.isEmpty(dep1.getAttributes()));
+		Assert.assertEquals("yes", dep1.getAttributes().getAttribute("early"));
+		Departure dep2 = route1.getDepartures().get(Id.create("last", Departure.class));
+		Assert.assertNotNull(dep2);
+		Assert.assertTrue(AttributesUtils.isEmpty(dep2.getAttributes()));
+
+	}
+}

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleIOTest.java
@@ -65,6 +65,9 @@ public class TransitScheduleIOTest {
 			schedule.addStopFacility(stop1);
 			schedule.addStopFacility(stop2);
 
+			schedule.getMinimalTransferTimes().set(stop1.getId(), stop2.getId(), 300.0);
+			schedule.getMinimalTransferTimes().set(stop2.getId(), stop1.getId(), 360.0);
+;
 			TransitLine line1 = f.createTransitLine(Id.create("blue", TransitLine.class));
 			line1.getAttributes().putAttribute("color", "like the sky");
 			line1.getAttributes().putAttribute("operator", "higher being");
@@ -97,8 +100,9 @@ public class TransitScheduleIOTest {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		new TransitScheduleWriterV2(schedule).write(outputStream);
 
-		String dataWritten = new String(outputStream.toByteArray());
-		System.out.println(dataWritten);
+		// to see the actual XML written:
+//		String dataWritten = new String(outputStream.toByteArray());
+//		System.out.println(dataWritten);
 
 		// read data
 		ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
@@ -110,12 +114,18 @@ public class TransitScheduleIOTest {
 		Assert.assertEquals("myImagination", schedule2.getAttributes().getAttribute("source"));
 
 		// assert stop facilities
-		Assert.assertTrue(AttributesUtils.isEmpty(schedule2.getFacilities().get(Id.create(1, TransitStopFacility.class)).getAttributes()));
+		TransitStopFacility stop1 = schedule2.getFacilities().get(Id.create(1, TransitStopFacility.class));
+		Assert.assertTrue(AttributesUtils.isEmpty(stop1.getAttributes()));
 		TransitStopFacility stop2 = schedule2.getFacilities().get(Id.create(2, TransitStopFacility.class));
 		Assert.assertFalse(AttributesUtils.isEmpty(stop2.getAttributes()));
 		Assert.assertEquals("thin", stop2.getAttributes().getAttribute("air"));
 		Assert.assertTrue(stop2.getCoord().hasZ());
 		Assert.assertEquals(98765.0, stop2.getCoord().getZ(), 0.0);
+
+		// assert minmal transfer times
+		Assert.assertEquals(300, schedule2.getMinimalTransferTimes().get(stop1.getId(), stop2.getId()), 0.0);
+		Assert.assertEquals(360, schedule2.getMinimalTransferTimes().get(stop2.getId(), stop1.getId()), 0.0);
+		Assert.assertEquals(Double.NaN, schedule2.getMinimalTransferTimes().get(stop1.getId(), stop1.getId()), 0.0);
 
 		// assert transit lines
 		TransitLine line1 = schedule2.getTransitLines().get(Id.create("blue", TransitLine.class));

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReaderTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReaderTest.java
@@ -63,7 +63,7 @@ public class TransitScheduleReaderTest extends MatsimTestCase {
 
 		TransitScheduleFactory builder = new TransitScheduleFactoryImpl();
 		TransitSchedule schedule = builder.createTransitSchedule();
-		new TransitScheduleReaderV1(schedule, network).readFile(inputDir + INPUT_TEST_FILE_TRANSITSCHEDULE);
+		new TransitScheduleReaderV1(schedule, scenario.getPopulation().getFactory().getRouteFactories()).readFile(inputDir + INPUT_TEST_FILE_TRANSITSCHEDULE);
 
 		assertEquals("wrong number of transit lines.", 1, schedule.getTransitLines().size());
 		assertEquals("wrong line id.", Id.create("T1", TransitLine.class), schedule.getTransitLines().keySet().iterator().next());

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReprojectionIOTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReprojectionIOTest.java
@@ -34,10 +34,10 @@ public class TransitScheduleReprojectionIOTest {
 	public void testInput() {
 		URL transitSchedule = IOUtils.newUrl(ExamplesUtils.getTestScenarioURL("pt-tutorial"), "transitschedule.xml");
 		final Scenario originalScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
-		new TransitScheduleReaderV1( originalScenario ).parse(transitSchedule);
+		new TransitScheduleReader( originalScenario ).readURL(transitSchedule);
 
 		final Scenario reprojectedScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
-		new TransitScheduleReaderV1( new Transformation() , reprojectedScenario ).parse(transitSchedule);
+		new TransitScheduleReader(new Transformation(), reprojectedScenario).readURL(transitSchedule);
 
 		assertCorrectlyReprojected( originalScenario.getTransitSchedule() , reprojectedScenario.getTransitSchedule() );
 	}
@@ -46,13 +46,13 @@ public class TransitScheduleReprojectionIOTest {
 	public void testOutput() {
 		URL transitSchedule = IOUtils.newUrl(ExamplesUtils.getTestScenarioURL("pt-tutorial"), "transitschedule.xml");
 		final Scenario originalScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
-		new TransitScheduleReaderV1( originalScenario ).parse(transitSchedule);
+		new TransitScheduleReader(originalScenario).readURL(transitSchedule);
 
 		final String file = utils.getOutputDirectory()+"/schedule.xml";
 		new TransitScheduleWriterV1( new Transformation() , originalScenario.getTransitSchedule() ).write( file );
 
 		final Scenario reprojectedScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
-		new TransitScheduleReaderV1( reprojectedScenario ).readFile( file );
+		new TransitScheduleReader(reprojectedScenario).readFile(file);
 
 		assertCorrectlyReprojected( originalScenario.getTransitSchedule() , reprojectedScenario.getTransitSchedule() );
 	}

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleWriterTest.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleWriterTest.java
@@ -44,14 +44,14 @@ public class TransitScheduleWriterTest {
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils();
 	
 	/**
-	 * Tests that the default format written is in v1 format.
+	 * Tests that the default format written is in v2 format.
 	 *
 	 * @throws IOException
 	 * @throws SAXException
 	 * @throws ParserConfigurationException
 	 */
 	@Test
-	public void testDefaultV1() throws IOException, SAXException, ParserConfigurationException {
+	public void testDefaultV2() throws IOException, SAXException, ParserConfigurationException {
 		String filename = this.utils.getOutputDirectory() + "schedule.xml";
 
 		TransitScheduleFactory builder = new TransitScheduleFactoryImpl();
@@ -64,7 +64,7 @@ public class TransitScheduleWriterTest {
 
 		TransitScheduleFactory builder2 = new TransitScheduleFactoryImpl();
 		TransitSchedule schedule2 = builder2.createTransitSchedule();
-		new TransitScheduleReaderV1(schedule2, new RouteFactories()).readFile(filename);
+		new TransitScheduleReaderV2(schedule2, new RouteFactories()).readFile(filename);
 		Assert.assertEquals(1, schedule2.getTransitLines().size());
 	}
 	


### PR DESCRIPTION
Changes according to [MATSIM-770](https://matsim.atlassian.net/browse/MATSIM-770).
New transitSchedule_v2 format with support for z-Coordinates, Attributes, Minimal Transfer Times between stop facilities.
We did not yet add support for connected services and portion working (Durchbindungen, Flügeln, Vereinen), as this needs more thoughts. We would have added Durchbindungen to the data structure in the hope to implement it in the future. But as it was stated, Flügeln and Vereinen should be considered then as well and this is too much in the moment (especially regarding the upcoming release-deadline), so we leave this for a later time.