### PR TITLE
make FleetProvider.network private

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/data/file/FleetProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/data/file/FleetProvider.java
@@ -36,7 +36,7 @@ import com.google.inject.name.Named;
 public class FleetProvider implements Provider<Fleet> {
 	@Inject
 	@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-	Network network;
+	private Network network;
 
 	private final URL url;
 


### PR DESCRIPTION
A tiny PR, mostly because the last build on jenkins failed at the deployment phase:
http://ci.matsim.org:8080/job/MATSim_contrib_M2/6195/