### PR TITLE
Hour data type is now consistent in both writeTime and parseTime.

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
+++ b/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
@@ -188,7 +188,7 @@ public class Time {
 		if (strings.length == 1) {
 			seconds = Math.abs(Double.parseDouble(strings[0]));
 		} else if (strings.length == 2) {
-			int h = Integer.parseInt(strings[0]);
+			long h = Long.parseLong(strings[0]);
 			int m = Integer.parseInt(strings[1]);
 
 			if ((m < 0) || (m > 59)) {
@@ -197,7 +197,7 @@ public class Time {
 
 			seconds = Math.abs(h) * 3600 + m * 60;
 		} else if (strings.length == 3) {
-			int h = Integer.parseInt(strings[0]);
+			long h = Long.parseLong(strings[0]);
 			int m = Integer.parseInt(strings[1]);
 			double s = Double.parseDouble(strings[2]);
 

--- a/matsim/src/test/java/org/matsim/core/utils/misc/TimeTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/misc/TimeTest.java
@@ -147,6 +147,9 @@ public class TimeTest extends TestCase {
 		assertEquals(-12*3600.0 - 34*60.0 - 56.7, Time.parseTime("-12:34:56.7"), 0.0);
 		assertEquals(0.0, Time.parseTime("00:00:00"), 0.0);
 		assertEquals(Integer.MIN_VALUE, Time.parseTime("-596523:14:08"), 0.0);
+		/* test for parsing hours greater than 2^31-1 (i.e. hour of type long)
+		 */
+		assertEquals(Long.MAX_VALUE, Time.parseTime("2562047788015215:28:07"), 0.0);
 	}
 	
 	public void testConvertHHMMInteger() {


### PR DESCRIPTION
"hour" data type is now consistently "long" in both writeTime and parseTime functions and is now tested for.