### PR TITLE
Config bean validation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -111,8 +111,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		}
 		DynModeTripsAnalyser.writeVehicleDistances(drtPassengerStats.getVehicleDistances(),
 				matsimServices.getControlerIO().getIterationFilename(event.getIteration(), "vehicleDistanceStats.csv"));
-		DynModeTripsAnalyser.analyseDetours(network, trips, drtgroup.getEstimatedBeelineDistanceFactor(),
-				drtgroup.getEstimatedDrtSpeed(),
+		DynModeTripsAnalyser.analyseDetours(network, trips,
 				matsimServices.getControlerIO().getIterationFilename(event.getIteration(), "drt_detours"));
 		DynModeTripsAnalyser.analyseWaitTimes(
 				matsimServices.getControlerIO().getIterationFilename(event.getIteration(), "waitStats"), trips, 1800);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModeTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModeTripsAnalyser.java
@@ -141,8 +141,7 @@ public class DynModeTripsAnalyser {
 		return directDistanceStats.getMean();
 	}
 
-	public static void analyseDetours(Network network, List<DynModeTrip> trips, double beelineDistanceFactor,
-			double freeSpeedModeFactor, String fileName) {
+	public static void analyseDetours(Network network, List<DynModeTrip> trips, String fileName) {
 		if (trips == null)
 			return;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -22,7 +22,14 @@ package org.matsim.contrib.drt.run;
 import java.net.URL;
 import java.util.Map;
 
-import org.matsim.core.config.*;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ReflectiveConfigGroup;
 
 public class DrtConfigGroup extends ReflectiveConfigGroup {
 	public static final String GROUP_NAME = "drt";
@@ -55,32 +62,55 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	public static final String PRINT_WARNINGS = "plotDetailedWarnings";
 	public static final String NUMBER_OF_THREADS = "numberOfThreads";
 
-	private Double stopDuration = null;// seconds
-	private Double maxWaitTime = null;// seconds
+	@PositiveOrZero
+	private double stopDuration = Double.NaN;// seconds
+
+	@PositiveOrZero
+	private double maxWaitTime = Double.NaN;// seconds
 
 	// max arrival time defined as:
 	// maxTravelTimeAlpha * unshared_ride_travel_time(fromLink, toLink) + maxTravelTimeBeta,
 	// where unshared_ride_travel_time(fromLink, toLink) is calculated with FastAStarEuclidean
 	// (hence AStarEuclideanOverdoFactor needs to be specified)
-	private Double maxTravelTimeAlpha = null;// [-], >= 1.0
-	private Double maxTravelTimeBeta = null;// [s], >= 0.0
-	private double AStarEuclideanOverdoFactor = 1.;// >= 1.0
+	@Min(1)
+	private double maxTravelTimeAlpha = Double.NaN;// [-]
+
+	@PositiveOrZero
+	private double maxTravelTimeBeta = Double.NaN;// [s]
+
+	@Min(1)
+	private double AStarEuclideanOverdoFactor = 1.;
+
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
+	@PositiveOrZero
 	private int rebalancingInterval = 0;// [s], if 0 then no rebalancing
+
 	private boolean idleVehiclesReturnToDepots = false;
+
+	@NotNull
 	private OperationalScheme operationalScheme = OperationalScheme.door2door;
 
-	private Double maxWalkDistance = null;// [m]; only for stationbased DRT scheme
+	@PositiveOrZero // used only for stationbased DRT scheme
+	private double maxWalkDistance = 0;// [m];
+
+	@PositiveOrZero
 	private double estimatedDrtSpeed = 25. / 3.6;// [m/s]
+
+	@Min(1)
 	private double estimatedBeelineDistanceFactor = 1.3;// [-]
 
+	@NotNull
 	private String vehiclesFile = null;
+
+	// used only for stationbased DRT scheme
 	private String transitStopFile = null; // only for stationbased DRT scheme
 
 	private boolean plotDetailedCustomerStats = true;
 	private boolean plotDetailedVehicleStats = false;
 	private boolean printDetailedWarnings = false;
+
+	@Positive
 	private int numberOfThreads = Runtime.getRuntime().availableProcessors();
 
 	public enum OperationalScheme {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -41,7 +41,6 @@ import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
 import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
-import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic.DynActionCreator;
@@ -95,7 +94,7 @@ public final class DrtControlerCreator {
 
 	private static void adjustConfig(Config config) {
 		DrtConfigGroup drtCfg = DrtConfigGroup.get(config);
-		config.addConfigConsistencyChecker(new DvrpConfigConsistencyChecker());
+		config.addConfigConsistencyChecker(new DrtConfigConsistencyChecker());
 		config.checkConsistency();
 		if (drtCfg.getOperationalScheme().equals(DrtConfigGroup.OperationalScheme.stationbased)) {
 			ActivityParams params = config.planCalcScore().getActivityParams(DrtStageActivityType.DRT_STAGE_ACTIVITY);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtExample.java
@@ -31,8 +31,6 @@ public class RunDrtExample {
 	
 	
 	public static void run(Config config, boolean otfvis) {
-		config.addConfigConsistencyChecker(new DrtConfigConsistencyChecker());
-		config.checkConsistency();
 		DrtControlerCreator.createControler(config, otfvis).run();;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
@@ -35,8 +35,6 @@ public class RunDrtScenario {
 	}
 
 	public static Controler createControler(Config config, boolean otfvis) {
-		config.addConfigConsistencyChecker(new DrtConfigConsistencyChecker());
-		config.checkConsistency();
 		return DrtControlerCreator.createControler(config, otfvis);
 	}
 

--- a/contribs/dvrp/pom.xml
+++ b/contribs/dvrp/pom.xml
@@ -15,8 +15,32 @@
 			</plugin>
 		</plugins>
 	</build>
-  
-  	<dependencies>
+
+	<dependencies>
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.1.Final</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.0.7.Final</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator-annotation-processor</artifactId>
+			<version>6.0.7.Final</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<version>3.0.1-b08</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -35,7 +59,7 @@
 			<version>0.10.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>locationchoice</artifactId>

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigConsistencyChecker.java
@@ -47,14 +47,5 @@ public class DvrpConfigConsistencyChecker implements ConfigConsistencyChecker {
 		if (config.qsim().isRemoveStuckVehicles()) {
 			throw new RuntimeException("Stuck DynAgents cannot be removed from simulation");
 		}
-
-		DvrpConfigGroup dvrpCfg = DvrpConfigGroup.get(config);
-		double alpha = dvrpCfg.getTravelTimeEstimationAlpha();
-		if (alpha > 1 || alpha <= 0) {
-			throw new RuntimeException(DvrpConfigGroup.TRAVEL_TIME_ESTIMATION_ALPHA + " must be in (0,1]");
-		}
-		if (dvrpCfg.getTravelTimeEstimationBeta() < 0) {
-			throw new RuntimeException(DvrpConfigGroup.TRAVEL_TIME_ESTIMATION_BETA + " must be zero or positive");
-		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -21,6 +21,12 @@ package org.matsim.contrib.dvrp.run;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -38,11 +44,19 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	public static final String TRAVEL_TIME_ESTIMATION_ALPHA = "travelTimeEstimationAlpha";
 	public static final String TRAVEL_TIME_ESTIMATION_BETA = "travelTimeEstimationBeta";
 
+	@NotNull
 	private String mode = null; // travel mode (passengers'/customers' perspective)
+
+	@Nullable
 	private String networkMode = TransportMode.car; // used for building routes, calculating travel times, etc.
-	// (dispatcher's perspective)
-	private double travelTimeEstimationAlpha = 0.05; // in (0, 1]; 1 => TTs from the last iteration only
-	private double travelTimeEstimationBeta = 0; // in [s], in [0, +oo); 0 => only offline TT estimation
+	// (dispatcher's perspective); null ==> no filtering (routing network equals scenario.network)
+
+	@Positive
+	@Max(1)
+	private double travelTimeEstimationAlpha = 0.05; // [-], 1 ==> TTs from the last iteration only
+
+	@PositiveOrZero
+	private double travelTimeEstimationBeta = 0; // [s], 0 ==> only offline TT estimation
 
 	public DvrpConfigGroup() {
 		super(GROUP_NAME);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynQSimConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynQSimConfigConsistencyChecker.java
@@ -20,6 +20,7 @@
 package org.matsim.contrib.dynagent.run;
 
 import org.apache.log4j.Logger;
+import org.matsim.contrib.util.BeanValidationConfigConsistencyChecker;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 import org.matsim.core.config.groups.QSimConfigGroup.StarttimeInterpretation;
@@ -30,6 +31,8 @@ public class DynQSimConfigConsistencyChecker implements ConfigConsistencyChecker
 
 	@Override
 	public void checkConsistency(Config config) {
+		new BeanValidationConfigConsistencyChecker().checkConsistency(config);
+
 		if (config.qsim().getStartTime() != 0 && !Time.isUndefinedTime(config.qsim().getStartTime())) {
 			// If properly handled this should not be a concern
 			log.warn("QSim.startTime should be 0:00:00 (or 0). This is what typically DynAgents assume");

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
@@ -33,12 +33,6 @@ public class TaxiConfigConsistencyChecker implements ConfigConsistencyChecker {
 			throw new RuntimeException(
 					TaxiConfigGroup.VEHICLE_DIVERSION + " requires " + TaxiConfigGroup.ONLINE_VEHICLE_TRACKER);
 		}
-		if (taxiCfg.getPickupDuration() < 0) {
-			throw new RuntimeException(TaxiConfigGroup.PICKUP_DURATION + " must be zero or positive");
-		}
-		if (taxiCfg.getDropoffDuration() < 0) {
-			throw new RuntimeException(TaxiConfigGroup.DROPOFF_DURATION + " must be zero or positive");
-		}
 		if (config.qsim().getNumberOfThreads() != 1) {
 			throw new RuntimeException("Only a single-threaded QSim allowed");
 		}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -22,6 +22,10 @@ package org.matsim.contrib.taxi.run;
 import java.net.URL;
 import java.util.Map;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
 import org.matsim.core.config.*;
 
 public class TaxiConfigGroup extends ReflectiveConfigGroup {
@@ -55,12 +59,20 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 
 	private boolean destinationKnown = false;
 	private boolean vehicleDiversion = false;
-	private Double pickupDuration = null;// seconds
-	private Double dropoffDuration = null;// seconds
+	
+	@PositiveOrZero
+	private double pickupDuration = Double.NaN;// seconds
+
+	@PositiveOrZero
+	private double dropoffDuration = Double.NaN;// seconds
+	
+	@Min(1)
 	private double AStarEuclideanOverdoFactor = 1.;
+	
 	private boolean onlineVehicleTracker = false;
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
+	@NotNull
 	private String taxisFile = null;
 
 	private boolean timeProfiles = false;


### PR DESCRIPTION
Use bean validation for simple config group validation instead of longish (often out-of-date and partially missing) sequences of 'if' statements in config checkers.

A couple of lines from of `DrtConfigGroup`:
```
//....
	@Min(1)
	private double maxTravelTimeAlpha = Double.NaN;// [-]

	@PositiveOrZero
	private double maxTravelTimeBeta = Double.NaN;// [s]

	@NotNull
	private OperationalScheme operationalScheme = OperationalScheme.door2door;

	@NotNull
	private String vehiclesFile = null;

	@Positive
	private int numberOfThreads = Runtime.getRuntime().availableProcessors();
//....
```
And the auto-generated checking result (when running DRT with empty dvrp and drt groups):
```
Exception in thread "main" javax.validation.ConstraintViolationException: Errors in config:
drt.maxTravelTimeBeta: must be greater than or equal to 0
drt.maxTravelTimeAlpha: must be greater than or equal to 1
drt.vehiclesFile: must not be null
drt.stopDuration: must be greater than or equal to 0
drt.maxWaitTime: must be greater than or equal to 0
dvrp.mode: must not be null
```
If there is a need -- `BeanValidationConfigConsistencyChecker` could be moved to core and executed by default.