### PR TITLE
Further DRT speed improvements

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.drt.optimizer.insertion;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
 
 import org.apache.log4j.Logger;
 import org.matsim.contrib.drt.data.DrtRequest;
@@ -52,6 +53,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	private final RequestInsertionScheduler insertionScheduler;
 	private final VehicleData.EntryFactory vehicleDataEntryFactory;
 
+	private final ForkJoinPool forkJoinPool;
 	private final ParallelMultiVehicleInsertionProblem insertionProblem;
 
 	@Inject
@@ -65,7 +67,9 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 		this.insertionScheduler = insertionScheduler;
 		this.vehicleDataEntryFactory = vehicleDataEntryFactory;
 
-		insertionProblem = new ParallelMultiVehicleInsertionProblem(pathDataProvider, drtCfg, mobsimTimer);
+		forkJoinPool = new ForkJoinPool(drtCfg.getNumberOfThreads());
+		insertionProblem = new ParallelMultiVehicleInsertionProblem(pathDataProvider, drtCfg, mobsimTimer,
+				forkJoinPool);
 		insertionScheduler.initSchedules(drtCfg.isChangeStartLinkToLastLinkInSchedule());
 	}
 
@@ -81,7 +85,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 		}
 
 		VehicleData vData = new VehicleData(mobsimTimer.getTimeOfDay(), fleet.getVehicles().values().stream(),
-				vehicleDataEntryFactory);
+				vehicleDataEntryFactory, forkJoinPool);
 
 		Iterator<DrtRequest> reqIter = unplannedRequests.iterator();
 		while (reqIter.hasNext()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourLinksProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourLinksProvider.java
@@ -55,14 +55,20 @@ class DetourLinksProvider {
 	private final InsertionGenerator insertionGenerator = new InsertionGenerator();
 	private final SingleVehicleInsertionFilter insertionFilter;
 
-	private final Map<Id<Vehicle>, List<Insertion>> filteredInsertionsPerVehicle = new ConcurrentHashMap<>(1000);
+	private final Map<Id<Vehicle>, List<Insertion>> filteredInsertionsPerVehicle;
 
-	private final Map<Id<Link>, Link> linksToPickup = new ConcurrentHashMap<>(500);
-	private final Map<Id<Link>, Link> linksFromPickup = new ConcurrentHashMap<>(100);
-	private final Map<Id<Link>, Link> linksToDropoff = new ConcurrentHashMap<>(100);
-	private final Map<Id<Link>, Link> linksFromDropoff = new ConcurrentHashMap<>(100);
+	private final Map<Id<Link>, Link> linksToPickup;
+	private final Map<Id<Link>, Link> linksFromPickup;
+	private final Map<Id<Link>, Link> linksToDropoff;
+	private final Map<Id<Link>, Link> linksFromDropoff;
 
-	public DetourLinksProvider(DrtConfigGroup drtCfg, MobsimTimer timer) {
+	public DetourLinksProvider(DrtConfigGroup drtCfg, MobsimTimer timer, int vEntriesCount) {
+		filteredInsertionsPerVehicle = new ConcurrentHashMap<>(vEntriesCount);
+		linksToPickup = new ConcurrentHashMap<>(vEntriesCount / 2);
+		linksFromPickup = new ConcurrentHashMap<>();
+		linksToDropoff = new ConcurrentHashMap<>();
+		linksFromDropoff = new ConcurrentHashMap<>();
+
 		// TODO use more sophisticated DetourTimeEstimator
 		double optimisticBeelineSpeed = 1.5 * drtCfg.getEstimatedDrtSpeed()
 				/ drtCfg.getEstimatedBeelineDistanceFactor();// 1.5 is used to prevent filtering out feasible insertions

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourLinksProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourLinksProvider.java
@@ -1,0 +1,125 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.data.DrtRequest;
+import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.data.Vehicle;
+import org.matsim.contrib.util.distance.DistanceUtils;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+
+/**
+ * @author michalm
+ */
+class DetourLinksProvider {
+	static class DetourLinksSet {
+		final Map<Id<Link>, Link> pickupDetourStartLinks;
+		final Map<Id<Link>, Link> pickupDetourEndLinks;
+		final Map<Id<Link>, Link> dropoffDetourStartLinks;
+		final Map<Id<Link>, Link> dropoffDetourEndLinks;
+
+		public DetourLinksSet(Map<Id<Link>, Link> linksToPickup, Map<Id<Link>, Link> linksFromPickup,
+				Map<Id<Link>, Link> linksToDropoff, Map<Id<Link>, Link> linksFromDropoff) {
+			this.pickupDetourStartLinks = linksToPickup;
+			this.pickupDetourEndLinks = linksFromPickup;
+			this.dropoffDetourStartLinks = linksToDropoff;
+			this.dropoffDetourEndLinks = linksFromDropoff;
+		}
+	}
+
+	private final InsertionGenerator insertionGenerator = new InsertionGenerator();
+	private final SingleVehicleInsertionFilter insertionFilter;
+
+	private final Map<Id<Vehicle>, List<Insertion>> filteredInsertionsPerVehicle = new HashMap<>();
+
+	private final Map<Id<Link>, Link> linksToPickup = new HashMap<>();
+	private final Map<Id<Link>, Link> linksFromPickup = new HashMap<>();
+	private final Map<Id<Link>, Link> linksToDropoff = new HashMap<>();
+	private final Map<Id<Link>, Link> linksFromDropoff = new HashMap<>();
+
+	public DetourLinksProvider(DrtConfigGroup drtCfg, MobsimTimer timer) {
+		// TODO use more sophisticated DetourTimeEstimator
+		double optimisticBeelineSpeed = 1.5 * drtCfg.getEstimatedDrtSpeed()
+				/ drtCfg.getEstimatedBeelineDistanceFactor();// 1.5 is used to prevent filtering out feasible insertions
+		insertionFilter = new SingleVehicleInsertionFilter(//
+				new DetourTimesProvider(
+						(from, to) -> DistanceUtils.calculateDistance(from, to) / optimisticBeelineSpeed,
+						drtCfg.getStopDuration()), //
+				new InsertionCostCalculator(drtCfg.getStopDuration(), timer));
+	}
+
+	void addDetourLinks(DrtRequest drtRequest, Entry vEntry) {
+		List<Insertion> insertions = insertionGenerator.generateInsertions(drtRequest, vEntry);
+
+		List<InsertionWithDetourTimes> insertionsWithDetourTimes = insertionFilter.findFeasibleInsertions(drtRequest,
+				vEntry, insertions);
+		List<Insertion> filteredInsertions = new ArrayList<>(insertionsWithDetourTimes.size());
+		filteredInsertionsPerVehicle.put(vEntry.vehicle.getId(), filteredInsertions);
+
+		for (InsertionWithDetourTimes insert : insertionsWithDetourTimes) {
+			int i = insert.getPickupIdx();
+			int j = insert.getDropoffIdx();
+			filteredInsertions.add(new Insertion(i, j));
+
+			// i -> pickup
+			Link toPickupLink = (i == 0) ? vEntry.start.link : vEntry.stops.get(i - 1).task.getLink();
+			linksToPickup.put(toPickupLink.getId(), toPickupLink);
+
+			// XXX optimise: if pickup/dropoff is inserted at existing stop,
+			// no need to calc a path from pickup/dropoff to the next stop (the path is already in Schedule)
+
+			if (i == j) {
+				// pickup -> dropoff
+				Link fromPickupLink = drtRequest.getToLink();
+				linksFromPickup.put(fromPickupLink.getId(), fromPickupLink);
+			} else {
+				// pickup -> i + 1
+				Link fromPickupLink = vEntry.stops.get(i).task.getLink();
+				linksFromPickup.put(fromPickupLink.getId(), fromPickupLink);
+
+				// j -> dropoff
+				Link toDropoffLink = vEntry.stops.get(j - 1).task.getLink();
+				linksToDropoff.put(toDropoffLink.getId(), toDropoffLink);
+			}
+
+			// dropoff -> j+1 // j+1 may not exist (dropoff appended after last stop)
+			if (j < vEntry.stops.size()) {
+				Link fromDropoffLink = vEntry.stops.get(j).task.getLink();
+				linksFromDropoff.put(fromDropoffLink.getId(), fromDropoffLink);
+			}
+		}
+	}
+
+	Map<Id<Vehicle>, List<Insertion>> getFilteredInsertionsPerVehicle() {
+		return filteredInsertionsPerVehicle;
+	}
+
+	DetourLinksSet getDetourLinksSet() {
+		return new DetourLinksSet(linksToPickup, linksFromPickup, linksToDropoff, linksFromDropoff);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -88,7 +88,7 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 
 	@Override
 	public Optional<BestInsertion> findBestInsertion(DrtRequest drtRequest, Collection<Entry> vEntries) {
-		DetourLinksProvider detourLinksProvider = new DetourLinksProvider(drtCfg, timer);
+		DetourLinksProvider detourLinksProvider = new DetourLinksProvider(drtCfg, timer, vEntries.size());
 		forkJoinPool.submit(() -> vEntries.parallelStream()//
 				.forEach(e -> detourLinksProvider.addDetourLinks(drtRequest, e)))//
 				.join();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -78,12 +78,12 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	private final DetourLinksStats detourLinksStats = new DetourLinksStats();
 
 	public ParallelMultiVehicleInsertionProblem(PrecalculablePathDataProvider pathDataProvider, DrtConfigGroup drtCfg,
-			MobsimTimer timer) {
+			MobsimTimer timer, ForkJoinPool forkJoinPool) {
 		this.pathDataProvider = pathDataProvider;
 		this.drtCfg = drtCfg;
 		this.timer = timer;
+		this.forkJoinPool = forkJoinPool;
 		insertionCostCalculator = new InsertionCostCalculator(drtCfg, timer);
-		forkJoinPool = new ForkJoinPool(drtCfg.getNumberOfThreads());
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -64,9 +64,9 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	@Override
 	public Optional<BestInsertion> findBestInsertion(DrtRequest drtRequest, Collection<Entry> vEntries) {
 		DetourLinksProvider detourLinksProvider = new DetourLinksProvider(drtCfg, timer);
-		for (Entry vEntry : vEntries) {
-			detourLinksProvider.addDetourLinks(drtRequest, vEntry);
-		}
+		forkJoinPool.submit(() -> vEntries.parallelStream()//
+				.forEach(e -> detourLinksProvider.addDetourLinks(drtRequest, e)))//
+				.join();
 
 		// DetourLinksSet set = detourLinksProvider.getDetourLinksSet();
 		// toPickupMean.addValue(set.pickupDetourStartLinks.size());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -55,12 +55,24 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 
 	}
 
+	// Stats on dijkstra searches:
+	// SummaryStatistics toPickupMean = new SummaryStatistics();
+	// SummaryStatistics fromPickupMean = new SummaryStatistics();
+	// SummaryStatistics toDropoffMean = new SummaryStatistics();
+	// SummaryStatistics fromDropoffMean = new SummaryStatistics();
+
 	@Override
 	public Optional<BestInsertion> findBestInsertion(DrtRequest drtRequest, Collection<Entry> vEntries) {
 		DetourLinksProvider detourLinksProvider = new DetourLinksProvider(drtCfg, timer);
 		for (Entry vEntry : vEntries) {
 			detourLinksProvider.addDetourLinks(drtRequest, vEntry);
 		}
+
+		// DetourLinksSet set = detourLinksProvider.getDetourLinksSet();
+		// toPickupMean.addValue(set.pickupDetourStartLinks.size());
+		// fromPickupMean.addValue(set.pickupDetourEndLinks.size());
+		// toDropoffMean.addValue(set.dropoffDetourStartLinks.size());
+		// fromDropoffMean.addValue(set.dropoffDetourEndLinks.size());
 
 		pathDataProvider.precalculatePathData(drtRequest, detourLinksProvider.getDetourLinksSet());
 
@@ -76,6 +88,15 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	}
 
 	public void shutdown() {
+		// System.out.println("================");
+		// System.out.println("toPickupMean=" + toPickupMean);
+		// System.out.println("================");
+		// System.out.println("fromPickupMean=" + fromPickupMean);
+		// System.out.println("================");
+		// System.out.println("toDropoffMean=" + toDropoffMean);
+		// System.out.println("================");
+		// System.out.println("fromDropoffMean=" + fromDropoffMean);
+		// System.out.println("================");
 		forkJoinPool.shutdown();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -19,24 +19,20 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.data.DrtRequest;
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.optimizer.insertion.SingleVehicleInsertionProblem.BestInsertion;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.data.Vehicle;
-import org.matsim.contrib.util.distance.DistanceUtils;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -44,81 +40,32 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
  */
 public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInsertionProblem {
 	private final PrecalculablePathDataProvider pathDataProvider;
+	private final DrtConfigGroup drtCfg;
+	private final MobsimTimer timer;
 	private final InsertionCostCalculator insertionCostCalculator;
 	private final ForkJoinPool forkJoinPool;
-	private final InsertionGenerator insertionGenerator = new InsertionGenerator();
-	private final SingleVehicleInsertionFilter insertionFilter;
 
 	public ParallelMultiVehicleInsertionProblem(PrecalculablePathDataProvider pathDataProvider, DrtConfigGroup drtCfg,
 			MobsimTimer timer) {
 		this.pathDataProvider = pathDataProvider;
+		this.drtCfg = drtCfg;
+		this.timer = timer;
 		insertionCostCalculator = new InsertionCostCalculator(drtCfg, timer);
 		forkJoinPool = new ForkJoinPool(drtCfg.getNumberOfThreads());
 
-		// TODO use more sophisticated DetourTimeEstimator
-		double optimisticBeelineSpeed = 1.5 * drtCfg.getEstimatedDrtSpeed()
-				/ drtCfg.getEstimatedBeelineDistanceFactor();// 1.5 is used to prevent filtering out feasible insertions
-		insertionFilter = new SingleVehicleInsertionFilter(//
-				new DetourTimesProvider(
-						(from, to) -> DistanceUtils.calculateDistance(from, to) / optimisticBeelineSpeed,
-						drtCfg.getStopDuration()), //
-				new InsertionCostCalculator(drtCfg.getStopDuration(), timer));
 	}
 
 	@Override
 	public Optional<BestInsertion> findBestInsertion(DrtRequest drtRequest, Collection<Entry> vEntries) {
-		Map<Id<Vehicle>, List<Insertion>> filteredInsertionsPerVehicle = new HashMap<>();
-
-		Map<Id<Link>, Link> linksToPickupMap = new HashMap<>();
-		Map<Id<Link>, Link> linksFromPickupMap = new HashMap<>();
-		Map<Id<Link>, Link> linksToDropoffMap = new HashMap<>();
-		Map<Id<Link>, Link> linksFromDropoffMap = new HashMap<>();
-
+		DetourLinksProvider detourLinksProvider = new DetourLinksProvider(drtCfg, timer);
 		for (Entry vEntry : vEntries) {
-			List<Insertion> insertions = insertionGenerator.generateInsertions(drtRequest, vEntry);
-
-			List<InsertionWithDetourTimes> insertionsWithDetourTimes = insertionFilter
-					.findFeasibleInsertions(drtRequest, vEntry, insertions);
-			List<Insertion> filteredInsertions = new ArrayList<>(insertionsWithDetourTimes.size());
-			filteredInsertionsPerVehicle.put(vEntry.vehicle.getId(), filteredInsertions);
-
-			for (InsertionWithDetourTimes insert : insertionsWithDetourTimes) {
-				int i = insert.getPickupIdx();
-				int j = insert.getDropoffIdx();
-				filteredInsertions.add(new Insertion(i, j));
-
-				// i -> pickup
-				Link toPickupLink = (i == 0) ? vEntry.start.link : vEntry.stops.get(i - 1).task.getLink();
-				linksToPickupMap.put(toPickupLink.getId(), toPickupLink);
-
-				// XXX optimise: if pickup/dropoff is inserted at existing stop,
-				// no need to calc a path from pickup/dropoff to the next stop (the path is already in Schedule)
-
-				if (i == j) {
-					// pickup -> dropoff
-					Link fromPickupLink = drtRequest.getToLink();
-					linksFromPickupMap.put(fromPickupLink.getId(), fromPickupLink);
-				} else {
-					// pickup -> i + 1
-					Link fromPickupLink = vEntry.stops.get(i).task.getLink();
-					linksFromPickupMap.put(fromPickupLink.getId(), fromPickupLink);
-
-					// j -> dropoff
-					Link toDropoffLink = vEntry.stops.get(j - 1).task.getLink();
-					linksToDropoffMap.put(toDropoffLink.getId(), toDropoffLink);
-				}
-
-				// dropoff -> j+1 // j+1 may not exist (dropoff appended after last stop)
-				if (j < vEntry.stops.size()) {
-					Link fromDropoffLink = vEntry.stops.get(j).task.getLink();
-					linksFromDropoffMap.put(fromDropoffLink.getId(), fromDropoffLink);
-				}
-			}
+			detourLinksProvider.addDetourLinks(drtRequest, vEntry);
 		}
 
-		pathDataProvider.precalculatePathData(drtRequest, linksToPickupMap, linksFromPickupMap, linksToDropoffMap,
-				linksFromDropoffMap);
+		pathDataProvider.precalculatePathData(drtRequest, detourLinksProvider.getDetourLinksSet());
 
+		Map<Id<Vehicle>, List<Insertion>> filteredInsertionsPerVehicle = detourLinksProvider
+				.getFilteredInsertionsPerVehicle();
 		return forkJoinPool.submit(() -> vEntries.parallelStream()//
 				.map(v -> new SingleVehicleInsertionProblem(pathDataProvider, insertionCostCalculator)
 						.findBestInsertion(drtRequest, v, filteredInsertionsPerVehicle.get(v.vehicle.getId())))//

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/PrecalculablePathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/PrecalculablePathDataProvider.java
@@ -25,15 +25,14 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.data.DrtRequest;
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
 import org.matsim.contrib.drt.optimizer.VehicleData.Stop;
+import org.matsim.contrib.drt.optimizer.insertion.DetourLinksProvider.DetourLinksSet;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
  * @author michalm
  */
 public interface PrecalculablePathDataProvider extends PathDataProvider {
-	void precalculatePathData(DrtRequest drtRequest, Map<Id<Link>, Link> linksToPickupMap,
-			Map<Id<Link>, Link> linksFromPickupMap, Map<Id<Link>, Link> linksToDropoffMap,
-			Map<Id<Link>, Link> linksFromDropoffMap);
+	void precalculatePathData(DrtRequest drtRequest, DetourLinksSet detourLinkSet);
 
 	static PathDataSet getPathDataSet(DrtRequest drtRequest, Entry vEntry, Map<Id<Link>, PathData> pathsToPickupMap,
 			Map<Id<Link>, PathData> pathsFromPickupMap, Map<Id<Link>, PathData> pathsToDropoffMap,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/StopBasedPathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/StopBasedPathDataProvider.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.data.DrtRequest;
 import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
+import org.matsim.contrib.drt.optimizer.insertion.DetourLinksProvider.DetourLinksSet;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.ManyToManyPathData;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
@@ -75,9 +76,7 @@ public class StopBasedPathDataProvider implements PrecalculablePathDataProvider 
 	}
 
 	@Override
-	public void precalculatePathData(DrtRequest drtRequest, Map<Id<Link>, Link> linksToPickupMap,
-			Map<Id<Link>, Link> linksFromPickupMap, Map<Id<Link>, Link> linksToDropoffMap,
-			Map<Id<Link>, Link> linksFromDropoffMap) {
+	public void precalculatePathData(DrtRequest drtRequest, DetourLinksSet detourLinkSet) {
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 


### PR DESCRIPTION
About 25% compared to the previous tests on TaxiBerlin (see #270 ).
Speed gains are mostly due to parallelisation of:
- insertion filtering (the new step 2 introduced in #270 )
- `VehicleData` creation
