### PR TITLE
Drt request rejection

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModePassengerStats.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModePassengerStats.java
@@ -184,6 +184,9 @@ public class DynModePassengerStats implements PersonEntersVehicleEventHandler, P
 					throw new NullPointerException("Arrival without departure?");
 				}
 			}
+			
+			// remove person in case the person has trips with dvrp and non-dvrp modes
+			this.departureTimes.remove(event.getPersonId());
 		}
 
 	}


### PR DESCRIPTION
Apparently, rejected DRT trips are handled in a way that the person is teleported to it's destination. I think that's ok, but I don't really understand why the DefaultTeleportationEngine is taking over...

* minor changes to avoid a runtime exception thrown by some analysis class in case there are rejected trips
* adding a test in which the drt request of one person should be rejected