### PR TITLE
throwing a person stuck and abort event in case a request is rejected

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.events.PersonStuckEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.data.DrtRequest;
 import org.matsim.contrib.drt.data.validator.DrtRequestValidator;
@@ -145,6 +146,7 @@ public class DefaultDrtOptimizer implements DrtOptimizer {
 			drtRequest.setRejected(true);
 			eventsManager.processEvent(
 					new DrtRequestRejectedEvent(mobsimTimer.getTimeOfDay(), drtRequest.getId(), causes));
+			eventsManager.processEvent(new PersonStuckEvent(mobsimTimer.getTimeOfDay(), drtRequest.getPassenger().getId(), drtRequest.getFromLink().getId(), drtRequest.getPassenger().getMode()));
 			return;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
 import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.events.PersonStuckEvent;
 import org.matsim.contrib.drt.data.DrtRequest;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.insertion.SingleVehicleInsertionProblem.BestInsertion;
@@ -97,6 +98,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 				req.setRejected(true);
 				eventsManager.processEvent(
 						new DrtRequestRejectedEvent(mobsimTimer.getTimeOfDay(), req.getId(), NO_INSERTION_FOUND_CAUSE));
+				eventsManager.processEvent(new PersonStuckEvent(mobsimTimer.getTimeOfDay(), req.getPassenger().getId(), req.getFromLink().getId(), req.getPassenger().getMode()));
 				if (drtCfg.isPrintDetailedWarnings()) {
 					log.warn("No insertion found for drt request " + req + " from passenger id=" + req.getPassenger()
 							.getId() + " fromLinkId=" + req.getFromLink().getId());


### PR DESCRIPTION
Thanks for your changes @michalmac.

Let us additionally throw a person stuck and abort event, ok?
This way, we make sure the agent gets a bad score and the consequences of the rejection are more visible when analyzing events.

In the longterm, I would still say, we need a switch to either take the agents out of the simulation (current implementation) or teleport the agents to their destination (and additionally throw a person stuck event).