### PR TITLE
Dvrp online tt

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleOccupancyEvaluator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleOccupancyEvaluator.java
@@ -98,7 +98,7 @@ public class DrtVehicleOccupancyEvaluator implements PersonEntersVehicleEventHan
 		if (startTime < 0)
 			startTime = 0;
 		double endTime;
-		if (config.qsim().getEndTime() == Time.UNDEFINED_TIME) {
+		if (Time.isUndefinedTime(config.qsim().getEndTime())) {
 			endTime = 36 * 3600;
 		} else
 			endTime = config.qsim().getEndTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModeTrip.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModeTrip.java
@@ -40,7 +40,8 @@ public class DynModeTrip implements Comparable<DynModeTrip> {
 	private final double waitTime;
 	private double travelTime = Double.NaN;
 	private double travelDistance_m = Double.NaN;
-	private double travelDistanceEstimate_m = Double.NaN;
+	private double unsharedDistanceEstimate_m = Double.NaN;
+	private double unsharedTimeEstimate_m = Double.NaN;
 	private Id<Link> toLink = null;
 	private double arrivalTime = Double.NaN;
 	private final Coord fromCoord;
@@ -79,8 +80,12 @@ public class DynModeTrip implements Comparable<DynModeTrip> {
 	}
 	
 
-	public void setTravelDistanceEstimate_m(double travelDistanceEstimate_m) {
-		this.travelDistanceEstimate_m = travelDistanceEstimate_m;
+	public void setUnsharedDistanceEstimate_m(double unsharedDistanceEstimate_m) {
+		this.unsharedDistanceEstimate_m = unsharedDistanceEstimate_m;
+	}
+
+	public void setUnsharedTimeEstimate_m(double unsharedTimeEstimate_m) {
+		this.unsharedTimeEstimate_m = unsharedTimeEstimate_m;
 	}
 
 	public Id<Vehicle> getVehicle() {
@@ -108,8 +113,12 @@ public class DynModeTrip implements Comparable<DynModeTrip> {
 	}
 	
 
-	public double getTravelDistanceEstimate_m() {
-		return travelDistanceEstimate_m;
+	public double getUnsharedDistanceEstimate_m() {
+		return unsharedDistanceEstimate_m;
+	}
+	
+	public double getUnsharedTimeEstimate_m() {
+		return unsharedTimeEstimate_m;
 	}
 
 	public void setTravelDistance(double travelDistance_m) {
@@ -177,7 +186,7 @@ public class DynModeTrip implements Comparable<DynModeTrip> {
 		return getDepartureTime() + demitter + getPerson() + demitter + getVehicle() + demitter + getFromLinkId()
 				+ demitter + format.format(fromCoordX) + demitter + format.format(fromCoordY) + demitter + getToLinkId() + demitter + format.format(toCoordX)
 				+ demitter + format.format(toCoordY) + demitter + getWaitTime() + demitter + getArrivalTime() + demitter
-				+ getInVehicleTravelTime() + demitter + format.format(getTravelDistance())+ demitter+ format.format(travelDistanceEstimate_m);
+				+ getInVehicleTravelTime() + demitter + format.format(getTravelDistance())+ demitter+ format.format(unsharedDistanceEstimate_m);
 	}
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/data/DrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/data/DrtRequest.java
@@ -24,7 +24,6 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.data.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
 
 /**
@@ -56,11 +55,9 @@ public class DrtRequest implements PassengerRequest {
 
 	private DrtStopTask pickupTask = null;
 	private DrtStopTask dropoffTask = null;
-	private final VrpPathWithTravelData unsharedRidePath;
 
 	public DrtRequest(Id<Request> id, MobsimPassengerAgent passenger, Link fromLink, Link toLink,
-			double earliestStartTime, double latestStartTime, double latestArrivalTime, double submissionTime,
-			VrpPathWithTravelData unsharedRidePath) {
+			double earliestStartTime, double latestStartTime, double latestArrivalTime, double submissionTime) {
 		this.id = id;
 		this.submissionTime = submissionTime;
 		this.earliestStartTime = earliestStartTime;
@@ -70,7 +67,6 @@ public class DrtRequest implements PassengerRequest {
 		this.passenger = passenger;
 		this.fromLink = fromLink;
 		this.toLink = toLink;
-		this.unsharedRidePath = unsharedRidePath;
 	}
 
 	@Override
@@ -135,10 +131,6 @@ public class DrtRequest implements PassengerRequest {
 
 	public void setDropoffTask(DrtStopTask dropoffTask) {
 		this.dropoffTask = dropoffTask;
-	}
-
-	public VrpPathWithTravelData getUnsharedRidePath() {
-		return unsharedRidePath;
 	}
 
 	public DrtRequestStatus getStatus() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -81,14 +81,13 @@ public class InsertionCostCalculator {
 			}
 
 			// no extra drive to pickup and stop (==> toPickupTT == 0 and stopDuration == 0)
-			double fromPickupTT = insertion.pathFromPickup.path.travelTime
-					+ insertion.pathFromPickup.firstAndLastLinkTT;
+			double fromPickupTT = insertion.pathFromPickup.getTravelTime();
 			double replacedDriveTT = calculateReplacedDriveDuration(vEntry, insertion.pickupIdx);
 			return fromPickupTT - replacedDriveTT;
 		}
 
-		double toPickupTT = insertion.pathToPickup.path.travelTime + insertion.pathToPickup.firstAndLastLinkTT;
-		double fromPickupTT = insertion.pathFromPickup.path.travelTime + insertion.pathFromPickup.firstAndLastLinkTT;
+		double toPickupTT = insertion.pathToPickup.getTravelTime();
+		double fromPickupTT = insertion.pathFromPickup.getTravelTime();
 		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, insertion.pickupIdx);
 		return toPickupTT + stopDuration + fromPickupTT - replacedDriveTT;
 	}
@@ -102,10 +101,10 @@ public class InsertionCostCalculator {
 
 		double toDropoffTT = insertion.dropoffIdx == insertion.pickupIdx ? // PICKUP->DROPOFF ?
 				0 // PICKUP->DROPOFF taken into account as fromPickupTT
-				: insertion.pathToDropoff.path.travelTime + insertion.pathToDropoff.firstAndLastLinkTT;
+				: insertion.pathToDropoff.getTravelTime();
 		double fromDropoffTT = insertion.dropoffIdx == vEntry.stops.size() ? // DROPOFF->STAY ?
 				0 //
-				: insertion.pathFromDropoff.path.travelTime + insertion.pathFromDropoff.firstAndLastLinkTT;
+				: insertion.pathFromDropoff.getTravelTime();
 		double replacedDriveTT = insertion.dropoffIdx == insertion.pickupIdx ? // PICKUP->DROPOFF ?
 				0 // replacedDriveTT already taken into account in pickupDetourTimeLoss
 				: calculateReplacedDriveDuration(vEntry, insertion.dropoffIdx);
@@ -149,8 +148,7 @@ public class InsertionCostCalculator {
 		double driveToPickupStartTime = (insertion.pickupIdx == 0) ? vEntry.start.time //
 				: vEntry.stops.get(insertion.pickupIdx - 1).task.getEndTime();
 
-		double pickupEndTime = driveToPickupStartTime + insertion.pathToPickup.path.travelTime
-				+ insertion.pathToPickup.firstAndLastLinkTT + stopDuration;
+		double pickupEndTime = driveToPickupStartTime + insertion.pathToPickup.getTravelTime() + stopDuration;
 
 		if (pickupEndTime > drtRequest.getEarliestStartTime() + maxWaitTime) {
 			return false;
@@ -158,9 +156,8 @@ public class InsertionCostCalculator {
 
 		// reject solutions when latestArrivalTime for the new request is violated
 		double dropoffStartTime = insertion.pickupIdx == insertion.dropoffIdx
-				? pickupEndTime + insertion.pathFromPickup.path.travelTime + insertion.pathFromPickup.firstAndLastLinkTT
-				: vEntry.stops.get(insertion.dropoffIdx - 1).task.getEndTime() + insertion.pathToDropoff.path.travelTime
-						+ insertion.pathToDropoff.firstAndLastLinkTT;
+				? pickupEndTime + insertion.pathFromPickup.getTravelTime()
+				: vEntry.stops.get(insertion.dropoffIdx - 1).task.getEndTime() + insertion.pathToDropoff.getTravelTime();
 
 		if (dropoffStartTime > drtRequest.getLatestArrivalTime()) {
 			return false;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelPathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelPathDataProvider.java
@@ -64,7 +64,7 @@ public class ParallelPathDataProvider implements PrecalculatablePathDataProvider
 
 	private final ExecutorService executorService;
 
-	// ==== recalculated by calcPathData()
+	// ==== recalculated by precalculatePathData()
 	private Map<Id<Link>, PathData> pathsToPickupMap;
 	private Map<Id<Link>, PathData> pathsFromPickupMap;
 	private Map<Id<Link>, PathData> pathsToDropoffMap;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SequentialPathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SequentialPathDataProvider.java
@@ -69,7 +69,7 @@ public class SequentialPathDataProvider implements PathDataProvider {
 				earliestPickupTime);
 
 		PathData pickupToDropoffPath = pathsFromPickup[0];// only if no other passengers on board (optimistic)
-		double minTravelTime = pickupToDropoffPath.path.travelTime + pickupToDropoffPath.firstAndLastLinkTT;
+		double minTravelTime = pickupToDropoffPath.getTravelTime();
 		double earliestDropoffTime = earliestPickupTime + minTravelTime + stopDuration; // over-optimistic
 
 		// calc backward dijkstra from dropoff to ends of all stops

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingStrategy.java
@@ -26,7 +26,9 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.data.Vehicle;
 
 /**
- * @author michalm Idle vehicles (=StayTask) may be re-allocated using this interface.
+ * Idle vehicles (=StayTask) may be re-allocated using this interface.
+ * 
+ * @author michalm
  */
 public interface RebalancingStrategy {
 	public class Relocation {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
@@ -84,6 +84,6 @@ public class DrtRequestCreator implements PassengerRequestCreator {
 				fromLink.getId(), toLink.getId(), unsharedRidePath.getTravelTime(), unsharedDistance));
 
 		return new DrtRequest(id, passenger, fromLink, toLink, departureTime, latestDepartureTime, latestArrivalTime,
-				submissionTime, unsharedRidePath);
+				submissionTime);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
@@ -78,7 +78,7 @@ public class DrtRequestCreator implements PassengerRequestCreator {
 		double maxTravelTime = drtCfg.getMaxTravelTimeAlpha() * optimisticTravelTime + drtCfg.getMaxTravelTimeBeta();
 		double latestArrivalTime = departureTime + maxTravelTime;
 
-		double unsharedDistance = VrpPaths.calcPathDistance(unsharedRidePath);
+		double unsharedDistance = VrpPaths.calcDistance(unsharedRidePath);
 
 		eventsManager.processEvent(new DrtRequestSubmittedEvent(timer.getTimeOfDay(), id, passenger.getId(),
 				fromLink.getId(), toLink.getId(), unsharedRidePath.getTravelTime(), unsharedDistance));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestRejectedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestRejectedEvent.java
@@ -28,9 +28,7 @@ import org.matsim.contrib.dvrp.data.Request;
 /**
  * @author michalm
  */
-
 public class DrtRequestRejectedEvent extends Event {
-
 	public static final String EVENT_TYPE = "DrtRequest rejected";
 
 	public static final String ATTRIBUTE_REQUEST = "request";
@@ -43,13 +41,12 @@ public class DrtRequestRejectedEvent extends Event {
 	}
 
 	@Override
-	
 	public String getEventType() {
 		return EVENT_TYPE;
 	}
-	
+
 	/**
-	 *  the ID of the initial request submitted
+	 * the ID of the initial request submitted
 	 */
 	public Id<Request> getRequestId() {
 		return requestId;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestRejectedEventHandler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestRejectedEventHandler.java
@@ -25,13 +25,9 @@ package org.matsim.contrib.drt.passenger.events;
 import org.matsim.core.events.handler.EventHandler;
 
 /**
- * @author  jbischoff
- *
- */
-/**
+ * @author jbischoff
  *
  */
 public interface DrtRequestRejectedEventHandler extends EventHandler {
 	public void handleEvent(final DrtRequestRejectedEvent event);
-
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestScheduledEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestScheduledEvent.java
@@ -29,7 +29,6 @@ import org.matsim.contrib.dvrp.data.*;
  * @author michalm
  */
 public class DrtRequestScheduledEvent extends Event {
-
 	public static final String EVENT_TYPE = "DrtRequest scheduled";
 
 	public static final String ATTRIBUTE_REQUEST = "request";
@@ -55,28 +54,30 @@ public class DrtRequestScheduledEvent extends Event {
 	public String getEventType() {
 		return EVENT_TYPE;
 	}
+
 	/**
 	 * the ID of the request
 	 */
 	public Id<Request> getRequestId() {
 		return requestId;
 	}
+
 	/**
-	 *  the vehicle scheduled to the request
+	 * the vehicle scheduled to the request
 	 */
 	public Id<Vehicle> getVehicleId() {
 		return vehicleId;
 	}
 
 	/**
-	 *  the <b>estimated</b> pickup time of the request
+	 * the <b>estimated</b> pickup time of the request
 	 */
 	public double getPickupTime() {
 		return pickupTime;
 	}
 
 	/**
-	 *  the <b>estimated</b> arrival time of the request
+	 * the <b>estimated</b> arrival time of the request
 	 */
 	public double getDropoffTime() {
 		return dropoffTime;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestScheduledEventHandler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestScheduledEventHandler.java
@@ -25,13 +25,9 @@ package org.matsim.contrib.drt.passenger.events;
 import org.matsim.core.events.handler.EventHandler;
 
 /**
- * @author  jbischoff
- *
- */
-/**
+ * @author jbischoff
  *
  */
 public interface DrtRequestScheduledEventHandler extends EventHandler {
 	public void handleEvent(final DrtRequestScheduledEvent event);
-
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -31,7 +31,6 @@ import org.matsim.contrib.dvrp.data.Request;
  * @author michalm
  */
 public class DrtRequestSubmittedEvent extends Event {
-
 	public static final String EVENT_TYPE = "DrtRequest submitted";
 
 	public static final String ATTRIBUTE_REQUEST = "request";
@@ -48,7 +47,6 @@ public class DrtRequestSubmittedEvent extends Event {
 	private final double unsharedRideTime;
 	private final double unsharedRideDistance;
 
-	
 	public DrtRequestSubmittedEvent(double time, Id<Request> requestId, Id<Person> personId, Id<Link> fromLinkId,
 			Id<Link> toLinkId, double unsharedRideTime, double unsharedRideDistance) {
 		super(time);
@@ -64,40 +62,44 @@ public class DrtRequestSubmittedEvent extends Event {
 	public String getEventType() {
 		return EVENT_TYPE;
 	}
+
 	/**
-	 *  the ID of the initial request submitted
+	 * the ID of the initial request submitted
 	 */
 	public Id<Request> getRequestId() {
 		return requestId;
 	}
+
 	/**
-	 *  the Person Id that submitted the request
+	 * the Person Id that submitted the request
 	 */
 	public Id<Person> getPersonId() {
 		return personId;
 	}
 
 	/**
-	 *  the request's origin
+	 * the request's origin
 	 */
 	public Id<Link> getFromLinkId() {
 		return fromLinkId;
 	}
+
 	/**
-	 *  the request's destination
+	 * the request's destination
 	 */
 	public Id<Link> getToLinkId() {
 		return toLinkId;
 	}
 
 	/**
-	 *  the estimated traveltime it would take to ride without any detours
+	 * the estimated traveltime it would take to ride without any detours
 	 */
 	public double getUnsharedRideTime() {
 		return unsharedRideTime;
 	}
+
 	/**
-	 *  the estimated distance it would take to ride without any detours
+	 * the estimated distance it would take to ride without any detours
 	 */
 	public double getUnsharedRideDistance() {
 		return unsharedRideDistance;
@@ -111,7 +113,7 @@ public class DrtRequestSubmittedEvent extends Event {
 		attr.put(ATTRIBUTE_FROM_LINK, fromLinkId + "");
 		attr.put(ATTRIBUTE_TO_LINK, toLinkId + "");
 		attr.put(ATTRIBUTE_UNSHARED_RIDE_TIME, unsharedRideTime + "");
-		attr.put(ATTRIBUTE_UNSHARED_RIDE_DISTANCE, unsharedRideDistance+"");
+		attr.put(ATTRIBUTE_UNSHARED_RIDE_DISTANCE, unsharedRideDistance + "");
 		return attr;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEventHandler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEventHandler.java
@@ -25,13 +25,8 @@ package org.matsim.contrib.drt.passenger.events;
 import org.matsim.core.events.handler.EventHandler;
 
 /**
- * @author  jbischoff
- *
- */
-/**
- *
+ * @author jbischoff
  */
 public interface DrtRequestSubmittedEventHandler extends EventHandler {
 	public void handleEvent(final DrtRequestSubmittedEvent event);
-
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -39,6 +39,7 @@ public class DrtRoutingModule implements RoutingModule {
 	private final DrtConfigGroup drtconfig;
 	private StageActivityTypes stageActivityTypes;
 	private final Network network;
+
 	@Inject
 	public DrtRoutingModule(Config config, Network network) {
 		this.drtconfig = DrtConfigGroup.get(config);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
@@ -19,6 +19,7 @@
 
 package org.matsim.contrib.drt.run;
 
+import org.matsim.contrib.drt.run.DrtConfigGroup.OperationalScheme;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
@@ -31,16 +32,20 @@ public class DrtConfigConsistencyChecker implements ConfigConsistencyChecker {
 
 		DrtConfigGroup drtCfg = DrtConfigGroup.get(config);
 		if (drtCfg.getMaxTravelTimeAlpha() < 1) {
-			throw new RuntimeException(
-					DrtConfigGroup.MAX_TRAVEL_TIME_ALPHA + " is below 1.0! See comments in the DrtConfigGroup");
+			throw new RuntimeException(DrtConfigGroup.MAX_TRAVEL_TIME_ALPHA + " may not be less than 1.0");
 		}
 		if (drtCfg.getMaxTravelTimeBeta() < 0) {
-			throw new RuntimeException(
-					DrtConfigGroup.MAX_TRAVEL_TIME_BETA + " is below 0.0! See comments in the DrtConfigGroup");
+			throw new RuntimeException(DrtConfigGroup.MAX_TRAVEL_TIME_BETA + " must be zero or positive");
 		}
 		if (drtCfg.getMaxWaitTime() < 0) {
-			throw new RuntimeException(
-					DrtConfigGroup.MAX_WAIT_TIME + " is below 0.0! See comments in the DrtConfigGroup");
+			throw new RuntimeException(DrtConfigGroup.MAX_WAIT_TIME + " must be zero or positive");
+		}
+		if (drtCfg.getOperationalScheme() == OperationalScheme.stationbased && drtCfg.getMaxWalkDistance() < 0) {
+			throw new RuntimeException(DrtConfigGroup.MAX_WALK_DISTANCE + " must be zero or positive"
+					+ " when the operational scheme is " + DrtConfigGroup.OperationalScheme.stationbased);
+		}
+		if (drtCfg.getStopDuration() < 0) {
+			throw new RuntimeException(DrtConfigGroup.STOP_DURATION + " must be zero or positive");
 		}
 		if (drtCfg.getNumberOfThreads() > Runtime.getRuntime().availableProcessors()) {
 			throw new RuntimeException(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -55,15 +55,15 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	public static final String PRINT_WARNINGS = "plotDetailedWarnings";
 	public static final String NUMBER_OF_THREADS = "numberOfThreads";
 
-	private double stopDuration = Double.NaN;// seconds
-	private double maxWaitTime = Double.NaN;// seconds
+	private Double stopDuration = null;// seconds
+	private Double maxWaitTime = null;// seconds
 
 	// max arrival time defined as:
 	// maxTravelTimeAlpha * unshared_ride_travel_time(fromLink, toLink) + maxTravelTimeBeta,
 	// where unshared_ride_travel_time(fromLink, toLink) is calculated with FastAStarEuclidean
 	// (hence AStarEuclideanOverdoFactor needs to be specified)
-	private double maxTravelTimeAlpha = Double.NaN;// [-], >= 1.0
-	private double maxTravelTimeBeta = Double.NaN;// [s], >= 0.0
+	private Double maxTravelTimeAlpha = null;// [-], >= 1.0
+	private Double maxTravelTimeBeta = null;// [s], >= 0.0
 	private double AStarEuclideanOverdoFactor = 1.;// >= 1.0
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
@@ -71,7 +71,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	private boolean idleVehiclesReturnToDepots = false;
 	private OperationalScheme operationalScheme = OperationalScheme.door2door;
 
-	private double maxWalkDistance = Double.NaN;// [m]; only for stationbased DRT scheme
+	private Double maxWalkDistance = null;// [m]; only for stationbased DRT scheme
 	private double estimatedDrtSpeed = 25. / 3.6;// [m/s]
 	private double estimatedBeelineDistanceFactor = 1.3;// [-]
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduler.java
@@ -143,7 +143,7 @@ public class DrtScheduler implements ScheduleInquiry {
 			DrtTask task = (DrtTask)tasks.get(i);
 			double calcEndTime = calcNewEndTime(vehicle, task, newBeginTime);
 
-			if (calcEndTime == Time.UNDEFINED_TIME) {
+			if (Time.isUndefinedTime(calcEndTime)) {
 				schedule.removeTask(task);
 				i--;
 			} else if (calcEndTime < newBeginTime) {// 0 s is fine (e.g. last 'wait')

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduler.java
@@ -211,12 +211,12 @@ public class DrtScheduler implements ScheduleInquiry {
 			if (diversion != null) { // divert vehicle
 				beforePickupTask = currentTask;
 				VrpPathWithTravelData vrpPath = VrpPaths.createPath(vehicleEntry.start.link, request.getFromLink(),
-						vehicleEntry.start.time, insertion.pathToPickup.path, travelTime);
+						vehicleEntry.start.time, insertion.pathToPickup, travelTime);
 				((OnlineDriveTaskTracker)beforePickupTask.getTaskTracker()).divertPath(vrpPath);
 			} else { // too late for diversion
 				if (request.getFromLink() != vehicleEntry.start.link) { // add a new drive task
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(vehicleEntry.start.link, request.getFromLink(),
-							vehicleEntry.start.time, insertion.pathToPickup.path, travelTime);
+							vehicleEntry.start.time, insertion.pathToPickup, travelTime);
 					beforePickupTask = new DrtDriveTask(vrpPath);
 					schedule.addTask(currentTask.getTaskIdx() + 1, beforePickupTask);
 				} else { // no need for a new drive task
@@ -266,7 +266,7 @@ public class DrtScheduler implements ScheduleInquiry {
 					Link toLink = request.getToLink(); // pickup->dropoff
 
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink,
-							stopTask.getEndTime(), insertion.pathFromPickup.path, travelTime);
+							stopTask.getEndTime(), insertion.pathFromPickup, travelTime);
 					Task driveFromPickupTask = new DrtDriveTask(vrpPath);
 					schedule.addTask(stopTask.getTaskIdx() + 1, driveFromPickupTask);
 
@@ -303,7 +303,7 @@ public class DrtScheduler implements ScheduleInquiry {
 				} else {// add drive task to pickup location
 					// insert drive i->pickup
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(stayOrStopTask.getLink(), request.getFromLink(),
-							stayOrStopTask.getEndTime(), insertion.pathToPickup.path, travelTime);
+							stayOrStopTask.getEndTime(), insertion.pathToPickup, travelTime);
 					beforePickupTask = new DrtDriveTask(vrpPath);
 					schedule.addTask(stayOrStopTask.getTaskIdx() + 1, beforePickupTask);
 				}
@@ -323,7 +323,7 @@ public class DrtScheduler implements ScheduleInquiry {
 				: stops.get(insertion.pickupIdx).task.getLink(); // pickup->i+1
 
 		VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink, startTime + stopDuration,
-				insertion.pathFromPickup.path, travelTime);
+				insertion.pathFromPickup, travelTime);
 		Task driveFromPickupTask = new DrtDriveTask(vrpPath);
 		schedule.addTask(taskIdx + 1, driveFromPickupTask);
 
@@ -361,7 +361,7 @@ public class DrtScheduler implements ScheduleInquiry {
 
 				// insert drive i->dropoff
 				VrpPathWithTravelData vrpPath = VrpPaths.createPath(stopTask.getLink(), request.getToLink(),
-						stopTask.getEndTime(), insertion.pathToDropoff.path, travelTime);
+						stopTask.getEndTime(), insertion.pathToDropoff, travelTime);
 				driveToDropoffTask = new DrtDriveTask(vrpPath);
 				schedule.addTask(stopTask.getTaskIdx() + 1, driveToDropoffTask);
 			}
@@ -392,7 +392,7 @@ public class DrtScheduler implements ScheduleInquiry {
 			Link toLink = stops.get(insertion.dropoffIdx).task.getLink(); // dropoff->j+1
 
 			VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getToLink(), toLink, startTime + stopDuration,
-					insertion.pathFromDropoff.path, travelTime);
+					insertion.pathFromDropoff, travelTime);
 			Task driveFromDropoffTask = new DrtDriveTask(vrpPath);
 			schedule.addTask(taskIdx + 1, driveFromDropoffTask);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
@@ -60,12 +60,16 @@ public class OneToManyPathSearch {
 	}
 
 	public static class PathData {
-		public final Path path;// shortest path
-		public final double firstAndLastLinkTT;// at both the first and last links
+		final Path path;// shortest path
+		private final double firstAndLastLinkTT;// at both the first and last links
 
 		public PathData(Path path, double firstAndLastLinkTT) {
 			this.path = new Path(null, ImmutableList.copyOf(path.links), path.travelTime, path.travelCost);
 			this.firstAndLastLinkTT = firstAndLastLinkTT;
+		}
+
+		public double getTravelTime() {
+			return path.travelTime + firstAndLastLinkTT;
 		}
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
@@ -23,9 +23,12 @@ import java.util.ArrayList;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.core.population.routes.*;
-import org.matsim.core.router.util.*;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.TravelTime;
 
 public class VrpPaths {
 	/**
@@ -44,6 +47,11 @@ public class VrpPaths {
 
 	public static VrpPathWithTravelData createZeroLengthPath(Link fromTolink, double departureTime) {
 		return new VrpPathWithTravelDataImpl(departureTime, 0, new Link[] { fromTolink }, new double[] { 0 });
+	}
+
+	public static VrpPathWithTravelData createPath(Link fromLink, Link toLink, double departureTime, PathData pathData,
+			TravelTime travelTime) {
+		return createPath(fromLink, toLink, departureTime, pathData.path, travelTime);
 	}
 
 	public static VrpPathWithTravelData createPath(Link fromLink, Link toLink, double departureTime, Path path,
@@ -94,9 +102,9 @@ public class VrpPaths {
 		return new VrpPathWithTravelDataImpl(departureTime, totalTT, links, linkTTs);
 	}
 
-	public static final double FIRST_LINK_TT = 1;
+	static final double FIRST_LINK_TT = 1;
 
-	public static double getLastLinkTT(Link lastLink, double time) {
+	static double getLastLinkTT(Link lastLink, double time) {
 		return lastLink.getLength() / lastLink.getFreespeed(time);
 	}
 
@@ -128,12 +136,11 @@ public class VrpPaths {
 	/**
 	 * @return The distance of a VRP path Includes the to link, but not the from link
 	 */
-	public static double calcPathDistance(VrpPath path) {
+	public static double calcDistance(VrpPath path) {
 		double distance = 0.0;
 		for (int i = 1; i < path.getLinkCount(); i++) {
 			distance += path.getLink(i).getLength();
 		}
-
 		return distance;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
@@ -51,5 +51,9 @@ public class DvrpConfigConsistencyChecker implements ConfigConsistencyChecker {
 		if (alpha > 1 || alpha <= 0) {
 			throw new RuntimeException("travelTimeEstimationAlpha must be in (0,1]");
 		}
+
+		if (dvrpCfg.getTravelTimeEstimationBeta() < 0) {
+			throw new RuntimeException("travelTimeEstimationBeta must be zero or positive");
+		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
@@ -32,16 +32,18 @@ public class DvrpConfigConsistencyChecker implements ConfigConsistencyChecker {
 		new DynQSimConfigConsistencyChecker().checkConsistency(config);
 
 		if (!config.qsim().isInsertingWaitingVehiclesBeforeDrivingVehicles()) {
-			log.warn("Typically, vrp paths are calculated from startLink to endLink"
-					+ "(not from startNode to endNode). That requires making some assumptions"
-					+ "on how much time travelling on the first and last links takes. "
-					+ "The current implementation assumes freeflow travelling on the last link, "
-					+ "which is actually the case in QSim, and a 1-second stay on the first link. "
-					+ "The latter expectation is optimistic, and to make it more likely,"
-					+ "departing vehicles must be inserted befor driving ones "
-					+ "(though that still does not guarantee 1-second stay");
+			// Typically, vrp paths are calculated from startLink to endLink
+			// (not from startNode to endNode). That requires making some assumptions
+			// on how much time travelling on the first and last links takes.
+			// The current implementation assumes:
+			// (a) free-flow travelling on the last link, which is actually the case in QSim, and
+			// (b) a 1-second stay on the first link (spent on moving over the first node).
+			// The latter expectation is assumes that departing vehicles must be inserted before driving ones
+			// (though that still does not guarantee 1-second stay since the vehicle may need to wait if the next
+			// link is fully congested)
+			log.warn(" 'QSim.insertingWaitingVehiclesBeforeDrivingVehicles' should be true in order to get"
+					+ " more precise travel time estimates. See comments in DvrpConfigConsistencyChecker");
 		}
-
 		if (config.qsim().isRemoveStuckVehicles()) {
 			throw new RuntimeException("Stuck DynAgents cannot be removed from simulation");
 		}
@@ -49,11 +51,10 @@ public class DvrpConfigConsistencyChecker implements ConfigConsistencyChecker {
 		DvrpConfigGroup dvrpCfg = DvrpConfigGroup.get(config);
 		double alpha = dvrpCfg.getTravelTimeEstimationAlpha();
 		if (alpha > 1 || alpha <= 0) {
-			throw new RuntimeException("travelTimeEstimationAlpha must be in (0,1]");
+			throw new RuntimeException(DvrpConfigGroup.TRAVEL_TIME_ESTIMATION_ALPHA + " must be in (0,1]");
 		}
-
 		if (dvrpCfg.getTravelTimeEstimationBeta() < 0) {
-			throw new RuntimeException("travelTimeEstimationBeta must be zero or positive");
+			throw new RuntimeException(DvrpConfigGroup.TRAVEL_TIME_ESTIMATION_BETA + " must be zero or positive");
 		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -81,7 +81,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 						+ " For 'time > currentTime + beta' correction is 0,"
 						+ " whereas if 'time < currentTime' it is 1."
 						////
-						+ " If beta is sufficinelty large, 'beta >> 0', only the currently observed TT is used.");
+						+ " If beta is sufficiently large, 'beta >> 0', only the currently observed TT is used.");
 		// In DVRP 'time < currentTime' may only happen for backward path search, a adding proper search termination
 		// criterion should prevent this from happening
 		return map;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleImpl.java
@@ -91,7 +91,7 @@ public class ScheduleImpl implements Schedule {
 		double beginTime = task.getBeginTime();
 		double endTime = task.getEndTime();
 		Link beginLink = Tasks.getBeginLink(task);
-		Link endLink = Tasks.getEndLink(task);
+		// Link endLink = Tasks.getEndLink(task);
 		int taskCount = tasks.size();
 
 		if (taskIdx < 0 || taskIdx > taskCount) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
@@ -36,7 +36,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
-public class DvrpTravelTimeEstimatorImpl implements DvrpTravelTimeEstimator, MobsimBeforeCleanupListener {
+public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, MobsimBeforeCleanupListener {
 	private final TravelTime observedTT;
 	private final Network network;
 
@@ -46,21 +46,21 @@ public class DvrpTravelTimeEstimatorImpl implements DvrpTravelTimeEstimator, Mob
 	private final double alpha;
 
 	@Inject
-	public DvrpTravelTimeEstimatorImpl(@Named(DvrpTravelTimeModule.DVRP_INITIAL) TravelTime initialTT,
+	public DvrpOfflineTravelTimeEstimator(@Named(DvrpTravelTimeModule.DVRP_INITIAL) TravelTime initialTT,
 			@Named(DvrpTravelTimeModule.DVRP_OBSERVED) TravelTime observedTT,
 			@Named(DvrpModule.DVRP_ROUTING) Network network, TravelTimeCalculatorConfigGroup ttCalcConfig,
 			DvrpConfigGroup dvrpConfig) {
 		this(initialTT, observedTT, network, ttCalcConfig, dvrpConfig.getTravelTimeEstimationAlpha());
 	}
 
-	public DvrpTravelTimeEstimatorImpl(TravelTime initialTT, TravelTime observedTT, Network network,
+	public DvrpOfflineTravelTimeEstimator(TravelTime initialTT, TravelTime observedTT, Network network,
 			TravelTimeCalculatorConfigGroup ttCalcConfig, double travelTimeEstimationAlpha) {
 		this.observedTT = observedTT;
 		this.network = network;
 
 		alpha = travelTimeEstimationAlpha;
 		if (alpha > 1 || alpha <= 0) {
-			throw new RuntimeException("travelTimeEstimationAlpha must be in (0,1]");
+			throw new IllegalArgumentException("travelTimeEstimationAlpha must be in (0,1]");
 		}
 
 		interval = ttCalcConfig.getTraveltimeBinSize();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
@@ -22,9 +22,11 @@ package org.matsim.contrib.dvrp.trafficmonitoring;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.*;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.*;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
@@ -36,6 +38,15 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
+/**
+ * Used for offline estimation of travel times for VrpOptimizer by means of the exponential moving average. The
+ * weighting decrease, alpha, must be in (0,1]. We suggest small values of alpha, e.g. 0.05.
+ * 
+ * The averaging starts from the initial travel time estimates. If not provided, the free-speed TTs is used as the
+ * initial estimates
+ * 
+ * @author michalm
+ */
 public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, MobsimBeforeCleanupListener {
 	private final TravelTime observedTT;
 	private final Network network;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOnlineTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOnlineTravelTimeEstimator.java
@@ -1,0 +1,71 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.dvrp.trafficmonitoring;
+
+import javax.inject.Inject;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.mobsim.framework.events.MobsimInitializedEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimInitializedListener;
+import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
+
+/**
+ * @author michalm
+ */
+public class DvrpOnlineTravelTimeEstimator implements DvrpTravelTimeEstimator, MobsimInitializedListener {
+	private final WithinDayTravelTime withinDayTT;
+	private final DvrpOfflineTravelTimeEstimator offlineTTEstimator;
+	private MobsimTimer mobsimTimer;
+	private final double beta;
+
+	@Inject
+	public DvrpOnlineTravelTimeEstimator(WithinDayTravelTime withinDayTT,
+			DvrpOfflineTravelTimeEstimator offlineTTEstimator, DvrpConfigGroup dvrpConfig) {
+		this.withinDayTT = withinDayTT;
+		this.offlineTTEstimator = offlineTTEstimator;
+
+		beta = dvrpConfig.getTravelTimeEstimationBeta();
+		if (beta < 0) {
+			throw new IllegalArgumentException("travelTimeEstimationBeta must be zero or positive");
+		}
+	}
+
+	@Override
+	public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
+		double currentTime = mobsimTimer.getTimeOfDay();
+		double correction = Math.min(1, Math.max(0, 1 - (time - currentTime) / beta));
+		double currentTT = withinDayTT.getLinkTravelTime(link, currentTime, person, vehicle);
+		double offlineTT = offlineTTEstimator.getLinkTravelTime(link, time, person, vehicle);
+		return correction * currentTT + (1 - correction) * offlineTT;
+
+		// XXX Alternatively:
+		// double currentOfflineTT = offlineTTEstimator.getLinkTravelTime(link, currentTime, person, vehicle);
+		// return correction * currentTT * offlineTT / currentOfflineTT + (1-correction) * offlineTT
+	}
+
+	@Override
+	public void notifyMobsimInitialized(@SuppressWarnings("rawtypes") MobsimInitializedEvent e) {
+		mobsimTimer = ((QSim)e.getQueueSimulation()).getSimTimer();
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOnlineTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOnlineTravelTimeEstimator.java
@@ -31,6 +31,11 @@ import org.matsim.vehicles.Vehicle;
 import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
 
 /**
+ * Online estimation of travel times for VrpOptimizer by combining WithinDayTravelTime and
+ * DvrpOfflineTravelTimeEstimator. The beta coefficient is provided in seconds and should be either 0 (no online
+ * estimation) or positive (mixed online-offline estimation). If beta is sufficiently large, 'beta >> 0', only the
+ * currently observed TT is used
+ * 
  * @author michalm
  */
 public class DvrpOnlineTravelTimeEstimator implements DvrpTravelTimeEstimator, MobsimInitializedListener {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeEstimator.java
@@ -19,11 +19,10 @@
 
 package org.matsim.contrib.dvrp.trafficmonitoring;
 
-import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.router.util.TravelTime;
 
 /**
  * @author michalm
  */
-public interface DvrpTravelTimeEstimator extends TravelTime, MobsimListener {
+public interface DvrpTravelTimeEstimator extends TravelTime {
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -19,13 +19,8 @@
 
 package org.matsim.contrib.dvrp.trafficmonitoring;
 
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.controler.AbstractModule;
-import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
-
-import com.google.inject.*;
-import com.google.inject.name.*;
 
 /**
  * Travel times recorded during the previous iteration. They are always updated after the mobsim ends. This is the
@@ -37,17 +32,11 @@ public class DvrpTravelTimeModule extends AbstractModule {
 	public static final String DVRP_ESTIMATED = "dvrp_estimated";
 
 	public void install() {
-		bind(TravelTime.class).annotatedWith(Names.named(DvrpTravelTimeModule.DVRP_INITIAL))
-				.toInstance(new FreeSpeedTravelTime());
+		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).toInstance(new FreeSpeedTravelTime());
+		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_OBSERVED).to(networkTravelTime());
+
 		bind(DvrpTravelTimeEstimator.class).to(DvrpTravelTimeEstimatorImpl.class).asEagerSingleton();
 		addTravelTimeBinding(DVRP_ESTIMATED).to(DvrpTravelTimeEstimator.class);
 		addMobsimListenerBinding().to(DvrpTravelTimeEstimator.class);
-	}
-
-	@Provides
-	@Named(DvrpTravelTimeModule.DVRP_OBSERVED)
-	@Singleton
-	TravelTime provideTravelTime(@Named(TransportMode.car) TravelTime observedTT) {
-		return observedTT;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -25,8 +25,7 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
 
 /**
- * Travel times recorded during the previous iteration. They are always updated after the mobsim ends. This is the
- * standard approach for running DVRP
+ * @author michalm
  */
 public class DvrpTravelTimeModule extends AbstractModule {
 	public static final String DVRP_INITIAL = "dvrp_initial";

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -19,8 +19,10 @@
 
 package org.matsim.contrib.dvrp.trafficmonitoring;
 
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
 
 /**
  * Travel times recorded during the previous iteration. They are always updated after the mobsim ends. This is the
@@ -34,9 +36,22 @@ public class DvrpTravelTimeModule extends AbstractModule {
 	public void install() {
 		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).toInstance(new FreeSpeedTravelTime());
 		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_OBSERVED).to(networkTravelTime());
-
-		bind(DvrpTravelTimeEstimator.class).to(DvrpTravelTimeEstimatorImpl.class).asEagerSingleton();
 		addTravelTimeBinding(DVRP_ESTIMATED).to(DvrpTravelTimeEstimator.class);
-		addMobsimListenerBinding().to(DvrpTravelTimeEstimator.class);
+
+		bind(DvrpOfflineTravelTimeEstimator.class).asEagerSingleton();
+		addMobsimListenerBinding().to(DvrpOfflineTravelTimeEstimator.class);
+
+		if (DvrpConfigGroup.get(getConfig()).getTravelTimeEstimationBeta() > 0) {// online estimation
+			bind(DvrpOnlineTravelTimeEstimator.class).asEagerSingleton();
+			addMobsimListenerBinding().to(DvrpOnlineTravelTimeEstimator.class);
+			bind(DvrpTravelTimeEstimator.class).to(DvrpOnlineTravelTimeEstimator.class);
+
+			bind(WithinDayTravelTime.class).asEagerSingleton();
+			addEventHandlerBinding().to(WithinDayTravelTime.class);
+			addMobsimListenerBinding().to(WithinDayTravelTime.class);
+
+		} else { // offline estimation
+			bind(DvrpTravelTimeEstimator.class).to(DvrpOfflineTravelTimeEstimator.class);
+		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/TravelTimeUtils.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/TravelTimeUtils.java
@@ -21,10 +21,14 @@ package org.matsim.contrib.dvrp.trafficmonitoring;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.events.*;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
 
+/**
+ * @author michalm
+ */
 public class TravelTimeUtils {
 	public static TravelTime createTravelTimesFromEvents(Scenario scenario, String eventsFile) {
 		TravelTimeCalculator ttCalculator = TravelTimeCalculator.create(scenario.getNetwork(),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/DynAgent.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/DynAgent.java
@@ -22,16 +22,22 @@ package org.matsim.contrib.dynagent;
 import java.util.List;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
+import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimAgent;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
-import org.matsim.core.mobsim.qsim.pt.*;
+import org.matsim.core.mobsim.qsim.pt.MobsimDriverPassengerAgent;
+import org.matsim.core.mobsim.qsim.pt.TransitVehicle;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.Facility;
-import org.matsim.pt.transitSchedule.api.*;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
 public final class DynAgent implements MobsimDriverPassengerAgent {
@@ -64,8 +70,7 @@ public final class DynAgent implements MobsimDriverPassengerAgent {
 
 		// initial activity
 		dynActivity = this.agentLogic.computeInitialActivity(this);
-		state = dynActivity.getEndTime() != Time.UNDEFINED_TIME ? //
-				MobsimAgent.State.ACTIVITY : MobsimAgent.State.ABORT;
+		state = Time.isUndefinedTime(dynActivity.getEndTime()) ? MobsimAgent.State.ABORT : MobsimAgent.State.ACTIVITY;
 	}
 
 	private void computeNextAction(DynAction oldDynAction, double now) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynQSimConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynQSimConfigConsistencyChecker.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.dynagent.run;
 import org.apache.log4j.Logger;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
-import org.matsim.core.config.groups.QSimConfigGroup;
+import org.matsim.core.config.groups.QSimConfigGroup.StarttimeInterpretation;
 import org.matsim.core.utils.misc.Time;
 
 public class DynQSimConfigConsistencyChecker implements ConfigConsistencyChecker {
@@ -30,18 +30,17 @@ public class DynQSimConfigConsistencyChecker implements ConfigConsistencyChecker
 
 	@Override
 	public void checkConsistency(Config config) {
-		QSimConfigGroup qSimConfig = config.qsim();
-
-		if (qSimConfig.getStartTime() != 0 && qSimConfig.getStartTime() != Time.UNDEFINED_TIME) {
-			log.warn("Simulation should start from time 0. This is what DynAgent assumes");
+		if (config.qsim().getStartTime() != 0 && !Time.isUndefinedTime(config.qsim().getStartTime())) {
+			// If properly handled this should not be a concern
+			log.warn("QSim.startTime should be 0:00:00 (or 0). This is what typically DynAgents assume");
 		}
-
-		if (qSimConfig.getSimStarttimeInterpretation() != //
-		QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime) {
-			throw new RuntimeException(
-					"DynAgents require simulation from the very beginning, preferably sec-by-sec from time 0."
-							+ " Please set \'simStarttimeInterpretation\' in the qSim config module to  \'onlyUseStarttime\'"
-							+ " and set the start time to 00:00:00.");
+		if (config.qsim().getTimeStepSize() != 1) {
+			// If properly handled this should not be a concern
+			log.warn("QSim.timeStepSize should be 1. This is what typically DynAgents assume");
+		}
+		if (config.qsim().getSimStarttimeInterpretation() != StarttimeInterpretation.onlyUseStarttime) {
+			throw new RuntimeException("DynAgents require simulation to start from the very beginning"
+					+ " Set 'QSim.simStarttimeInterpretation' to " + StarttimeInterpretation.onlyUseStarttime);
 		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/distance/DistanceCalculators.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/distance/DistanceCalculators.java
@@ -20,35 +20,29 @@
 package org.matsim.contrib.util.distance;
 
 import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.network.*;
-import org.matsim.contrib.dvrp.router.*;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.dvrp.router.DijkstraWithDijkstraTreeCache;
+import org.matsim.contrib.dvrp.router.DistanceAsTravelDisutility;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.util.TimeDiscretizer;
 import org.matsim.core.network.NetworkUtils;
-import org.matsim.core.router.util.*;
+import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 public class DistanceCalculators {
-	public static final DistanceCalculator BEELINE_DISTANCE_CALCULATOR = new DistanceCalculator() {
-		@Override
-		public double calcDistance(Coord from, Coord to) {
-			return DistanceUtils.calculateDistance(from, to);
-		}
-	};
-
-	public static DistanceCalculator crateFreespeedDistanceCalculator(final Network network) {
-		return crateFreespeedBasedCalculator(network, false);
+	public static DistanceCalculator crateFreespeedDistanceCalculator(Network network) {
+		return crateFreespeedBasedCalculator(network, new DistanceAsTravelDisutility());
 	}
 
-	public static DistanceCalculator crateFreespeedTimeCalculator(final Network network) {
-		return crateFreespeedBasedCalculator(network, true);
+	public static DistanceCalculator crateFreespeedTimeCalculator(Network network) {
+		return crateFreespeedBasedCalculator(network, new TimeAsTravelDisutility(new FreeSpeedTravelTime()));
 	}
 
-	private static DistanceCalculator crateFreespeedBasedCalculator(final Network network, final boolean timeBased) {
-		TravelTime ttimeCalc = new FreeSpeedTravelTime();
-		TravelDisutility tcostCalc = timeBased ? new TimeAsTravelDisutility(ttimeCalc)
-				: new DistanceAsTravelDisutility();
-		final DijkstraWithDijkstraTreeCache dijkstraTree = new DijkstraWithDijkstraTreeCache(network, tcostCalc,
-				ttimeCalc, TimeDiscretizer.CYCLIC_24_HOURS);
+	private static DistanceCalculator crateFreespeedBasedCalculator(Network network,
+			TravelDisutility travelDisutility) {
+		final DijkstraWithDijkstraTreeCache dijkstraTree = new DijkstraWithDijkstraTreeCache(network, travelDisutility,
+				new FreeSpeedTravelTime(), TimeDiscretizer.CYCLIC_24_HOURS);
 
 		return new DistanceCalculator() {
 			@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/distance/DistanceUtils.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/distance/DistanceUtils.java
@@ -1,6 +1,7 @@
 package org.matsim.contrib.util.distance;
 
-import org.matsim.api.core.v01.*;
+import org.matsim.api.core.v01.BasicLocation;
+import org.matsim.api.core.v01.Coord;
 
 public class DistanceUtils {
 	public static double calculateDistance(BasicLocation<?> fromLocation, BasicLocation<?> toLocation) {
@@ -11,15 +12,19 @@ public class DistanceUtils {
 		return calculateSquaredDistance(fromLocation.getCoord(), toLocation.getCoord());
 	}
 
+	/**
+	 * @return distance (for distance-based comparison/sorting, consider using the squared distance)
+	 */
 	public static double calculateDistance(Coord fromCoord, Coord toCoord) {
 		return Math.sqrt(calculateSquaredDistance(fromCoord, toCoord));
 	}
 
+	/**
+	 * @return SQUARED distance (to avoid unnecessary Math.sqrt() calls when comparing distances)
+	 */
 	public static double calculateSquaredDistance(Coord fromCoord, Coord toCoord) {
 		double deltaX = toCoord.getX() - fromCoord.getX();
 		double deltaY = toCoord.getY() - fromCoord.getY();
-
-		// this is a SQUARED distance!!! (to avoid unnecessary Math.sqrt() calls)
 		return deltaX * deltaX + deltaY * deltaY;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/SquareGridSystem.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/SquareGridSystem.java
@@ -44,7 +44,6 @@ public class SquareGridSystem implements ZonalSystem {
 			Zone zone = zonalSystem.getZone(n);
 			zonesWithNodes.put(zone.getId(), zone);
 		}
-
 		return zonesWithNodes;
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystemImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystemImpl.java
@@ -22,8 +22,10 @@ package org.matsim.contrib.zone;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.*;
-import org.matsim.contrib.zone.util.*;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.zone.util.NetworkWithZonesUtils;
+import org.matsim.contrib.zone.util.ZoneFinder;
 
 public class ZonalSystemImpl implements ZonalSystem {
 	private final Map<Id<Zone>, Zone> zones;
@@ -31,7 +33,6 @@ public class ZonalSystemImpl implements ZonalSystem {
 
 	public ZonalSystemImpl(Map<Id<Zone>, Zone> zones, ZoneFinder zoneFinder, Network network) {
 		this.zones = zones;
-
 		nodeToZoneMap = NetworkWithZonesUtils.createNodeToZoneMap(network, zoneFinder);
 	}
 
@@ -42,6 +43,6 @@ public class ZonalSystemImpl implements ZonalSystem {
 
 	@Override
 	public Zone getZone(Node node) {
-		return nodeToZoneMap.get(node);
+		return nodeToZoneMap.get(node.getId());
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/DvrpBenchmarkTravelTimeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/DvrpBenchmarkTravelTimeModule.java
@@ -19,8 +19,8 @@
 
 package org.matsim.contrib.taxi.benchmark;
 
-import org.matsim.api.core.v01.TransportMode;
-import org.matsim.contrib.dvrp.trafficmonitoring.*;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeEstimator;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
@@ -44,8 +44,7 @@ public class DvrpBenchmarkTravelTimeModule extends AbstractModule {
 	public void install() {
 		// Because TravelTimeCalculatorModule is not installed for benchmarking, we need to add a binding
 		// for the car mode
-		addTravelTimeBinding(TransportMode.car).toInstance(travelTime);
-
+		bindNetworkTravelTime().toInstance(travelTime);
 		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_ESTIMATED).toInstance(travelTime);
 
 		// since we cannot undo: addMobsimListenerBinding().to(VrpTravelTimeEstimator.class)

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/TaxiToRequestAssignmentCostProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/TaxiToRequestAssignmentCostProvider.java
@@ -88,7 +88,7 @@ public class TaxiToRequestAssignmentCostProvider {
 			PathData pathData) {
 		double travelTime = pathData == null ? //
 				params.nullPathCost : // no path (too far away)
-				pathData.firstAndLastLinkTT + pathData.path.travelTime;
+				pathData.getTravelTime();
 		return Math.max(reqEntry.destination.getEarliestStartTime(), departure.time + travelTime);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
@@ -181,7 +181,7 @@ public class VehicleAssignmentProblem<D> {
 			// TODO if null is frequent we may be more efficient by increasing the neighbourhood
 			VrpPathWithTravelData vrpPath = pathData == null ? //
 					VrpPaths.calcAndCreatePath(departure.link, dest.link, departure.time, router, travelTime)
-					: VrpPaths.createPath(departure.link, dest.link, departure.time, pathData.path, travelTime);
+					: VrpPaths.createPath(departure.link, dest.link, departure.time, pathData, travelTime);
 
 			dispatches.add(new Dispatch<>(departure.vehicle, dest.destination, vrpPath));
 		}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/zonal/ZonalRequestInserter.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/zonal/ZonalRequestInserter.java
@@ -19,7 +19,6 @@
 package org.matsim.contrib.taxi.optimizer.zonal;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
@@ -30,7 +30,14 @@ public class TaxiConfigConsistencyChecker implements ConfigConsistencyChecker {
 
 		TaxiConfigGroup taxiCfg = TaxiConfigGroup.get(config);
 		if (taxiCfg.isVehicleDiversion() && !taxiCfg.isOnlineVehicleTracker()) {
-			throw new RuntimeException("Diversion requires online tracking");
+			throw new RuntimeException(
+					TaxiConfigGroup.VEHICLE_DIVERSION + " requires " + TaxiConfigGroup.ONLINE_VEHICLE_TRACKER);
+		}
+		if (taxiCfg.getPickupDuration() < 0) {
+			throw new RuntimeException(TaxiConfigGroup.PICKUP_DURATION + " must be zero or positive");
+		}
+		if (taxiCfg.getDropoffDuration() < 0) {
+			throw new RuntimeException(TaxiConfigGroup.DROPOFF_DURATION + " must be zero or positive");
 		}
 		if (config.qsim().getNumberOfThreads() != 1) {
 			throw new RuntimeException("Only a single-threaded QSim allowed");

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -55,8 +55,8 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 
 	private boolean destinationKnown = false;
 	private boolean vehicleDiversion = false;
-	private double pickupDuration = Double.NaN;// seconds
-	private double dropoffDuration = Double.NaN;// seconds
+	private Double pickupDuration = null;// seconds
+	private Double dropoffDuration = null;// seconds
 	private double AStarEuclideanOverdoFactor = 1.;
 	private boolean onlineVehicleTracker = false;
 	private boolean changeStartLinkToLastLinkInSchedule = false;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -385,7 +385,7 @@ public class TaxiScheduler implements TaxiScheduleInquiry {
 			TaxiTask task = (TaxiTask)tasks.get(i);
 			double calcEndTime = calcNewEndTime(vehicle, task, newBeginTime);
 
-			if (calcEndTime == Time.UNDEFINED_TIME) {
+			if (Time.isUndefinedTime(calcEndTime)) {
 				schedule.removeTask(task);
 				i--;
 			} else if (calcEndTime < newBeginTime) {// 0 s is fine (e.g. last 'wait')

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
@@ -20,7 +20,6 @@
 package org.matsim.contrib.taxi.util.stats;
 
 import java.util.Collection;
-import java.util.stream.Stream;
 
 import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.data.Request;


### PR DESCRIPTION
Online estimation of travel times for by combining `WithinDayTravelTime` and `DvrpOfflineTravelTimeEstimator` (the latter by means of the exponential moving average). `travelTimeEstimationBeta` added to `DvrpConfigGroup` to tune the estimation.

For `beta = 0`, only the offline estimate is used, whereas if `beta >> 0` only the currently observed (i.e. within-day) TT is used.