### PR TITLE
add MinCostFlowRebalancingParams to DrtConfigGroup

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregator.java
@@ -32,88 +32,74 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.events.PersonDepartureEvent;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.config.Config;
 import org.matsim.core.utils.misc.Time;
 
 /**
- * @author  jbischoff
- *
- */
-/**
+ * @author jbischoff
  *
  */
 public class ZonalDemandAggregator implements PersonDepartureEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;
-	private final int binsize = 1800; 
-	private Map<Double,Map<String,MutableInt>> departures = new HashMap<>();
-	private Map<Double,Map<String,MutableInt>> previousIterationDepartures = new HashMap<>();
-	/**
-	 * 
-	 */
+	private final int timeBinSize;
+	private final Map<Double, Map<String, MutableInt>> departures = new HashMap<>();
+	private final Map<Double, Map<String, MutableInt>> previousIterationDepartures = new HashMap<>();
+
 	@Inject
-	public ZonalDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, Config config) {
-		this.zonalSystem= zonalSystem;
+	public ZonalDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, DvrpConfigGroup dvrpCfg,
+			DrtConfigGroup drtCfg) {
+		this.zonalSystem = zonalSystem;
+		mode = dvrpCfg.getMode();
+		timeBinSize = drtCfg.getMinCostFlowRebalancing().getInterval();
 		events.addHandler(this);
-		DvrpConfigGroup dvrpconfig = DvrpConfigGroup.get(config);
-		this.mode = dvrpconfig.getMode();
-		
 	}
-	
+
 	@Override
