### PR TITLE
removed the automagically added 'dummy' activity from scoring

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/groups/PlanCalcScoreConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlanCalcScoreConfigGroup.java
@@ -86,6 +86,7 @@ public final class PlanCalcScoreConfigGroup extends ConfigGroup {
 		{
 			ActivityParams params = new ActivityParams("dummy");
 			params.setTypicalDuration(2. * 3600.);
+			params.setScoringThisActivityAtAll(false);
 			this.addActivityParams(params);
 			// (this is there so that an empty config prints out at least one
 			// activity type,


### PR DESCRIPTION
I understand that this `dummy ` act only exists for having an example in the output config. If there is no other purpose for that (hadn't checked) then this should go away. I also wonder what happens if someone uses `dummy ` acts in his scenario.

For teaching purposes, the config dumper could add this explicitly whenever there are no other params added. Maybe renaming it to something like `ActivityParamDemoAddYourOwnBlockToRemoveThisDemo`