### PR TITLE
Remove custom use of log4j

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -22,7 +22,6 @@ package org.matsim.core.controler;
 import org.apache.log4j.Logger;
 import org.matsim.analysis.IterationStopWatch;
 import org.matsim.core.config.Config;
-import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.controler.listener.ControlerListener;
 import org.matsim.core.gbl.MatsimRandom;
 
@@ -54,7 +53,6 @@ public abstract class AbstractController {
     }
 
     AbstractController(ControlerListenerManagerImpl controlerListenerManager, IterationStopWatch stopWatch, MatsimServices matsimServices) {
-        ControlerUtils.initializeOutputLogging();
         log.info("Used Controler-Class: " + this.getClass().getCanonicalName());
         this.controlerListenerManagerImpl = controlerListenerManager;
         this.controlerListenerManagerImpl.setControler(matsimServices);
@@ -68,11 +66,6 @@ public abstract class AbstractController {
         // draw...
         // Fixme [kn] this should really be ten thousand draws instead of just
         // one
-    }
-
-    protected final void setupOutputDirectory(final String outputDirectory, String runId, final OverwriteFileSetting overwriteFiles) {
-        this.controlerIO = new OutputDirectoryHierarchy(outputDirectory, runId, overwriteFiles); // output dir needs to be there before logging
-        OutputDirectoryLogging.initLogging(this.getControlerIO()); // logging needs to be early
     }
 
     final void setupOutputDirectory(OutputDirectoryHierarchy controlerIO) {

--- a/matsim/src/main/java/org/matsim/core/controler/ControlerUtils.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControlerUtils.java
@@ -66,10 +66,4 @@ public final class ControlerUtils {
 	    log.info("Checking consistency of config done.");
 	}
 
-	public static void initializeOutputLogging() {
-		    OutputDirectoryLogging.catchLogEntries();
-		    Gbl.printSystemInfo();
-		    Gbl.printBuildInfo();
-	    }
-
 }

--- a/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryLogging.java
+++ b/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryLogging.java
@@ -25,6 +25,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.matsim.core.gbl.Gbl;
 import org.matsim.core.utils.io.CollectLogMessagesAppender;
 import org.matsim.core.utils.io.IOUtils;
 
@@ -130,6 +131,8 @@ public final class OutputDirectoryLogging {
 			collectLogMessagesAppender.close();
 			collectLogMessagesAppender = null;
 		}
+		Gbl.printSystemInfo();
+		Gbl.printBuildInfo();
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryLogging.java
+++ b/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryLogging.java
@@ -20,19 +20,15 @@
 
 package org.matsim.core.controler;
 
-import java.io.IOException;
-import java.net.URL;
-
 import org.apache.log4j.Appender;
-import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.log4j.PropertyConfigurator;
-import org.apache.log4j.helpers.Loader;
 import org.apache.log4j.spi.LoggingEvent;
 import org.matsim.core.utils.io.CollectLogMessagesAppender;
 import org.matsim.core.utils.io.IOUtils;
+
+import java.io.IOException;
 
 /**
  * 
@@ -55,28 +51,6 @@ public final class OutputDirectoryLogging {
 	public static final String WARNLOGFILE = "logfileWarningsErrors.log";
 
 	private static Logger log = Logger.getLogger(OutputDirectoryLogging.class);
-
-	/** initializes Log4J */
-	static {
-		final String logProperties = "log4j.xml";
-		URL url = Loader.getResource(logProperties);
-		if (url != null) {
-			PropertyConfigurator.configure(url);
-		} else {
-			Logger root = Logger.getRootLogger();
-			root.setLevel(Level.INFO);
-			ConsoleAppender consoleAppender = new ConsoleAppender(Controler.DEFAULTLOG4JLAYOUT, "System.out");
-			consoleAppender.setName("A1");
-			root.addAppender(consoleAppender);
-			consoleAppender.setLayout(Controler.DEFAULTLOG4JLAYOUT);
-			log.error("");
-			log.error("Could not find configuration file " + logProperties + " for Log4j in the classpath.");
-			log.error("A default configuration is used, setting log level to INFO with a ConsoleAppender.");
-			log.error("");
-			log.error("");
-		}
-	}
-
 
 	/**
 	 * This variable is used to store the log4j output before it can be written


### PR DESCRIPTION
To be able to use MATSim as a library, it helps to be able to redirect logging to other facilities. The by now most common way to do this is to use a logging API such as slf4j. Maybe at one point we should switch to that.

However, even now it is possible to redirect log4j to slf4j, and slf4j to anything, by using a "stub" log4j implementation to replace it (from the outside, via dependency management). We did that at Berkeley Lab.

_That_ however only works if MATSim refrains from using _very_ custom Log4j features in two places. This pull request removes those usages. I think they aren't very important any more. Let me know what you think.