### PR TITLE
Fix some issues with Counts.

### DIFF
--- a/matsim/src/main/java/org/matsim/counts/CountsWriter.java
+++ b/matsim/src/main/java/org/matsim/counts/CountsWriter.java
@@ -26,6 +26,7 @@ import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.io.MatsimXmlWriter;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
@@ -54,36 +55,50 @@ public class CountsWriter extends MatsimXmlWriter implements MatsimWriter {
 	public final void write(final String filename) {
 		try {
 			openFile(filename);
-
-			// write custom header
-			writeXmlHead();
-
-			this.handler.startCounts(this.counts, this.writer);
-			this.handler.writeSeparator(this.writer);
-			
-			List<Count> countsTemp = new Vector<Count>();
-			countsTemp.addAll(this.counts.getCounts().values());
-			Collections.sort(countsTemp, new CountComparator());
-
-            for (Count c : countsTemp) {
-                List<Volume> volumesTemp = new Vector<Volume>();
-                volumesTemp.addAll(c.getVolumes().values());
-                Collections.sort(volumesTemp, new VolumeComparator());
-                this.handler.startCount(c, this.writer);
-                for (Volume v : volumesTemp) {
-                    this.handler.startVolume(v, this.writer);
-                    this.handler.endVolume(this.writer);
-                }
-                this.handler.endCount(this.writer);
-                this.handler.writeSeparator(this.writer);
-                this.writer.flush();
-            }
-			this.handler.endCounts(this.writer);
+			doTheWriting();
 			close();
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public final void write(final OutputStream stream) {
+		try {
+			openOutputStream(stream);
+			doTheWriting();
+			close();
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void doTheWriting() throws IOException {
+		// write custom header
+		writeXmlHead();
+
+		this.handler.startCounts(this.counts, this.writer);
+		this.handler.writeSeparator(this.writer);
+
+		List<Count> countsTemp = new Vector<Count>();
+		countsTemp.addAll(this.counts.getCounts().values());
+		Collections.sort(countsTemp, new CountComparator());
+
+					for (Count c : countsTemp) {
+							List<Volume> volumesTemp = new Vector<Volume>();
+							volumesTemp.addAll(c.getVolumes().values());
+							Collections.sort(volumesTemp, new VolumeComparator());
+							this.handler.startCount(c, this.writer);
+							for (Volume v : volumesTemp) {
+									this.handler.startVolume(v, this.writer);
+									this.handler.endVolume(this.writer);
+							}
+							this.handler.endCount(this.writer);
+							this.handler.writeSeparator(this.writer);
+							this.writer.flush();
+					}
+		this.handler.endCounts(this.writer);
 	}
 
 	@Override

--- a/matsim/src/main/resources/dtd/counts_v1.xsd
+++ b/matsim/src/main/resources/dtd/counts_v1.xsd
@@ -6,11 +6,11 @@
 
 <xsd:complexType name="countsType">	
 	<xsd:sequence>
-		<xsd:element name="count" type="countType" minOccurs="1" maxOccurs="unbounded"/>
+		<xsd:element name="count" type="countType" minOccurs="0" maxOccurs="unbounded"/>
 	</xsd:sequence>
 	<xsd:attribute name="name" type="xsd:string" use="required"/>
 	<xsd:attribute name="desc" type="xsd:string" use="optional"/>
-	<xsd:attribute name="year" type="xsd:gYear" use="required"/>
+	<xsd:attribute name="year" type="xsd:int" use="required"/>
 	<xsd:attribute name="layer" type="xsd:string" use="optional"/><!-- deprecated, should no longer be used. -->
 </xsd:complexType>
 

--- a/matsim/src/test/java/org/matsim/counts/MatsimCountsIOTest.java
+++ b/matsim/src/test/java/org/matsim/counts/MatsimCountsIOTest.java
@@ -1,0 +1,121 @@
+package org.matsim.counts;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class MatsimCountsIOTest {
+
+	/**
+	 * Such a file with year 0 could be created by MATSim when the year was not explicitly set,
+	 * but it could not be read back in as "0" was not recognized as a valid year by the XML validator originally.
+	 */
+	@Test
+	public void testReading_year0() {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<counts xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"xsi:noNamespaceSchemaLocation=\"http://matsim.org/files/dtd/counts_v1.xsd\"\n" +
+				" name=\"test\" desc=\"test counting stations\" year=\"0\"  layer=\"0\" \n" +
+				" > \n" +
+				"\n" +
+				"\t<count loc_id=\"100\" cs_id=\"005\">\n" +
+				"\t\t<volume h=\"1\" val=\"10.00\" />\n" +
+				"\t\t<volume h=\"2\" val=\"1.00\" />\n" +
+				"\t\t<volume h=\"3\" val=\"2.00\" />\n" +
+				"\t\t<volume h=\"4\" val=\"3.00\" />\n" +
+				"\t\t<volume h=\"5\" val=\"4.00\" />\n" +
+				"\t\t<volume h=\"6\" val=\"5.00\" />\n" +
+				"\t\t<volume h=\"7\" val=\"6.00\" />\n" +
+				"\t\t<volume h=\"8\" val=\"7.00\" />\n" +
+				"\t\t<volume h=\"9\" val=\"8.00\" />\n" +
+				"\t\t<volume h=\"10\" val=\"9.00\" />\n" +
+				"\t\t<volume h=\"11\" val=\"10.00\" />\n" +
+				"\t\t<volume h=\"12\" val=\"11.00\" />\n" +
+				"\t\t<volume h=\"13\" val=\"12.00\" />\n" +
+				"\t\t<volume h=\"14\" val=\"13.00\" />\n" +
+				"\t\t<volume h=\"15\" val=\"14.00\" />\n" +
+				"\t\t<volume h=\"16\" val=\"15.00\" />\n" +
+				"\t\t<volume h=\"17\" val=\"16.00\" />\n" +
+				"\t\t<volume h=\"18\" val=\"17.00\" />\n" +
+				"\t\t<volume h=\"19\" val=\"18.00\" />\n" +
+				"\t\t<volume h=\"20\" val=\"19.00\" />\n" +
+				"\t\t<volume h=\"21\" val=\"20.00\" />\n" +
+				"\t\t<volume h=\"22\" val=\"21.00\" />\n" +
+				"\t\t<volume h=\"23\" val=\"22.00\" />\n" +
+				"\t\t<volume h=\"24\" val=\"23.00\" />\n" +
+				"\t</count>\n" +
+				"</counts>\n";
+
+		Counts counts = new Counts();
+		MatsimCountsReader reader = new MatsimCountsReader(counts);
+		ByteArrayInputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+		reader.parse(stream);
+		Assert.assertEquals(1, counts.getCounts().size());
+	}
+
+	/**
+	 * originally, year was defined of type "gYear" in the xml schema, which required 4-digit years.
+	 * This test checks that such years can still be read in now that it is defined as int.
+	 */
+	@Test
+	public void testReading_year1padded() {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<counts xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"xsi:noNamespaceSchemaLocation=\"http://matsim.org/files/dtd/counts_v1.xsd\"\n" +
+				" name=\"test\" desc=\"test counting stations\" year=\"0001\"  layer=\"0\" \n" +
+				" > \n" +
+				"\n" +
+				"\t<count loc_id=\"100\" cs_id=\"005\">\n" +
+				"\t\t<volume h=\"1\" val=\"10.00\" />\n" +
+				"\t\t<volume h=\"2\" val=\"1.00\" />\n" +
+				"\t\t<volume h=\"3\" val=\"2.00\" />\n" +
+				"\t\t<volume h=\"4\" val=\"3.00\" />\n" +
+				"\t\t<volume h=\"5\" val=\"4.00\" />\n" +
+				"\t\t<volume h=\"6\" val=\"5.00\" />\n" +
+				"\t\t<volume h=\"7\" val=\"6.00\" />\n" +
+				"\t\t<volume h=\"8\" val=\"7.00\" />\n" +
+				"\t\t<volume h=\"9\" val=\"8.00\" />\n" +
+				"\t\t<volume h=\"10\" val=\"9.00\" />\n" +
+				"\t\t<volume h=\"11\" val=\"10.00\" />\n" +
+				"\t\t<volume h=\"12\" val=\"11.00\" />\n" +
+				"\t\t<volume h=\"13\" val=\"12.00\" />\n" +
+				"\t\t<volume h=\"14\" val=\"13.00\" />\n" +
+				"\t\t<volume h=\"15\" val=\"14.00\" />\n" +
+				"\t\t<volume h=\"16\" val=\"15.00\" />\n" +
+				"\t\t<volume h=\"17\" val=\"16.00\" />\n" +
+				"\t\t<volume h=\"18\" val=\"17.00\" />\n" +
+				"\t\t<volume h=\"19\" val=\"18.00\" />\n" +
+				"\t\t<volume h=\"20\" val=\"19.00\" />\n" +
+				"\t\t<volume h=\"21\" val=\"20.00\" />\n" +
+				"\t\t<volume h=\"22\" val=\"21.00\" />\n" +
+				"\t\t<volume h=\"23\" val=\"22.00\" />\n" +
+				"\t\t<volume h=\"24\" val=\"23.00\" />\n" +
+				"\t</count>\n" +
+				"</counts>\n";
+
+		Counts counts = new Counts();
+		MatsimCountsReader reader = new MatsimCountsReader(counts);
+		ByteArrayInputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+		reader.parse(stream);
+		Assert.assertEquals(1, counts.getCounts().size());
+	}
+
+	@Test
+	public void testDefaultYear_empty() {
+		Counts counts = new Counts();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		new CountsWriter(counts).write(out);
+
+		Counts counts2 = new Counts();
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		new MatsimCountsReader(counts2).parse(in);
+		// there should not have been an Exception
+	}
+
+}


### PR DESCRIPTION
A new, empty counts container could be created and written out. But it could not be read back in because the XML-Schema defined that there must be at least 1 counting station in the file (why?), and because the (required) year was initially set to 0, which was not accepted as a valid year (actually, "1" would also not be accepted by the XML parser, but "0001" would have been accpted). Changing the year-attribute to int, so "0" is also supported.
Adding tests for these things.