-	public void reset(int iteration){
+	public void reset(int iteration) {
 		previousIterationDepartures.clear();
 		previousIterationDepartures.putAll(departures);
 		departures.clear();
 		prepareZones();
-
 	}
 
-	/* (non-Javadoc)
-	 * @see org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler#handleEvent(org.matsim.api.core.v01.events.PersonDepartureEvent)
-	 */
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
-		if (event.getLegMode().equals(mode)){
+		if (event.getLegMode().equals(mode)) {
 			Double bin = getBinForTime(event.getTime());
-			
+
 			String zoneId = zonalSystem.getZoneForLinkId(event.getLinkId());
 			if (zoneId == null) {
-				Logger.getLogger(getClass()).error("No zone found for linkId "+ event.getLinkId().toString());
+				Logger.getLogger(getClass()).error("No zone found for linkId " + event.getLinkId().toString());
 				return;
 			}
-			if (departures.containsKey(bin)){
-			this.departures.get(bin).get(zoneId).increment();
-			}
-			else Logger.getLogger(getClass()).error("Time "+Time.writeTime(event.getTime())+" / bin "+bin+" is out of boundary"); 
-			}
+			if (departures.containsKey(bin)) {
+				this.departures.get(bin).get(zoneId).increment();
+			} else
+				Logger.getLogger(getClass())
+						.error("Time " + Time.writeTime(event.getTime()) + " / bin " + bin + " is out of boundary");
 		}
-	
-	
-	private void prepareZones(){
-		for (int i = 0;i<(3600/binsize)*36;i++){
-			
-			Map<String,MutableInt> zonesPerSlot = new HashMap<>();
-			for (String zone : zonalSystem.getZones().keySet()){
+	}
+
+	private void prepareZones() {
+		for (int i = 0; i < (3600 / timeBinSize) * 36; i++) {
+			Map<String, MutableInt> zonesPerSlot = new HashMap<>();
+			for (String zone : zonalSystem.getZones().keySet()) {
 				zonesPerSlot.put(zone, new MutableInt());
 			}
-			departures.put(Double.valueOf(i),zonesPerSlot);
-
+			departures.put(Double.valueOf(i), zonesPerSlot);
 		}
 	}
-	
-	private Double getBinForTime(double time){
-		
-		return Math.floor(time/binsize); 
+
+	private Double getBinForTime(double time) {
+		return Math.floor(time / timeBinSize);
 	}
-	
-	public Map<String,MutableInt> getExpectedDemandForTimeBin(double time){
+
+	public Map<String, MutableInt> getExpectedDemandForTimeBin(double time) {
 		Double bin = getBinForTime(time);
 		return previousIterationDepartures.getOrDefault(bin, Collections.emptyMap());
 	}
-	
 }
-

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
@@ -23,19 +23,19 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 
 /**
  * @author michalm
  */
 public class LinearRebalancingTargetCalculator implements RebalancingTargetCalculator {
-	private static final double TARGET_ALPHA = 0.5;
-	private static final double TARGET_BETA = 0.5;
-
 	private final ZonalDemandAggregator demandAggregator;
+	private final MinCostFlowRebalancingParams params;
 
 	@Inject
-	public LinearRebalancingTargetCalculator(ZonalDemandAggregator demandAggregator) {
+	public LinearRebalancingTargetCalculator(ZonalDemandAggregator demandAggregator, DrtConfigGroup drtCfg) {
 		this.demandAggregator = demandAggregator;
+		params = drtCfg.getMinCostFlowRebalancing();
 	}
 
 	// FIXME targets should be calculated more intelligently
@@ -46,6 +46,6 @@ public class LinearRebalancingTargetCalculator implements RebalancingTargetCalcu
 		if (expectedDemand == null || expectedDemand.intValue() == 0) {
 			return 0;// for larger zones we may assume that target is at least 1 (or in some cases) ??????
 		}
-		return (int)Math.round(TARGET_ALPHA * expectedDemand.intValue() + TARGET_BETA);
+		return (int)Math.round(params.getTargetAlpha() * expectedDemand.intValue() + params.getTargetBeta());
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingModule.java
@@ -18,25 +18,26 @@
 
 package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
+import javax.inject.Inject;
+
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 
 /**
  * @author michalm
  */
 public class MinCostFlowRebalancingModule extends AbstractModule {
-	private final double cellSize;
-
-	public MinCostFlowRebalancingModule(double cellSize) {
-		this.cellSize = cellSize;
-	}
+	@Inject
+	private DrtConfigGroup drtCfg;
 
 	@Override
 	public void install() {
-		bind(DrtZonalSystem.class).toProvider(new DrtZonalSystem.DrtZonalSystemProvider(cellSize));
+		MinCostFlowRebalancingParams params = drtCfg.getMinCostFlowRebalancing();
+		bind(DrtZonalSystem.class).toProvider(new DrtZonalSystem.DrtZonalSystemProvider(params.getCellSize()));
 		bind(RebalancingStrategy.class).to(MinCostFlowRebalancingStrategy.class).asEagerSingleton();
 		bind(RebalancingTargetCalculator.class).to(LinearRebalancingTargetCalculator.class).asEagerSingleton();
 		bind(MinCostRelocationCalculator.class).to(AggregatedMinCostRelocationCalculator.class).asEagerSingleton();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -1,0 +1,199 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
+
+import java.util.Map;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * @author michalm
+ */
+public class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
+	public static boolean isRebalancingEnabled(MinCostFlowRebalancingParams params) {
+		return params != null && params.getInterval() > 0;
+	}
+
+	public static final String SET_NAME = "minCostFlowRebalancing";
+
+	public static final String INTERVAL = "interval";
+	static final String INTERVAL_EXP = "Specifies how often empty vehicle rebalancing is executed."
+			+ " 0 s means no rebalancing. Default is 1800 s.";
+
+	public static final String MIN_SERVICE_TIME = "minServiceTime";
+	static final String MIN_SERVICE_TIME_EXP = //
+			"Minimum remaining service time of an idle/busy vehicle to be considered as rebalancable/soon-idle (respectively)."
+					+ " Default is 3600 s. In general, should be higher than interval (e.g. 2 x interval).";
+
+	public static final String MAX_TIME_BEFORE_IDLE = "maxTimeBeforeIdle";
+	static final String MAX_TIME_BEFORE_IDLE_EXP = //
+			"Maximum remaining time before busy vehicle becomes idle to be considered as soon-idle vehicle."
+					+ " Default is 900 s. In general should be lower than interval (e.g. 0.5 x interval)";
+
+	public static final String TARGET_ALPHA = "targetAlpha";
+	static final String TARGET_ALPHA_EXP = "alpha coefficient in linear target calculation."
+			+ " In general, should be lower then 1.0 to prevent over-reacting and high empty milleage.";
+
+	public static final String TARGET_BETA = "targetBeta";
+	static final String TARGET_BETA_EXP = "beta constant in linear target calculation."
+			+ " In general, should be lower then 1.0 to prevent over-reacting and high empty milleage.";
+
+	public static final String CELL_SIZE = "cellSize";
+	static final String CELL_SIZE_EXP = "size of square cells used for demand aggregation."
+			+ " Depends on demand, supply and network. Often used with values in the range of 500 - 2000 m";
+
+	@PositiveOrZero
+	private int interval = 1800;// [s], if 0 then no rebalancing
+
+	@Positive
+	public double minServiceTime = 2 * interval;// [s]
+
+	@PositiveOrZero
+	public double maxTimeBeforeIdle = 0.5 * interval;// [s], if 0 then soon-idle vehicle will not be considered
+
+	@PositiveOrZero
+	public double targetAlpha = Double.NaN;
+
+	@PositiveOrZero
+	public double targetBeta = Double.NaN;
+
+	@Positive
+	public double cellSize = Double.NaN;// [m]
+
+	public MinCostFlowRebalancingParams() {
+		super(SET_NAME);
+	}
+
+	@Override
+	public Map<String, String> getComments() {
+		Map<String, String> map = super.getComments();
+		map.put(INTERVAL, INTERVAL_EXP);
+		map.put(MIN_SERVICE_TIME, MIN_SERVICE_TIME_EXP);
+		map.put(MAX_TIME_BEFORE_IDLE, MAX_TIME_BEFORE_IDLE_EXP);
+		map.put(TARGET_ALPHA, TARGET_ALPHA_EXP);
+		map.put(TARGET_BETA, TARGET_BETA_EXP);
+		map.put(CELL_SIZE, CELL_SIZE_EXP);
+		return map;
+	}
+
+	/**
+	 * @return -- {@value #INTERVAL_EXP}
+	 */
+	@StringGetter(INTERVAL)
+	public int getInterval() {
+		return interval;
+	}
+
+	/**
+	 * @param interval
+	 *            -- {@value #INTERVAL_EXP}
+	 */
+	@StringSetter(INTERVAL)
+	public void setInterval(int interval) {
+		this.interval = interval;
+	}
+
+	/**
+	 * @return -- {@value #MIN_SERVICE_TIME_EXP}
+	 */
+	@StringGetter(MIN_SERVICE_TIME)
+	public double getMinServiceTime() {
+		return minServiceTime;
+	}
+
+	/**
+	 * @param minServiceTime
+	 *            -- {@value #MIN_SERVICE_TIME_EXP}
+	 */
+	@StringSetter(MIN_SERVICE_TIME)
+	public void setMinServiceTime(double minServiceTime) {
+		this.minServiceTime = minServiceTime;
+	}
+
+	/**
+	 * @return -- {@value #MAX_TIME_BEFORE_IDLE_EXP}
+	 */
+	@StringGetter(MAX_TIME_BEFORE_IDLE)
+	public double getMaxTimeBeforeIdle() {
+		return maxTimeBeforeIdle;
+	}
+
+	/**
+	 * @param maxTimeBeforeIdle--
+	 *            {@value #MAX_TIME_BEFORE_IDLE_EXP}
+	 */
+	@StringSetter(MAX_TIME_BEFORE_IDLE)
+	public void setMaxTimeBeforeIdle(double maxTimeBeforeIdle) {
+		this.maxTimeBeforeIdle = maxTimeBeforeIdle;
+	}
+
+	/**
+	 * @return -- {@value #TARGET_ALPHA_EXP}
+	 */
+	@StringGetter(TARGET_ALPHA)
+	public double getTargetAlpha() {
+		return targetAlpha;
+	}
+
+	/**
+	 * @param targetAlpha
+	 *            -- {@value #TARGET_ALPHA_EXP}
+	 */
+	@StringSetter(TARGET_ALPHA)
+	public void setTargetAlpha(double targetAlpha) {
+		this.targetAlpha = targetAlpha;
+	}
+
+	/**
+	 * @return -- {@value #TARGET_BETA_EXP}
+	 */
+	@StringGetter(TARGET_BETA)
+	public double getTargetBeta() {
+		return targetBeta;
+	}
+
+	/**
+	 * @param targetBeta
+	 *            -- {@value #TARGET_BETA_EXP}
+	 */
+	@StringSetter(TARGET_BETA)
+	public void setTargetBeta(double targetBeta) {
+		this.targetBeta = targetBeta;
+	}
+
+	/**
+	 * @return -- {@value #CELL_SIZE_EXP}
+	 */
+	@StringGetter(CELL_SIZE)
+	public double getCellSize() {
+		return cellSize;
+	}
+
+	/**
+	 * @param cellSize
+	 *            -- {@value #CELL_SIZE_EXP}
+	 */
+	@StringSetter(CELL_SIZE)
+	public void setCellSize(double cellSize) {
+		this.cellSize = cellSize;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParamsConsistencyChecker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParamsConsistencyChecker.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ * copyright       : (C) 2016 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -17,28 +17,22 @@
  *                                                                         *
  * *********************************************************************** */
 
-/**
- * 
- */
-package org.matsim.contrib.drt.analysis.zonal;
+package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
-import org.matsim.core.controler.AbstractModule;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 
-/**
- * @author  jbischoff
- * A module to analyse DRT trips based on a zonal grid system.
- */
-
-public class DrtZonalModule extends AbstractModule {
-
-	/* (non-Javadoc)
-	 * @see org.matsim.core.controler.AbstractModule#install()
-	 */
+public class MinCostFlowRebalancingParamsConsistencyChecker implements ConfigConsistencyChecker {
 	@Override
-	public void install() {
-		bind(ZonalDemandAggregator.class).asEagerSingleton();
-		//the MinCostFlowRebalancing does not need this collector
-		//bind(ZonalIdleVehicleCollector.class).asEagerSingleton();
+	public void checkConsistency(Config config) {
+		MinCostFlowRebalancingParams params = DrtConfigGroup.get(config).getMinCostFlowRebalancing();
+		if (params == null) {
+			return;// no rebalancing
+		}
+		if (params.getMinServiceTime() <= params.getMaxTimeBeforeIdle()) {
+			throw new RuntimeException(MinCostFlowRebalancingParams.MIN_SERVICE_TIME + " must be greater than "
+					+ MinCostFlowRebalancingParams.MAX_TIME_BEFORE_IDLE);
+		}
 	}
-
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
@@ -20,6 +20,8 @@
 package org.matsim.contrib.drt.run;
 
 import org.apache.log4j.Logger;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParamsConsistencyChecker;
 import org.matsim.contrib.drt.run.DrtConfigGroup.OperationalScheme;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.core.config.Config;
@@ -57,5 +59,10 @@ public class DrtConfigConsistencyChecker implements ConfigConsistencyChecker {
 		if (config.qsim().getNumberOfThreads() != 1) {
 			throw new RuntimeException("Only a single-threaded QSim allowed");
 		}
+
+		if (drtCfg.getParameterSets(MinCostFlowRebalancingParams.SET_NAME).size() > 1) {
+			throw new RuntimeException("More then one rebalancing parameter sets is specified");
+		}
+		new MinCostFlowRebalancingParamsConsistencyChecker().checkConsistency(config);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -20,20 +20,23 @@
 package org.matsim.contrib.drt.run;
 
 import java.net.URL;
+import java.util.Collection;
 import java.util.Map;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 public class DrtConfigGroup extends ReflectiveConfigGroup {
-	
+
 	public static final String GROUP_NAME = "drt";
 
 	@SuppressWarnings("deprecation")
@@ -43,28 +46,24 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String STOP_DURATION = "stopDuration";
 	static final String STOP_DURATION_EXP = "Bus stop duration.";
-	
+
 	public static final String MAX_WAIT_TIME = "maxWaitTime";
 	static final String MAX_WAIT_TIME_EXP = "Max wait time for the bus to come (optimisation constraint).";
-	
+
 	public static final String MAX_TRAVEL_TIME_ALPHA = "maxTravelTimeAlpha";
 	static final String MAX_TRAV_ALPHA_EXP = "Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. "
 			+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
 			+ "Alpha should not be smaller than 1.";
-	
+
 	public static final String MAX_TRAVEL_TIME_BETA = "maxTravelTimeBeta";
 	static final String MAX_TRAVEL_TIME_BETA_EXP = "Defines the shift of the maxTravelTime estimation function (optimisation constraint), i.e. "
 			+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
 			+ "Beta should not be smaller than 0.";
-	
+
 	public static final String CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE = "changeStartLinkToLastLinkInSchedule";
 	static final String CHANGE_START_EXP = "If true, the startLink is changed to last link in the current schedule, so the taxi starts the next "
-				+ "day at the link where it stopped operating the day before. False by default.";
+			+ "day at the link where it stopped operating the day before. False by default.";
 
-	public static final String REBALANCING_INTERVAL = "rebalancingInterval";
-	static final String REB_INT_EXP = "Specifies how often empty vehicle rebalancing is executed. 0 means no rebalancing (the default).";
-
-	
 	public static final String IDLE_VEHICLES_RETURN_TO_DEPOTS = "idleVehiclesReturnToDepots";
 	static final String IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP = "Idle vehicles return to the nearest of all start links. See: Vehicle.getStartLink()";
 
@@ -90,20 +89,19 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String PLOT_CUST_STATS = "writeDetailedCustomerStats";
 	static final String CUST_STATS_EXP = "Writes out detailed DRT customer stats in each iteration. True by default.";
-	
+
 	public static final String PLOT_VEH_STATS = "writeDetailedVehicleStats";
 	static final String VEH_STATS_EXP = "Writes out detailed vehicle stats in each iteration. Creates one file per vehicle and iteration. "
 			+ "False by default.";
-	
+
 	public static final String PRINT_WARNINGS = "plotDetailedWarnings";
 	static final String PRINT_WARNINGS_EXP = "Prints detailed warnings for DRT customers that cannot be served or routed. Default is false.";
-	
+
 	public static final String NUMBER_OF_THREADS = "numberOfThreads";
 	static final String NUMBER_OF_THREADS_EXP = "Number of threads used for parallel evaluation of request insertion into existing schedules."
 			+ " Scales well up to 4, due to path data provision, the most computationally intensive part,"
 			+ " using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)'";
 
-		
 	@PositiveOrZero
 	private double stopDuration = Double.NaN;// seconds
 
@@ -121,9 +119,6 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	private double maxTravelTimeBeta = Double.NaN;// [s]
 
 	private boolean changeStartLinkToLastLinkInSchedule = false;
-
-	@PositiveOrZero
-	private int rebalancingInterval = 0;// [s], if 0 then no rebalancing
 
 	private boolean idleVehiclesReturnToDepots = false;
 
@@ -166,173 +161,150 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 		Map<String, String> map = super.getComments();
 		map.put(STOP_DURATION, STOP_DURATION_EXP);
 		map.put(MAX_WAIT_TIME, MAX_WAIT_TIME_EXP);
-		map.put(MAX_TRAVEL_TIME_ALPHA,
-				MAX_TRAV_ALPHA_EXP);
-		map.put(MAX_TRAVEL_TIME_BETA,
-				MAX_TRAVEL_TIME_BETA_EXP);
-		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE,
-				CHANGE_START_EXP);
-		map.put(VEHICLES_FILE,
-				VEH_FILE_EXP);
+		map.put(MAX_TRAVEL_TIME_ALPHA, MAX_TRAV_ALPHA_EXP);
+		map.put(MAX_TRAVEL_TIME_BETA, MAX_TRAVEL_TIME_BETA_EXP);
+		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE, CHANGE_START_EXP);
+		map.put(VEHICLES_FILE, VEH_FILE_EXP);
 		map.put(PLOT_CUST_STATS, CUST_STATS_EXP);
-		map.put(PLOT_VEH_STATS,
-				VEH_STATS_EXP);
-		map.put(REBALANCING_INTERVAL,
-				REB_INT_EXP);
-		map.put(IDLE_VEHICLES_RETURN_TO_DEPOTS,
-				IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP);
+		map.put(PLOT_VEH_STATS, VEH_STATS_EXP);
+		map.put(IDLE_VEHICLES_RETURN_TO_DEPOTS, IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP);
 		map.put(OPERATIONAL_SCHEME, OP_SCHEME_EXP);
 		map.put(MAX_WALK_DISTANCE, MAX_WALK_EXP);
 		map.put(TRANSIT_STOP_FILE, TRANSIT_STOP_FILE_EXP);
 		map.put(ESTIMATED_DRT_SPEED, ESTIMATED_DRT_SPEED_EXP);
-		map.put(ESTIMATED_BEELINE_DISTANCE_FACTOR,
-				ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP);
-		map.put(NUMBER_OF_THREADS,
-				NUMBER_OF_THREADS_EXP);
-		map.put(PRINT_WARNINGS,
-				PRINT_WARNINGS_EXP);
+		map.put(ESTIMATED_BEELINE_DISTANCE_FACTOR, ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP);
+		map.put(NUMBER_OF_THREADS, NUMBER_OF_THREADS_EXP);
+		map.put(PRINT_WARNINGS, PRINT_WARNINGS_EXP);
 		return map;
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #STOP_DURATION_EXP}
 	 */
 	@StringGetter(STOP_DURATION)
 	public double getStopDuration() {
 		return stopDuration;
 	}
+
 	/**
-	 * 
-	 * @param -- {@value #STOP_DURATION_EXP}
+	 * @param --
+	 *            {@value #STOP_DURATION_EXP}
 	 */
 	@StringSetter(STOP_DURATION)
 	public void setStopDuration(double stopDuration) {
 		this.stopDuration = stopDuration;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #MAX_WAIT_TIME_EXP}
 	 */
 	@StringGetter(MAX_WAIT_TIME)
 	public double getMaxWaitTime() {
 		return maxWaitTime;
 	}
+
 	/**
-	 * 
-	 * @param -- {@value #MAX_WAIT_TIME_EXPP}
+	 * @param --
+	 *            {@value #MAX_WAIT_TIME_EXPP}
 	 */
 	@StringSetter(MAX_WAIT_TIME)
 	public void setMaxWaitTime(double maxWaitTime) {
 		this.maxWaitTime = maxWaitTime;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #MAX_TRAV_ALPHA_EXP}
 	 */
 	@StringGetter(MAX_TRAVEL_TIME_ALPHA)
 	public double getMaxTravelTimeAlpha() {
 		return maxTravelTimeAlpha;
 	}
+
 	/**
-	 * 
-	 * @param maxTravelTimeAlpha {@value #MAX_TRAV_ALPHA_EXP}
+	 * @param maxTravelTimeAlpha
+	 *            {@value #MAX_TRAV_ALPHA_EXP}
 	 */
 	@StringSetter(MAX_TRAVEL_TIME_ALPHA)
 	public void setMaxTravelTimeAlpha(double maxTravelTimeAlpha) {
 		this.maxTravelTimeAlpha = maxTravelTimeAlpha;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #MAX_TRAV_BETA_EXP}
 	 */
 	@StringGetter(MAX_TRAVEL_TIME_BETA)
 	public double getMaxTravelTimeBeta() {
 		return maxTravelTimeBeta;
 	}
+
 	/**
-	 * 
-	 * @param maxTravelTimeAlpha -- {@value #MAX_TRAV_BETA_EXP}
+	 * @param maxTravelTimeAlpha
+	 *            -- {@value #MAX_TRAV_BETA_EXP}
 	 */
 	@StringSetter(MAX_TRAVEL_TIME_BETA)
 	public void setMaxTravelTimeBeta(double maxTravelTimeBeta) {
 		this.maxTravelTimeBeta = maxTravelTimeBeta;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #CHANGE_START_EXP}
 	 */
 	@StringGetter(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE)
 	public boolean isChangeStartLinkToLastLinkInSchedule() {
 		return changeStartLinkToLastLinkInSchedule;
 	}
+
 	/**
-	 * 
-	 * @param changeStartLinkToLastLinkInSchedule -- {@value #CHANGE_START_EXP}
+	 * @param changeStartLinkToLastLinkInSchedule
+	 *            -- {@value #CHANGE_START_EXP}
 	 */
 	@StringSetter(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE)
 	public void setChangeStartLinkToLastLinkInSchedule(boolean changeStartLinkToLastLinkInSchedule) {
 		this.changeStartLinkToLastLinkInSchedule = changeStartLinkToLastLinkInSchedule;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #VEH_FILE_EXP}
 	 */
 	@StringGetter(VEHICLES_FILE)
 	public String getVehiclesFile() {
 		return vehiclesFile;
 	}
+
 	/**
-	 * 
-	 * @param vehiclesFile -- {@value #VEH_FILE_EXP}
+	 * @param vehiclesFile
+	 *            -- {@value #VEH_FILE_EXP}
 	 */
 	@StringSetter(VEHICLES_FILE)
 	public void setVehiclesFile(String vehiclesFile) {
 		this.vehiclesFile = vehiclesFile;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #VEH_FILE_EXP}
 	 */
 	public URL getVehiclesFileUrl(URL context) {
 		return ConfigGroup.getInputFileURL(context, this.vehiclesFile);
 	}
-	/**
-	 * 
-	 * @return -- {@value #REBALANCING_INTERVAL_EXP}
-	 */
-	@StringGetter(REBALANCING_INTERVAL)
-	public int getRebalancingInterval() {
-		return rebalancingInterval;
-	}
 
 	/**
-	 * 
-	 * @return -- {@value #REB_INT_EXP}
-	 */
-	@StringSetter(REBALANCING_INTERVAL)
-	public void setRebalancingInterval(int rebalancingInterval) {
-		this.rebalancingInterval = rebalancingInterval;
-	}
-
-	/**
-	 * 
 	 * @return -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP}}
 	 */
 	@StringGetter(IDLE_VEHICLES_RETURN_TO_DEPOTS)
 	public boolean getIdleVehiclesReturnToDepots() {
 		return idleVehiclesReturnToDepots;
 	}
+
 	/**
-	 * 
-	 * @param idleVehiclesReturnToDepots -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP} 
+	 * @param idleVehiclesReturnToDepots
+	 *            -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP}
 	 */
 	@StringSetter(IDLE_VEHICLES_RETURN_TO_DEPOTS)
 	public void setIdleVehiclesReturnToDepots(boolean idleVehiclesReturnToDepots) {
 		this.idleVehiclesReturnToDepots = idleVehiclesReturnToDepots;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #OP_SCHEME_EXP}
 	 */
 	@StringGetter(OPERATIONAL_SCHEME)
@@ -341,8 +313,8 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
-	 * @param operationalScheme -- {@value #OP_SCHEME_EXP}
+	 * @param operationalScheme
+	 *            -- {@value #OP_SCHEME_EXP}
 	 */
 	@StringSetter(OPERATIONAL_SCHEME)
 	public void setOperationalScheme(String operationalScheme) {
@@ -351,22 +323,21 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #TRANSIT_STOP_FILE_EXP}
 	 */
 	@StringGetter(TRANSIT_STOP_FILE)
 	public String getTransitStopFile() {
 		return transitStopFile;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #TRANSIT_STOP_FILE_EXP}
-	 */	
+	 */
 	public URL getTransitStopsFileUrl(URL context) {
 		return ConfigGroup.getInputFileURL(context, this.transitStopFile);
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #TRANSIT_STOP_FILE_EXP}
 	 */
 	@StringSetter(TRANSIT_STOP_FILE)
@@ -375,15 +346,14 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #MAX_WALK_EXP}
 	 */
 	@StringGetter(MAX_WALK_DISTANCE)
 	public double getMaxWalkDistance() {
 		return maxWalkDistance;
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #MAX_WALK_EXP}
 	 */
 	@StringSetter(MAX_WALK_DISTANCE)
@@ -399,24 +369,24 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	public double getEstimatedDrtSpeed() {
 		return estimatedDrtSpeed;
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #ESTIMATED_DRT_SPEED_EXP}
 	 */
 	@StringSetter(ESTIMATED_DRT_SPEED)
 	public void setEstimatedSpeed(double estimatedSpeed) {
 		this.estimatedDrtSpeed = estimatedSpeed;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP}
 	 */
 	@StringGetter(ESTIMATED_BEELINE_DISTANCE_FACTOR)
 	public double getEstimatedBeelineDistanceFactor() {
 		return estimatedBeelineDistanceFactor;
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP}
 	 */
 	@StringSetter(ESTIMATED_BEELINE_DISTANCE_FACTOR)
@@ -425,7 +395,6 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #CUST_STATS_EXP}
 	 */
 	@StringGetter(PLOT_CUST_STATS)
@@ -434,59 +403,79 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
-	 * @param -- {@value #CUST_STATS_EXP}
+	 * @param --
+	 *            {@value #CUST_STATS_EXP}
 	 */
 	@StringSetter(PLOT_CUST_STATS)
 	public void setPlotDetailedCustomerStats(boolean plotDetailedCustomerStats) {
 		this.plotDetailedCustomerStats = plotDetailedCustomerStats;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #VEH_STATS_EXP}
 	 */
 	@StringGetter(PLOT_VEH_STATS)
 	public boolean isPlotDetailedVehicleStats() {
 		return plotDetailedVehicleStats;
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #VEH_STATS_EXP}
 	 */
 	@StringSetter(PLOT_VEH_STATS)
 	public void setPlotDetailedVehicleStats(boolean plotDetailedVehicleStats) {
 		this.plotDetailedVehicleStats = plotDetailedVehicleStats;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #NUMBER_OF_THREADS_EXP}
 	 */
 	@StringGetter(NUMBER_OF_THREADS)
 	public int getNumberOfThreads() {
 		return numberOfThreads;
 	}
+
 	/**
-	 * 
 	 * @param-- {@value #NUMBER_OF_THREADS_EXP}
 	 */
 	@StringSetter(NUMBER_OF_THREADS)
 	public void setNumberOfThreads(final int numberOfThreads) {
 		this.numberOfThreads = numberOfThreads;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #PRINT_WARNINGS_EXP}
 	 */
 	@StringGetter(PRINT_WARNINGS)
 	public boolean isPrintDetailedWarnings() {
 		return printDetailedWarnings;
 	}
+
 	/**
-	 * 
-	 * @param -- {@value #PRINT_WARNINGS_EXP}
+	 * @param --
+	 *            {@value #PRINT_WARNINGS_EXP}
 	 */
 	@StringSetter(PRINT_WARNINGS)
 	public void setPrintDetailedWarnings(boolean printDetailedWarnings) {
 		this.printDetailedWarnings = printDetailedWarnings;
+	}
+
+	/**
+	 * 
+	 * @return 'minCostFlowRebalancing' parameter set defined in the DRT config or null if the parameters were not
+	 *         specified
+	 */
+	@Valid
+	public MinCostFlowRebalancingParams getMinCostFlowRebalancing() {
+		Collection<? extends ConfigGroup> parameterSets = getParameterSets(MinCostFlowRebalancingParams.SET_NAME);
+		return parameterSets.isEmpty() ? null : (MinCostFlowRebalancingParams)parameterSets.iterator().next();
+	}
+
+	@Override
+	public ConfigGroup createParameterSet(String type) {
+		if (type.startsWith(MinCostFlowRebalancingParams.SET_NAME)) {
+			return new MinCostFlowRebalancingParams();
+		}
+		return super.createParameterSet(type);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModule.java
@@ -7,7 +7,10 @@ import org.matsim.contrib.drt.data.validator.DrtRequestValidator;
 import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
+import org.matsim.contrib.drt.optimizer.rebalancing.NoRebalancingStrategy;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingModule;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.drt.routing.DefaultAccessEgressStopFinder;
 import org.matsim.contrib.drt.routing.DrtMainModeIdentifier;
 import org.matsim.contrib.drt.routing.DrtRoutingModule;
@@ -38,7 +41,11 @@ public final class DrtModule extends AbstractModule {
 		bind(TravelDisutilityFactory.class).annotatedWith(Names.named(DefaultDrtOptimizer.DRT_OPTIMIZER))
 				.toInstance(timeCalculator -> new TimeAsTravelDisutility(timeCalculator));
 
-		install(new MinCostFlowRebalancingModule(1000));
+		if (MinCostFlowRebalancingParams.isRebalancingEnabled(drtCfg.getMinCostFlowRebalancing())) {
+			install(new MinCostFlowRebalancingModule());
+		} else {
+			bind(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
+		}
 
 		switch (drtCfg.getOperationalScheme()) {
 			case door2door:

--- a/contribs/drt/src/main/resources/drt_example/drtconfig_door2door.xml
+++ b/contribs/drt/src/main/resources/drt_example/drtconfig_door2door.xml
@@ -16,10 +16,6 @@
 		<param name="maxTravelTimeBeta" value="1200.0" />
 		<!-- Max wait time for the bus to come (optimisation constraint). -->
 		<param name="maxWaitTime" value="1200.0" />
-	
-		<!-- Number of threads used for parallel evaluation of request insertion into existing schedules. Scales well up to 4, using more does not improve performance. Default == 4 (or no. of available threads to JVM if less than 4. -->
-		
-		<!--param name="numberOfThreads" value="4" / -->
 
 		<!-- Operational Scheme, either door2door or stopbased. door2door by default -->
 		<param name="operationalScheme" value="door2door" />
@@ -35,8 +31,13 @@
 
 		<!-- Writes out detailed vehicle stats in each iteration. Creates one file per vehicle and iteration. False by default. -->
 		<param name="writeDetailedVehicleStats" value="false" />
+
+		<parameterset type="minCostFlowRebalancing">
+			<param name="targetAlpha" value="0.5"/>
+			<param name="targetBeta" value="0.5"/>
+			<param name="cellSize" value="2000"/>
+		</parameterset>
 	</module>
-	
 	
 	<module name="dvrp" >
 
@@ -49,8 +50,6 @@
 		<!-- Used for estimation of travel times for VrpOptimizer by means of the exponential moving average. The weighting decrease, alpha, must be in (0,1]. We suggest small values of alpha, e.g. 0.05. The averaging starts from the initial travel time estimates. If not provided, the free-speed TTs is used as the initial estimates For more info see comments in: VrpTravelTimeEstimator, VrpTravelTimeModules, DvrpModule. -->
 		<param name="travelTimeEstimationAlpha" value="0.05" />
 	</module>
-
-
 
 	<module name="network">
 		<param name="inputNetworkFile" value="network.xml.gz" />
@@ -90,7 +89,6 @@
 			<param name="openingTime" value="06:00:00" />
 			<param name="latestStartTime" value="09:00:00" />
 			<param name="closingTime" value="17:00:00" />
-
 		</parameterset>
 
 		<parameterset type="activityParams">

--- a/contribs/drt/src/main/resources/drt_example/drtconfig_stopbased.xml
+++ b/contribs/drt/src/main/resources/drt_example/drtconfig_stopbased.xml
@@ -18,10 +18,6 @@
 		<param name="maxWaitTime" value="1200.0" />
 		<!-- Maximum walk distance to next stop location in stationbased system. -->
 		<param name="maxWalkDistance" value="1500.0" />
- 
-		<!-- Number of threads used for parallel evaluation of request insertion into existing schedules. Scales well up to 4, using more does not improve performance. Default == 4 (or no. of available threads to JVM if less than 4). -->
-		
-		<!-- param name="numberOfThreads" value="4" / -->
 
 		<!-- Operational Scheme, either door2door or stopbased. door2door by default -->
 		<param name="operationalScheme" value="stopbased" />
@@ -40,8 +36,13 @@
 
 		<!-- Writes out detailed vehicle stats in each iteration. Creates one file per vehicle and iteration. False by default. -->
 		<param name="writeDetailedVehicleStats" value="false" />
+
+		<parameterset type="minCostFlowRebalancing">
+			<param name="targetAlpha" value="0.5"/>
+			<param name="targetBeta" value="0.5"/>
+			<param name="cellSize" value="2000"/>
+		</parameterset>
 	</module>
-	
 	
 	<module name="dvrp" >
 
@@ -54,8 +55,6 @@
 		<!-- Used for estimation of travel times for VrpOptimizer by means of the exponential moving average. The weighting decrease, alpha, must be in (0,1]. We suggest small values of alpha, e.g. 0.05. The averaging starts from the initial travel time estimates. If not provided, the free-speed TTs is used as the initial estimates For more info see comments in: VrpTravelTimeEstimator, VrpTravelTimeModules, DvrpModule. -->
 		<param name="travelTimeEstimationAlpha" value="0.05" />
 	</module>
-
-
 
 	<module name="network">
 		<param name="inputNetworkFile" value="network.xml.gz" />
@@ -82,7 +81,7 @@
 	</module>
 
 	<module name="controler">
-		<param name="outputDirectory" value="output/drt_stationbased" />
+		<param name="outputDirectory" value="output/drt_stopbased" />
 		<param name="overwriteFiles" value="deleteDirectoryIfExists" />
 		<param name="firstIteration" value="0" />
 		<param name="lastIteration" value="0" />
@@ -95,7 +94,6 @@
 			<param name="openingTime" value="06:00:00" />
 			<param name="latestStartTime" value="09:00:00" />
 			<param name="closingTime" value="17:00:00" />
-
 		</parameterset>
 
 		<parameterset type="activityParams">

--- a/contribs/drt/src/main/resources/mielec_2014_02/mielec_drt_config.xml
+++ b/contribs/drt/src/main/resources/mielec_2014_02/mielec_drt_config.xml
@@ -13,6 +13,12 @@
 
 		<param name="vehiclesFile" value="vehicles-10-cap-4.xml" />
 		<!-- param name="vehiclesFile" value="vehicles-20-cap-2.xml" / -->
+
+		<parameterset type="minCostFlowRebalancing">
+			<param name="targetAlpha" value="0.5"/>
+			<param name="targetBeta" value="0.5"/>
+			<param name="cellSize" value="500"/>
+		</parameterset>
 	</module>
 
 	<module name="network">

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/example/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/example/RunDrtExampleIT.java
@@ -49,7 +49,6 @@ public class RunDrtExampleIT {
 		
 		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
-		config.controler().setDumpDataAtEnd(false);
 		RunDrtExample.run(config, false);
 	}
 	
@@ -62,7 +61,6 @@ public class RunDrtExampleIT {
 		
 		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
-		config.controler().setDumpDataAtEnd(false);
 		RunDrtExample.run(config, false);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/example/RunOneSharedTaxiExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/example/RunOneSharedTaxiExampleIT.java
@@ -27,6 +27,6 @@ import org.matsim.contrib.drt.run.examples.RunOneSharedTaxiExample;
 public class RunOneSharedTaxiExampleIT {
 	@Test
 	public void testRun() {
-		RunOneSharedTaxiExample.run(false, 1);// fleet rebalancing only in it. 1
+		RunOneSharedTaxiExample.run(false, 0);
 	}
 }


### PR DESCRIPTION
Add `MinCostFlowRebalancingParams` to `DrtConfigGroup`, where all parameters used by the min-cost-flow rebalancing are specified. If the parameter set is not specified - no rebalancing is performed.

There is no need to add `MinCostFlowRebalancingModule` to the controller manually - now it all happens automatically based on the config.

