### PR TITLE
Facilities related changes

### DIFF
--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/ChooseRandomTripMode.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/ChooseRandomTripMode.java
@@ -67,9 +67,14 @@ public final class ChooseRandomTripMode implements PlanAlgorithm {
 		}
 		
 		//don't change the trips between the same links
-		if (!trips.get(rndIdx).getOriginActivity().getLinkId().toString().equals(trips.get(rndIdx).getDestinationActivity().getLinkId().toString()))
-			setRandomTripMode(trips.get(rndIdx), plan, ffcard, owcard);
-		else return;
+		if (trips.get(rndIdx).getOriginActivity().getFacilityId()!=null) {
+			if (! trips.get(rndIdx).getOriginActivity().getFacilityId().toString().equals(trips.get(rndIdx).getDestinationActivity().getFacilityId().toString()))
+				setRandomTripMode(trips.get(rndIdx), plan, ffcard, owcard);
+		} else{
+			if (! trips.get(rndIdx).getOriginActivity().getLinkId().toString().equals(trips.get(rndIdx).getDestinationActivity().getLinkId().toString()))
+				setRandomTripMode(trips.get(rndIdx), plan, ffcard, owcard);
+		}
+
 	}
 	
 	private void setRandomTripMode(final Trip trip, final Plan plan, boolean ffcard, boolean owcard) {

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/sharedvehicles/replanning/OptimizeVehicleAllocationAtTourLevelAlgorithm.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/sharedvehicles/replanning/OptimizeVehicleAllocationAtTourLevelAlgorithm.java
@@ -65,8 +65,6 @@ public class OptimizeVehicleAllocationAtTourLevelAlgorithm implements GenericPla
 	private final boolean allowNullRoutes;
 	private final VehicleRessources vehicleRessources;
 
-	private boolean anchorAtFacilities = false;
-
 	public OptimizeVehicleAllocationAtTourLevelAlgorithm(
 			final StageActivityTypes stageActivitiesForSubtourDetection,
 			final Random random,
@@ -187,8 +185,8 @@ public class OptimizeVehicleAllocationAtTourLevelAlgorithm implements GenericPla
 			final Collection<Subtour> subtours =
 				TripStructureUtils.getSubtours(
 						p,
-						stageActs,
-						anchorAtFacilities );
+						stageActs
+                );
 			for ( final Subtour s : subtours ) {
 				if ( s.getParent() != null ) continue; // is not a root tour
 				boolean isFirstTrip = true;
@@ -217,7 +215,7 @@ public class OptimizeVehicleAllocationAtTourLevelAlgorithm implements GenericPla
 		for ( final SubtourRecord record : vehicularTours ) {
 			final Subtour s = record.subtour;
 			assert s.getParent() == null;
-			final Id anchor = anchorAtFacilities ?
+			final Id anchor = s.getTrips().get( 0 ).getOriginActivity().getFacilityId()!=null ?
 				s.getTrips().get( 0 ).getOriginActivity().getFacilityId() :
 				s.getTrips().get( 0 ).getOriginActivity().getLinkId();
 

--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -1,6 +1,11 @@
 package org.matsim.core.controler;
 
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Provider;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -25,12 +30,6 @@ import org.matsim.facilities.FacilitiesFromPopulation;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 
 public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim {
 	// I think it is ok to have this public final.  Since one may want to use it as a delegate.  kai, may'18
@@ -98,6 +97,7 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 			case setInScenario:
 				Gbl.assertIf(! this.activityFacilities.getFacilities().isEmpty() );
 				break;
+			case onePerActivityLinkInPlansFile:
 			case onePerActivityLocationInPlansFile:
 				FacilitiesFromPopulation facilitiesFromPopulation = new FacilitiesFromPopulation(activityFacilities, facilitiesConfigGroup);
 

--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -113,6 +113,10 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 				throw new RuntimeException("Facilities source '"+this.facilitiesConfigGroup.getFacilitiesSource()+"' is not implemented yet.");
 		}
 
+		// get links for facilities
+		// using car only network to get the links for facilities. Amit July'18
+		XY2LinksForFacilities.run(carOnlyNetwork, this.activityFacilities);
+
 		// make sure all routes are calculated.
 		// At least xy2links is needed here, i.e. earlier than PrepareForMobsimImpl.  It could, however, presumably be separated out
 		// (i.e. we introduce a separate PersonPrepareForMobsim).  kai, jul'18

--- a/matsim/src/main/java/org/matsim/core/controler/XY2LinksForFacilities.java
+++ b/matsim/src/main/java/org/matsim/core/controler/XY2LinksForFacilities.java
@@ -52,9 +52,11 @@ public class XY2LinksForFacilities {
                     linkNullWarn++;
                 }
                 Link link = NetworkUtils.getNearestLink(network, activityFacility.getCoord());
-                if (link==null) throw new RuntimeException("No nearest link is found for coord "+activityFacility.getCoord());
-
-                ((ActivityFacilityImpl)activityFacility).setLinkId(link.getId());
+                if (link==null) {
+                    LOGGER.warn("No nearest link is found for coord "+activityFacility.getCoord());
+                } else{
+                    ((ActivityFacilityImpl)activityFacility).setLinkId(link.getId());
+                }
 
             } else if (activityFacility.getCoord()==null){
                 if (coordNullWarn==0) {

--- a/matsim/src/main/java/org/matsim/core/controler/XY2LinksForFacilities.java
+++ b/matsim/src/main/java/org/matsim/core/controler/XY2LinksForFacilities.java
@@ -1,0 +1,68 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.controler;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.gbl.Gbl;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.facilities.ActivityFacilities;
+import org.matsim.facilities.ActivityFacility;
+import org.matsim.facilities.ActivityFacilityImpl;
+
+/**
+ * Created by amit on 13.07.18.
+ */
+
+public class XY2LinksForFacilities {
+
+    public static final Logger LOGGER = Logger.getLogger(XY2LinksForFacilities.class);
+
+    public static void run(Network network, ActivityFacilities facilities){
+
+        int coordNullWarn = 0;
+        int linkNullWarn = 0;
+
+        for (ActivityFacility activityFacility : facilities.getFacilities().values()) {
+
+            if (activityFacility.getCoord()==null && activityFacility.getLinkId()== null) {
+                throw new RuntimeException("Neither coordinate nor linkId are available for facility id "+ activityFacility.getId()+". Aborting....");
+            } else if (activityFacility.getLinkId()==null){
+                if (linkNullWarn==0) {
+                    LOGGER.warn("There is no link for at least a facility. Assigning links for such facilities from coords.");
+                    LOGGER.warn(Gbl.ONLYONCE);
+                    linkNullWarn++;
+                }
+                Link link = NetworkUtils.getNearestLink(network, activityFacility.getCoord());
+                if (link==null) throw new RuntimeException("No nearest link is found for coord "+activityFacility.getCoord());
+
+                ((ActivityFacilityImpl)activityFacility).setLinkId(link.getId());
+
+            } else if (activityFacility.getCoord()==null){
+                if (coordNullWarn==0) {
+                    LOGGER.warn("There is no coord for the facility.");
+                    LOGGER.warn(Gbl.ONLYONCE);
+                    coordNullWarn++;
+                }
+            }
+        }
+    }
+}

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -20,6 +20,14 @@
 
 package org.matsim.core.population.algorithms;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Id;
@@ -33,15 +41,6 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Subtour;
 import org.matsim.core.router.TripStructureUtils.Trip;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
 
 /**
  * Changes the transportation mode of one random non-empty subtour in a plan to a randomly chosen
@@ -79,8 +78,6 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 
 	private PermissibleModesCalculator permissibleModesCalculator;
 
-	private boolean anchorAtFacilities = false;
-	
 	private final double probaForChangeSingleTripMode;
 	private TripsToLegsAlgorithm tripsToLegs = null ;
 	private ChooseRandomSingleLegMode changeSingleLegMode = null ;
@@ -144,7 +141,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 			return;
 		}
 
-		final Id<? extends BasicLocation> homeLocation = anchorAtFacilities ?
+		final Id<? extends BasicLocation> homeLocation = ((Activity) plan.getPlanElements().get(0)).getFacilityId()!=null ?
 			((Activity) plan.getPlanElements().get(0)).getFacilityId() :
 			((Activity) plan.getPlanElements().get(0)).getLinkId();
 
@@ -158,8 +155,8 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 							TripStructureUtils.getTrips(plan, stageActivityTypes),
 							TripStructureUtils.getSubtours(
 									plan,
-									stageActivityTypes,
-									anchorAtFacilities),
+									stageActivityTypes
+							),
 							permissibleModesForThisPlan);
 			
 			if (!choiceSet.isEmpty()) {
@@ -184,7 +181,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 			}
 
 			final Set<String> usableChainBasedModes = new LinkedHashSet<>();
-			final Id<? extends BasicLocation> subtourStartLocation = anchorAtFacilities ?
+			final Id<? extends BasicLocation> subtourStartLocation = subtour.getTrips().get( 0 ).getOriginActivity().getFacilityId()!=null ?
 				subtour.getTrips().get( 0 ).getOriginActivity().getFacilityId() :
 				subtour.getTrips().get( 0 ).getOriginActivity().getLinkId();
 			
@@ -274,14 +271,14 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 	}
 
 	private Id<? extends BasicLocation> getLocationId(Activity activity) {
-		return anchorAtFacilities ?
+		return activity.getFacilityId()!=null ?
 			activity.getFacilityId() :
 			activity.getLinkId();
 	}
 	
 	private boolean atSameLocation(Activity firstLegUsingMode,
 			Activity lastLegUsingMode) {
-		return anchorAtFacilities ?
+		return firstLegUsingMode.getFacilityId()!=null ?
 			firstLegUsingMode.getFacilityId().equals(
 					lastLegUsingMode.getFacilityId() ) :
 			firstLegUsingMode.getLinkId().equals(
@@ -336,11 +333,6 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 						trip.getDestinationActivity());
 			}
 
-	}
-
-	public void setAnchorSubtoursAtFacilitiesInsteadOfLinks(
-			final boolean anchorAtFacilities) {
-		this.anchorAtFacilities = anchorAtFacilities;
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
@@ -111,7 +111,14 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 			for (PlanElement pe : plan.getPlanElements()) {
 				if (pe instanceof Activity) {
 					Activity act = (Activity) pe;
-					if ( act.getLinkId() == null ) {
+					if ( act.getLinkId() == null // neither activity nor facility has a link
+							&&
+							//this check is necessary here, else, XY2Links will put the link/coord back to activity which is clear violation of facilitiesConfigGroup.removingLinksAndCoordinates =true. Amit July'18
+							( act.getFacilityId() == null
+									|| this.activityFacilities.getFacilities().isEmpty()
+									|| this.activityFacilities.getFacilities().get(act.getFacilityId()) == null
+									|| this.activityFacilities.getFacilities().get(act.getFacilityId()).getLinkId() == null)
+							) {
 					    	needsXY2Links = true;
 							needsReRoute = true;
 							break;

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/XY2Links.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/XY2Links.java
@@ -89,6 +89,7 @@ public final class XY2Links extends AbstractPersonAlgorithm implements PlanAlgor
 						if (facility != null) {
 							act.setLinkId(facility.getLinkId());
 							// yy facility.getLinkId may be null, in particular since linkId is not even part of the facilities DTD. kai, feb'16
+							// right, just had such a situation in CarSharingIT test. Amit Jul'18
 
 							if (act.getLinkId() == null && act.getCoord()==null){
 								// for FacilitiesSource.onePerActivityLocationInPlansFile, one can opt to keep coords in facility only. Amit Jan'18

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/XY2Links.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/XY2Links.java
@@ -86,16 +86,17 @@ public final class XY2Links extends AbstractPersonAlgorithm implements PlanAlgor
 					if (act.getFacilityId() != null) {
 						ActivityFacility facility = facilities.getFacilities().get(act.getFacilityId());
 
-						if (facility != null) {
-							act.setLinkId(facility.getLinkId());
-							// yy facility.getLinkId may be null, in particular since linkId is not even part of the facilities DTD. kai, feb'16
-							// right, just had such a situation in CarSharingIT test. Amit Jul'18
-
-							if (act.getLinkId() == null && act.getCoord()==null){
-								// for FacilitiesSource.onePerActivityLocationInPlansFile, one can opt to keep coords in facility only. Amit Jan'18
-								act.setCoord(facility.getCoord());
-							}
-						}
+						//following is not necessary. Kai, Amit July'18
+//						if (facility != null) {
+//							act.setLinkId(facility.getLinkId());
+//							// yy facility.getLinkId may be null, in particular since linkId is not even part of the facilities DTD. kai, feb'16
+//							// right, just had such a situation in CarSharingIT test. Amit Jul'18
+//
+//							if (act.getLinkId() == null && act.getCoord()==null){
+//								// for FacilitiesSource.onePerActivityLocationInPlansFile, one can opt to keep coords in facility only. Amit Jan'18
+//								act.setCoord(facility.getCoord());
+//							}
+//						}
 					}
 				}
 				

--- a/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
@@ -115,7 +115,6 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 						this.modes,
 						this.chainBasedModes,
 						MatsimRandom.getLocalInstance(), behavior, probaForChangeSingleTripMode);
-		chooseRandomLegMode.setAnchorSubtoursAtFacilitiesInsteadOfLinks( false );
 		return chooseRandomLegMode;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
@@ -19,8 +19,13 @@
  * *********************************************************************** */
 package org.matsim.core.router;
 
+import java.util.List;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.population.*;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.config.Config;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.algorithms.PersonAlgorithm;
@@ -31,8 +36,6 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.Facility;
 import org.matsim.vehicles.Vehicle;
-
-import java.util.List;
 
 /**
  * {@link PlanAlgorithm} responsible for routing all trips of a plan.
@@ -143,15 +146,23 @@ public class PlanRouter implements PlanAlgorithm, PersonAlgorithm {
 	// helpers
 	// /////////////////////////////////////////////////////////////////////////
 	private Facility toFacility(final Activity act) {
-		if (  (act.getLinkId() == null && act.getCoord() == null)  // yyyy this used to be || instead of && --???  kai, jun'16
-				&& facilities != null
-				&& !facilities.getFacilities().isEmpty()) {
-			// use facilities only if the activity does not provide the required fields.
-			// yyyyyy Seems to me that the Access/EgressRoutingModule only needs either link or coord to start from.  So we only go
-			// to facilities if neither is provided.  --  This may, however, be at odds of how it is done in the AccessEgressRoutingModule, so we 
-			// need to conceptually sort this out!!  kai, jun'16
+//		if (  (act.getLinkId() == null && act.getCoord() == null)  // yyyy this used to be || instead of && --???  kai, jun'16
+//				&& facilities != null
+//				&& !facilities.getFacilities().isEmpty()) {
+//			// use facilities only if the activity does not provide the required fields.
+//			// yyyyyy Seems to me that the Access/EgressRoutingModule only needs either link or coord to start from.  So we only go
+//			// to facilities if neither is provided.  --  This may, however, be at odds of how it is done in the AccessEgressRoutingModule, so we
+//			// need to conceptually sort this out!!  kai, jun'16
+//			return facilities.getFacilities().get( act.getFacilityId() );
+//		}
+
+		// use facility first if available i.e. reversing the logic above Amit July'18
+		if (	facilities != null &&
+				! facilities.getFacilities().isEmpty() &&
+				act.getFacilityId() != null ) {
 			return facilities.getFacilities().get( act.getFacilityId() );
 		}
+
 		return new ActivityWrapperFacility( act );
 	}
 

--- a/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
@@ -19,17 +19,16 @@
  * *********************************************************************** */
 package org.matsim.core.router;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.gbl.Gbl;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Helps to work on plans with complex trips.
@@ -141,30 +140,12 @@ public class TripStructureUtils {
 	}
 
 	public static Collection<Subtour> getSubtours(
-			final Plan plan,
-			final StageActivityTypes stageActivityTypes) {
+            final Plan plan,
+            final StageActivityTypes stageActivityTypes) {
 		return getSubtours(
 				plan.getPlanElements(),
-				stageActivityTypes);
-	}
-
-	public static Collection<Subtour> getSubtours(
-			final List<? extends PlanElement> plan,
-			final StageActivityTypes stageActivityTypes) {
-		return getSubtours(
-				plan,
-				stageActivityTypes,
-				false );
-	}
-
-	public static Collection<Subtour> getSubtours(
-			final Plan plan,
-			final StageActivityTypes stageActivityTypes,
-			final boolean useFacilitiesInsteadOfLinks) {
-		return getSubtours(
-				plan.getPlanElements(),
-				stageActivityTypes,
-				useFacilitiesInsteadOfLinks );
+				stageActivityTypes
+        );
 	}
 
 	/**
@@ -196,9 +177,8 @@ public class TripStructureUtils {
 	 * sequence
 	 */
 	public static Collection<Subtour> getSubtours(
-			final List<? extends PlanElement> planElements,
-			final StageActivityTypes stageActivityTypes,
-			final boolean useFacilitiesInsteadOfLinks) {
+            final List<? extends PlanElement> planElements,
+            final StageActivityTypes stageActivityTypes) {
 		final List<Subtour> subtours = new ArrayList<>();
 
 		Id<?> destinationId = null;
@@ -206,30 +186,32 @@ public class TripStructureUtils {
 		final List<Trip> trips = getTrips( planElements , stageActivityTypes );
 		final List<Trip> nonAllocatedTrips = new ArrayList<>( trips );
 		for (Trip trip : trips) {
-			final Id<?> originId = useFacilitiesInsteadOfLinks ?
-					trip.getOriginActivity().getFacilityId() :
-						trip.getOriginActivity().getLinkId();
+            final Id<?> originId;
+            //use facilities if available
+		    if (trip.getOriginActivity().getFacilityId()!=null ) {
+		        originId = trip.getOriginActivity().getFacilityId();
+            } else {
+		        originId = trip.getOriginActivity().getLinkId();
+            }
 
 					if ( originId == null ) {
-						throw new NullPointerException( "the "+
-								(useFacilitiesInsteadOfLinks ? "facility " : "link " )+
-								"id for origin activity "+trip.getOriginActivity()+
-								" is null!" );
+						throw new NullPointerException( "Both facility id and link id for origin activity "+trip.getOriginActivity()+
+								" are null!" );
 					}
 
 					if (destinationId != null && !originId.equals( destinationId )) {
 						throw new RuntimeException( "unconsistent trip location sequence: "+destinationId+" != "+originId );
 					}
 
-					destinationId = useFacilitiesInsteadOfLinks ?
-							trip.getDestinationActivity().getFacilityId() :
-								trip.getDestinationActivity().getLinkId();
+            if (trip.getDestinationActivity().getFacilityId()!=null ) {
+                destinationId = trip.getDestinationActivity().getFacilityId();
+            } else {
+                destinationId = trip.getDestinationActivity().getLinkId();
+            }
 
 							if ( destinationId == null ) {
-								throw new NullPointerException( "the "+
-										(useFacilitiesInsteadOfLinks ? "facility " : "link " )+
-										"id for destination activity "+trip.getDestinationActivity()+
-										" is null!" );
+								throw new NullPointerException( "Both facility id and link id for destination activity "+trip.getDestinationActivity()+
+										" are null!" );
 							}
 
 							originIds.add( originId );

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
@@ -173,6 +173,7 @@ public class FacilitiesFromPopulation {
 							if (facility == null) {
 								facility = factory.createActivityFacility(Id.create(this.idPrefix + idxCounter++, ActivityFacility.class), c, linkId);
 								this.facilities.addActivityFacility(facility);
+								// TODO: !bug! all activities without coord will have same facility id. Amit Jul'18
 								facilitiesPerCoordinate.put(c, facility);
 							}
 						}

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
@@ -170,7 +170,7 @@ public class FacilitiesFromPopulation {
 							}
 						} else {
 							if (c == null)  {
-								throw new RuntimeException("Coordinate for the facility "+facility.getId()+" is null, cannot collect facilities per coordinate. " +
+								throw new RuntimeException("Coordinate for the activity "+a+" is null, cannot collect facilities per coordinate. " +
 										"Probably, use " + FacilitiesConfigGroup.FacilitiesSource.onePerActivityLinkInPlansFile + " instead and collect facilities per link.");
 							}
 

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesFromPopulation.java
@@ -169,11 +169,15 @@ public class FacilitiesFromPopulation {
 								facilitiesPerLinkId.put(linkId, facility);
 							}
 						} else {
+							if (c == null)  {
+								throw new RuntimeException("Coordinate for the facility "+facility.getId()+" is null, cannot collect facilities per coordinate. " +
+										"Probably, use " + FacilitiesConfigGroup.FacilitiesSource.onePerActivityLinkInPlansFile + " instead and collect facilities per link.");
+							}
+
 							facility = facilitiesPerCoordinate.get(c);
 							if (facility == null) {
 								facility = factory.createActivityFacility(Id.create(this.idPrefix + idxCounter++, ActivityFacility.class), c, linkId);
 								this.facilities.addActivityFacility(facility);
-								// TODO: !bug! all activities without coord will have same facility id. Amit Jul'18
 								facilitiesPerCoordinate.put(c, facility);
 							}
 						}

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
@@ -149,8 +149,7 @@ public class FacilitiesReaderMatsimV1 extends MatsimXmlParser {
                             Id.create(atts.getValue("id"), ActivityFacility.class),
                             Id.create(atts.getValue("linkId"),Link.class));
             } else { //neither coord nor link present
-                this.currfacility =
-                        this.factory.createActivityFacility(Id.create(atts.getValue("id"), ActivityFacility.class), null,null);
+                throw new RuntimeException("Neither coordinate nor linkId are available for facility id "+ atts.getValue("id")+". Aborting....");
             }
         }
 

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
@@ -20,6 +20,8 @@
 
 package org.matsim.facilities;
 
+import java.util.Map;
+import java.util.Stack;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -32,9 +34,6 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
 import org.xml.sax.Attributes;
-
-import java.util.Map;
-import java.util.Stack;
 
 /**
  * A reader for facilities-files of MATSim according to <code>facilities_v1.dtd</code>.
@@ -124,18 +123,38 @@ public class FacilitiesReaderMatsimV1 extends MatsimXmlParser {
     }
 
     private void startFacility(final Attributes atts) {
-        this.currfacility =
-                this.factory.createActivityFacility(
-                        Id.create(atts.getValue("id"), ActivityFacility.class),
-                        coordinateTransformation.transform(
-                                new Coord(
-                                        Double.parseDouble(atts.getValue("x")),
-                                        Double.parseDouble(atts.getValue("y")))));
-        this.facilities.addActivityFacility(this.currfacility);
-        String value = atts.getValue("linkId");
-        if (value != null) {
-            ((ActivityFacilityImpl) this.currfacility).setLinkId(Id.create(value, Link.class));
+        if ( atts.getValue("x") !=null && atts.getValue("y") !=null ) {
+            if (atts.getValue("linkId") !=null) { //both coord and link present
+                this.currfacility =
+                        this.factory.createActivityFacility(
+                                Id.create(atts.getValue("id"), ActivityFacility.class),
+                                coordinateTransformation.transform(
+                                        new Coord(
+                                                Double.parseDouble(atts.getValue("x")),
+                                                Double.parseDouble(atts.getValue("y")))),
+                                Id.create(atts.getValue("linkId"),Link.class));
+            } else { // only coord present
+                this.currfacility =
+                        this.factory.createActivityFacility(
+                                Id.create(atts.getValue("id"), ActivityFacility.class),
+                                coordinateTransformation.transform(
+                                        new Coord(
+                                                Double.parseDouble(atts.getValue("x")),
+                                                Double.parseDouble(atts.getValue("y")))));
+            }
+        } else {
+            if (atts.getValue("linkId") !=null) { //only link present
+            this.currfacility =
+                    this.factory.createActivityFacility(
+                            Id.create(atts.getValue("id"), ActivityFacility.class),
+                            Id.create(atts.getValue("linkId"),Link.class));
+            } else { //neither coord nor link present
+                this.currfacility =
+                        this.factory.createActivityFacility(Id.create(atts.getValue("id"), ActivityFacility.class), null,null);
+            }
         }
+
+        this.facilities.addActivityFacility(this.currfacility);
         ((ActivityFacilityImpl) this.currfacility).setDesc(atts.getValue("desc"));
     }
 

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
@@ -20,6 +20,11 @@
 
 package org.matsim.facilities;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedSet;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.core.api.internal.MatsimWriter;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -28,12 +33,6 @@ import org.matsim.core.utils.io.MatsimXmlWriter;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
-
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.SortedSet;
 
 /**
  * @author mrieser / Senozon AG
@@ -143,9 +142,11 @@ import java.util.SortedSet;
         if (facility.getLinkId() != null) {
             out.write(" linkId=\"" + facility.getLinkId().toString() + "\"");
         }
-        final Coord coord = coordinateTransformation.transform(facility.getCoord());
-        out.write(" x=\"" + coord.getX() + "\"");
-        out.write(" y=\"" + coord.getY() + "\"");
+        if (facility.getCoord()!=null) {
+            final Coord coord = coordinateTransformation.transform(facility.getCoord());
+            out.write(" x=\"" + coord.getX() + "\"");
+            out.write(" y=\"" + coord.getY() + "\"");
+        }
         if (facility.getDesc() != null) {
             out.write(" desc=\"" + facility.getDesc() + "\"");
         }

--- a/matsim/src/main/resources/dtd/facilities_v1.dtd
+++ b/matsim/src/main/resources/dtd/facilities_v1.dtd
@@ -18,8 +18,8 @@
         <!ELEMENT facility   (activity*,attributes?)>
         <!ATTLIST facility
                 id         CDATA #REQUIRED
-                x          CDATA #REQUIRED
-                y          CDATA #REQUIRED
+                x          CDATA #IMPLIED
+                y          CDATA #IMPLIED
                 linkId     CDATA #IMPLIED
                 desc       CDATA #IMPLIED>
 

--- a/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsSubtoursTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsSubtoursTest.java
@@ -790,8 +790,8 @@ public class TripStructureUtilsSubtoursTest {
 		final Collection<Subtour> subtours =
 			TripStructureUtils.getSubtours(
 					fixture.plan,
-					CHECKER,
-					fixture.useFacilitiesAsAnchorPoint);
+					CHECKER
+            );
 
 		assertEquals(
 				"[anchorAtFacilities="+fixture.useFacilitiesAsAnchorPoint+"] "+
@@ -815,8 +815,8 @@ public class TripStructureUtilsSubtoursTest {
 		try {
 			TripStructureUtils.getSubtours(
 					fixture.plan,
-					CHECKER,
-					fixture.useFacilitiesAsAnchorPoint);
+					CHECKER
+            );
 		}
 		catch (RuntimeException e) {
 			hadException = true;
@@ -835,8 +835,8 @@ public class TripStructureUtilsSubtoursTest {
 			final Collection<Subtour> subtours =
 				TripStructureUtils.getSubtours(
 						f.plan,
-						CHECKER,
-						f.useFacilitiesAsAnchorPoint);
+						CHECKER
+                );
 			int countTrips = 0;
 
 			for (Subtour s : subtours) {
@@ -854,7 +854,7 @@ public class TripStructureUtilsSubtoursTest {
 	@Test
 	public void testFatherhood() throws Exception {
 		for (Fixture f : allFixtures( useFacilitiesAsAnchorPoint )) {
-			final Collection<Subtour> subtours = TripStructureUtils.getSubtours( f.plan , CHECKER , f.useFacilitiesAsAnchorPoint );
+			final Collection<Subtour> subtours = TripStructureUtils.getSubtours( f.plan , CHECKER);
 
 			for (Subtour s : subtours) {
 				for ( Subtour child : s.getChildren() ) {

--- a/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsSubtoursTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsSubtoursTest.java
@@ -88,10 +88,14 @@ public class TripStructureUtilsSubtoursTest {
 			final String type,
 			final Id<?> loc) {
 		final Id<Link> linkLoc = anchorAtFacilities ? Id.create( "nowhere", Link.class ) : Id.create(loc, Link.class);
-		final Id<ActivityFacility> facLoc = anchorAtFacilities ? Id.create(loc, ActivityFacility.class) : Id.create( "nowhere", ActivityFacility.class );
 
 		final Activity act = fact.createActivityFromLinkId( type , linkLoc );
-		((Activity) act).setFacilityId( facLoc );
+
+		if (anchorAtFacilities) {
+			final Id<ActivityFacility> facLoc = Id.create(loc, ActivityFacility.class) ;
+			((Activity) act).setFacilityId( facLoc );
+		}
+
 		return act;
 	}
 	

--- a/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
@@ -98,14 +98,14 @@ public class ActivityFacilitiesSourceTest {
 				break;
 			case fromFile:
 				for (ActivityFacility af : activityFacilities.getFacilities().values()){
-					Assert.assertNull(af.getLinkId());
+					Assert.assertNotNull(af.getLinkId());
 				}
 				break;
 			case setInScenario:
 				Assert.assertEquals("wrong number of facilities", 2, activityFacilities.getFacilities().size(), MatsimTestUtils.EPSILON);
 				if (facilitiesWithCoordOnly) {
 					for (ActivityFacility af : activityFacilities.getFacilities().values()){
-						Assert.assertNull(af.getLinkId());
+						Assert.assertNotNull(af.getLinkId());
 					}
 				} else {
 					for (ActivityFacility af : activityFacilities.getFacilities().values()){

--- a/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
@@ -120,11 +120,11 @@ public class ActivityFacilitiesSourceTest {
 				}
 				break;
 			case onePerActivityLocationInPlansFile:
-				// TODO fix this
-//				Assert.assertEquals("wrong number of facilities", 4, getFacilities(scenario.getConfig().controler().getOutputDirectory()).getFacilities().size(), MatsimTestUtils.EPSILON);
-//				for (ActivityFacility af : activityFacilities.getFacilities().values()){
-//					Assert.assertNotNull(af.getCoord());
-//				}
+				Assert.assertEquals("wrong number of facilities", 2, getFacilities(scenario.getConfig().controler().getOutputDirectory()).getFacilities().size(), MatsimTestUtils.EPSILON);
+				for (ActivityFacility af : activityFacilities.getFacilities().values()){
+					Assert.assertNotNull(af.getCoord());
+					Assert.assertNotNull(af.getLinkId());
+				}
 				break;
 		}
 	}
@@ -209,7 +209,9 @@ public class ActivityFacilitiesSourceTest {
 			person.addPlan(plan);
 			scenario.getPopulation().addPerson(person);
 		}
-		{ // activity from link only
+
+		// activity from link only
+		if (! this.facilitiesSource.equals(FacilitiesConfigGroup.FacilitiesSource.onePerActivityLocationInPlansFile)){
 			Person person = populationFactory.createPerson(Id.createPersonId("1"));
 			Plan plan = populationFactory.createPlan();
 			Activity home = populationFactory.createActivityFromLinkId("h", Id.createLinkId("1"));
@@ -245,6 +247,11 @@ public class ActivityFacilitiesSourceTest {
 			plan.addActivity(home);
 			plan.addLeg(populationFactory.createLeg(mode));
 			Activity work = populationFactory.createActivityFromLinkId("w", Id.createLinkId("20"));
+
+			if ( this.facilitiesSource.equals(FacilitiesConfigGroup.FacilitiesSource.onePerActivityLocationInPlansFile)){
+				work.setCoord(new Coord(10000.0, 0.0));
+			}
+
 			if (assignFacilityIdToActivity(facilitiesSource)) {
 				work.setFacilityId(Id.create("2", ActivityFacility.class));
 			}

--- a/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/ActivityFacilitiesSourceTest.java
@@ -20,11 +20,13 @@
 package org.matsim.facilities;
 
 import java.io.File;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -47,43 +49,95 @@ import org.matsim.testcases.MatsimTestUtils;
  * Created by amit on 05.02.18.
  */
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(Parameterized.class)
 public class ActivityFacilitiesSourceTest {
 	
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
 	
 	private final String mode = TransportMode.car;
 //    private static final String outDir = "test/output/"+ActivityFacilitiesSourceTest.class.getCanonicalName().replace('.','/')+"/";
-	
+
+	private final FacilitiesConfigGroup.FacilitiesSource facilitiesSource;
+	private final boolean facilitiesWithCoordOnly ;
+
+	public ActivityFacilitiesSourceTest(FacilitiesConfigGroup.FacilitiesSource facilitiesSource, boolean facilitiesWithCoordOnly) {
+		this.facilitiesSource = facilitiesSource;
+		this.facilitiesWithCoordOnly = facilitiesWithCoordOnly;
+	}
+
+	@Parameterized.Parameters(name = "{index}: FacilitiesSource - {0}; facilitiesWithCoordOnly - {1}")
+	public static Collection<Object[]> parametersForFacilitiesSourceTest() {
+		// it is not clear to me why/how this works.  The documentation of JUnitParamsRunner says that such
+		// implicit behavior ("dirty tricks") should no longer be necessary when using it.  kai, jul'18
+		return Arrays.asList(
+				new Object[]{FacilitiesConfigGroup.FacilitiesSource.none, true} // true/false doen't matter here
+				,new Object[]{FacilitiesConfigGroup.FacilitiesSource.fromFile, true}// true/false doen't matter here
+				,new Object[]{FacilitiesConfigGroup.FacilitiesSource.setInScenario, true}
+				,new Object[]{FacilitiesConfigGroup.FacilitiesSource.setInScenario, false}
+				,new Object[]{FacilitiesConfigGroup.FacilitiesSource.onePerActivityLinkInPlansFile, true} // true/false doen't matter here
+				,new Object[]{FacilitiesConfigGroup.FacilitiesSource.onePerActivityLocationInPlansFile, true} // true/false doen't matter here
+		);
+	}
+
 	@Test
-	@Parameters
-	public void facilitiesSourceTest(FacilitiesConfigGroup.FacilitiesSource facilitiesSource, boolean facilitiesWithCoordOnly) {
+	public void test(){
 		String outDir = utils.getOutputDirectory() ;
 		String testOutDir = outDir + "/" + facilitiesSource.toString() + "_facilitiesWithCoordOnly_" + String
-																			     .valueOf(facilitiesWithCoordOnly) + "/";
+				.valueOf(facilitiesWithCoordOnly) + "/";
 		new File(testOutDir).mkdirs();
-		
-		Scenario scenario = prepareScenario(facilitiesSource, facilitiesWithCoordOnly);
+
+		Scenario scenario = prepareScenario();
 		scenario.getConfig().controler().setOutputDirectory(testOutDir);
 		scenario.getConfig().controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
 		new Controler(scenario).run();
+
+		// checks
+		ActivityFacilities activityFacilities = getFacilities(scenario.getConfig().controler().getOutputDirectory());
+		switch (this.facilitiesSource) {
+			case none:
+				break;
+			case fromFile:
+				for (ActivityFacility af : activityFacilities.getFacilities().values()){
+					Assert.assertNull(af.getLinkId());
+				}
+				break;
+			case setInScenario:
+				Assert.assertEquals("wrong number of facilities", 2, activityFacilities.getFacilities().size(), MatsimTestUtils.EPSILON);
+				if (facilitiesWithCoordOnly) {
+					for (ActivityFacility af : activityFacilities.getFacilities().values()){
+						Assert.assertNull(af.getLinkId());
+					}
+				} else {
+					for (ActivityFacility af : activityFacilities.getFacilities().values()){
+						Assert.assertNull(af.getCoord());
+					}
+				}
+				break;
+			case onePerActivityLinkInPlansFile:
+				Assert.assertEquals("wrong number of facilities", 4, getFacilities(scenario.getConfig().controler().getOutputDirectory()).getFacilities().size(), MatsimTestUtils.EPSILON);
+				for (ActivityFacility af : activityFacilities.getFacilities().values()){
+					Assert.assertNotNull(af.getLinkId());
+				}
+				break;
+			case onePerActivityLocationInPlansFile:
+				// TODO fix this
+//				Assert.assertEquals("wrong number of facilities", 4, getFacilities(scenario.getConfig().controler().getOutputDirectory()).getFacilities().size(), MatsimTestUtils.EPSILON);
+//				for (ActivityFacility af : activityFacilities.getFacilities().values()){
+//					Assert.assertNotNull(af.getCoord());
+//				}
+				break;
+		}
 	}
-	
-	private Object[] parametersForFacilitiesSourceTest() {
-		// it is not clear to me why/how this works.  The documentation of JUnitParamsRunner says that such
-		// implicit behavior ("dirty tricks") should no longer be necessary when using it.  kai, jul'18
-		return new Object[]{
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.none, true}, // true/false doen't matter with 'none'
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.fromFile, true},// true/false doen't matter with 'fromFile'
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.setInScenario, true},
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.setInScenario, false},
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.onePerActivityLocationInPlansFile, true},
-				new Object[]{FacilitiesConfigGroup.FacilitiesSource.onePerActivityLocationInPlansFile, false}
-		};
+
+	private ActivityFacilities getFacilities(String outputDir){
+		Scenario scenario = ScenarioUtils.loadScenario(ConfigUtils.createConfig());
+		new FacilitiesReaderMatsimV1(scenario).readFile(outputDir+"/output_facilities.xml.gz");
+		return scenario.getActivityFacilities();
 	}
+
 	
 	// create basic scenario
-	private Scenario prepareScenario(FacilitiesConfigGroup.FacilitiesSource facilitiesSource, boolean facilitiesWithCoordOnly) {
+	private Scenario prepareScenario() {
 		Config config = ConfigUtils.loadConfig(IOUtils.newUrl(ExamplesUtils.getTestScenarioURL("equil"), "config.xml"));
 		config.plans().setInputFile(null);
 		config.controler().setLastIteration(0);
@@ -190,7 +244,7 @@ public class ActivityFacilitiesSourceTest {
 			home.setEndTime(7.8 * 3600.0);
 			plan.addActivity(home);
 			plan.addLeg(populationFactory.createLeg(mode));
-			Activity work = populationFactory.createActivityFromCoord("w", new Coord(10000.0, 0.0));
+			Activity work = populationFactory.createActivityFromLinkId("w", Id.createLinkId("20"));
 			if (assignFacilityIdToActivity(facilitiesSource)) {
 				work.setFacilityId(Id.create("2", ActivityFacility.class));
 			}

--- a/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourTest.java
@@ -182,7 +182,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String[] modes = new String[] {"car", "pt", "walk"};
 		
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, new Random(15102011), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks( false );
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		Plan plan = PopulationUtils.createPlan();
 		person.addPlan(plan);
@@ -268,7 +267,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.pt;
 		String[] modes = new String[] {expectedMode, originalMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(false);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(network, activityChainString, originalMode);
@@ -285,7 +283,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.pt;
 		String[] modes = new String[] {expectedMode, originalMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(true);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(facilities, activityChainString, originalMode);
@@ -301,7 +298,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.walk;
 		String[] modes = new String[] {TransportMode.car, TransportMode.pt};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(false);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(network, activityChainString, originalMode);
@@ -317,7 +313,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.walk;
 		String[] modes = new String[] {TransportMode.car, TransportMode.pt};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(true);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(facilities, activityChainString, originalMode);
@@ -334,7 +329,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.car;
 		String[] modes = new String[] {expectedMode, originalMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(true);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(facilities, activityChainString, originalMode);
@@ -351,7 +345,6 @@ public class ChooseRandomLegModeForSubtourTest {
 		String originalMode = TransportMode.car;
 		String[] modes = new String[] {expectedMode, originalMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(false);
 		Person person = PopulationUtils.getFactory().createPerson(Id.create("1000", Person.class));
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(network, activityChainString, originalMode);
@@ -366,7 +359,6 @@ public class ChooseRandomLegModeForSubtourTest {
 	private void testCarDoesntTeleport(Network network, String originalMode, String otherMode) {
 		String[] modes = new String[] {originalMode, otherMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(false);
 
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(network, activityChainString, originalMode);
@@ -401,8 +393,7 @@ public class ChooseRandomLegModeForSubtourTest {
 	private void testCarDoesntTeleport(ActivityFacilities facilities, String originalMode, String otherMode) {
 		String[] modes = new String[] {originalMode, otherMode};
 		ChooseRandomLegModeForSubtour testee = new ChooseRandomLegModeForSubtour( EmptyStageActivityTypes.INSTANCE , new MainModeIdentifierImpl() ,new AllowTheseModesForEveryone(modes), modes, CHAIN_BASED_MODES, MatsimRandom.getRandom(), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes, probaForRandomSingleTripMode);
-		testee.setAnchorSubtoursAtFacilitiesInsteadOfLinks(true);
-		
+
 		for (String activityChainString : activityChainStrings) {
 			Plan plan = createPlan(facilities, activityChainString, originalMode);
 			testee.run(plan);
@@ -441,13 +432,13 @@ public class ChooseRandomLegModeForSubtourTest {
 		final Collection<Subtour> originalSubtours =
 			TripStructureUtils.getSubtours(
 						originalPlan,
-						EmptyStageActivityTypes.INSTANCE,
-						useFacilities);
+						EmptyStageActivityTypes.INSTANCE
+			);
 		final Collection<Subtour> mutatedSubtours =
 			TripStructureUtils.getSubtours(
 						plan,
-						EmptyStageActivityTypes.INSTANCE,
-						useFacilities);
+						EmptyStageActivityTypes.INSTANCE
+			);
 
 		assertEquals(
 				"number of subtour changed",


### PR DESCRIPTION
Here is a summary of the important changes:

- MATSIM-801: coord for facility is optional (however, there will be an exception if neither link nor coord is available)
- similar to XY2Links, there is now also XY2LinkForFacilities which sets linkId for facilities if not available already
- slowly moving towards the convention in which facilities are used before activities and activities are used as fall-back option
- same convention is used to identify the subTours in TripStructureUtils