### PR TITLE
add mobsimMode to support other modes than "car"

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
@@ -21,52 +21,30 @@ package org.matsim.contrib.drt.passenger;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.contrib.drt.data.DrtRequest;
-import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.routing.DrtRoute;
-import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.data.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
-import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
-import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.framework.PlanAgent;
-import org.matsim.core.router.FastAStarEuclideanFactory;
-import org.matsim.core.router.util.LeastCostPathCalculator;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
  */
 public class DrtRequestCreator implements PassengerRequestCreator {
-	private final DrtConfigGroup drtCfg;
-	private final TravelTime travelTime;
-	private final LeastCostPathCalculator router;
 	private final EventsManager eventsManager;
 	private final MobsimTimer timer;
 
 	@Inject
-	public DrtRequestCreator(DrtConfigGroup drtCfg, @Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, EventsManager eventsManager,
-			MobsimTimer timer, @Named(DefaultDrtOptimizer.DRT_OPTIMIZER) TravelDisutility travelDisutility) {
-		this.drtCfg = drtCfg;
-		this.travelTime = travelTime;
+	public DrtRequestCreator(EventsManager eventsManager, MobsimTimer timer) {
 		this.eventsManager = eventsManager;
 		this.timer = timer;
-		// Euclidean with overdoFactor > 1.0 could lead to 'experiencedTT < unsharedRideTT',
-		// while the benefit would be a marginal reduction of computation time ==> so stick to 1.0
-		router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime);
 	}
 
 	@Override
@@ -76,7 +54,6 @@ public class DrtRequestCreator implements PassengerRequestCreator {
 		//XXX this will not work if pre-booking is allowed in DRT
 		Leg leg = (Leg)((PlanAgent)passenger).getCurrentPlanElement();
 		DrtRoute drtRoute = (DrtRoute)leg.getRoute();
-
 		double latestDepartureTime = departureTime + drtRoute.getMaxWaitTime();
 		double latestArrivalTime = departureTime + drtRoute.getTravelTime();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
 import org.matsim.contrib.dvrp.passenger.BusStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerEngine;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
@@ -46,9 +47,10 @@ public class DrtActionCreator implements VrpAgentLogic.DynActionCreator {
 	private final VrpLegFactory legFactory;
 
 	@Inject
-	public DrtActionCreator(PassengerEngine passengerEngine, VrpOptimizer optimizer, MobsimTimer timer) {
-		this(passengerEngine,
-				v -> VrpLegFactory.createWithOnlineTracker(v, (VrpOptimizerWithOnlineTracking)optimizer, timer));
+	public DrtActionCreator(PassengerEngine passengerEngine, VrpOptimizer optimizer, MobsimTimer timer,
+			DvrpConfigGroup dvrpCfg) {
+		this(passengerEngine, v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v,
+				(VrpOptimizerWithOnlineTracking)optimizer, timer));
 	}
 
 	public DrtActionCreator(PassengerEngine passengerEngine, VrpLegFactory legFactory) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiActionCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiActionCreator.java
@@ -20,10 +20,18 @@
 package org.matsim.contrib.dvrp.examples.onetaxi;
 
 import org.matsim.contrib.dvrp.data.Vehicle;
-import org.matsim.contrib.dvrp.passenger.*;
-import org.matsim.contrib.dvrp.schedule.*;
-import org.matsim.contrib.dvrp.vrpagent.*;
-import org.matsim.contrib.dynagent.*;
+import org.matsim.contrib.dvrp.passenger.PassengerEngine;
+import org.matsim.contrib.dvrp.passenger.SinglePassengerDropoffActivity;
+import org.matsim.contrib.dvrp.passenger.SinglePassengerPickupActivity;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.schedule.DriveTask;
+import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
+import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
+import org.matsim.contrib.dynagent.DynAction;
+import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.QSim;
 
@@ -35,18 +43,20 @@ import com.google.inject.Inject;
 final class OneTaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 	private final PassengerEngine passengerEngine;
 	private final MobsimTimer timer;
+	private final String mobsimMode;
 
 	@Inject
-	public OneTaxiActionCreator(PassengerEngine passengerEngine, QSim qSim) {
+	public OneTaxiActionCreator(PassengerEngine passengerEngine, QSim qSim, DvrpConfigGroup dvrpCfg) {
 		this.passengerEngine = passengerEngine;
 		this.timer = qSim.getSimTimer();
+		this.mobsimMode = dvrpCfg.getMobsimMode();
 	}
 
 	@Override
 	public DynAction createAction(DynAgent dynAgent, Vehicle vehicle, double now) {
-		Task task = vehicle.getSchedule().getCurrentTask(); 
+		Task task = vehicle.getSchedule().getCurrentTask();
 		if (task instanceof DriveTask) {
-			return VrpLegFactory.createWithOfflineTracker(vehicle, timer);
+			return VrpLegFactory.createWithOfflineTracker(mobsimMode, vehicle, timer);
 		} else if (task instanceof OneTaxiServeTask) { // PICKUP or DROPOFF
 			final OneTaxiServeTask serveTask = (OneTaxiServeTask)task;
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckActionCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckActionCreator.java
@@ -19,13 +19,14 @@
 
 package org.matsim.contrib.dvrp.examples.onetruck;
 
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dvrp.data.Vehicle;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.contrib.dynagent.DynAction;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.contrib.dynagent.StaticDynActivity;
@@ -49,9 +50,10 @@ final class OneTruckActionCreator implements VrpAgentLogic.DynActionCreator {
 	public DynAction createAction(DynAgent dynAgent, Vehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
 		if (task instanceof DriveTask) {
-			return VrpLegFactory.createWithOfflineTracker(vehicle, timer);
+			return VrpLegFactory.createWithOfflineTracker(TransportMode.truck, vehicle, timer);
 		} else if (task instanceof OneTruckServeTask) { // PICKUP or DROPOFF
-			return new StaticDynActivity(((OneTruckServeTask)task).isPickup() ? "pickup" : "dropoff", task.getEndTime());
+			return new StaticDynActivity(((OneTruckServeTask)task).isPickup() ? "pickup" : "dropoff",
+					task.getEndTime());
 		} else { // WAIT
 			return new VrpActivity("OneTaxiStay", (StayTask)task);
 		}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
@@ -34,6 +34,7 @@ import org.matsim.core.config.ReflectiveConfigGroup;
 public class DvrpConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String GROUP_NAME = "dvrp";
+
 	@SuppressWarnings("deprecation")
 	public static DvrpConfigGroup get(Config config) {
 		return (DvrpConfigGroup)config.getModule(GROUP_NAME);// will fail if not in the config
@@ -44,16 +45,23 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 			+ "(passengers'/customers' perspective)";
 
 	public static final String NETWORK_MODE = "networkMode";
-	static final String NETWORK_MODE_EXP = "Mode of which the network will be used for routing vehicles, calculating travel times, "
-			+ "etc. (fleet operator's perspective). " + "Default is car.";
+	static final String NETWORK_MODE_EXP = "Mode of which the network will be used for routing vehicles. "
+			+ "Default is car, i.e. the car network is used. "
+			+ "'null' means no network filtering - the scenario.network is used";
+
+	public static final String MOBSIM_MODE = "mobsimMode";
+	static final String MOBSIM_MODE_EXP =
+			"Mode of which the network will be used for throwing events and hence calculating travel times. "
+					+ "Default is car.";
 
 	public static final String TRAVEL_TIME_ESTIMATION_ALPHA = "travelTimeEstimationAlpha";
-	static final String TRAVEL_TIME_ESTIMATION_ALPHA_EXP = "Used for OFFLINE estimation of travel times for VrpOptimizer"
-			+ " by means of the exponential moving average."
-			+ " The weighting decrease, alpha, must be in (0,1]."
-			+ " We suggest small values of alpha, e.g. 0.05."
-			+ " The averaging starts from the initial travel time estimates. If not provided,"
-			+ " the free-speed TTs is used as the initial estimates";
+	static final String TRAVEL_TIME_ESTIMATION_ALPHA_EXP =
+			"Used for OFFLINE estimation of travel times for VrpOptimizer"
+					+ " by means of the exponential moving average."
+					+ " The weighting decrease, alpha, must be in (0,1]."
+					+ " We suggest small values of alpha, e.g. 0.05."
+					+ " The averaging starts from the initial travel time estimates. If not provided,"
+					+ " the free-speed TTs is used as the initial estimates";
 
 	public static final String TRAVEL_TIME_ESTIMATION_BETA = "travelTimeEstimationBeta";
 	static final String TRAVEL_TIME_ESTIMATION_BETA_EXP = "Used for ONLINE estimation of travel times for VrpOptimizer"
@@ -61,7 +69,8 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 			+ " The beta coefficient is provided in seconds and should be either 0 (no online estimation)"
 			+ " or positive (mixed online-offline estimation)."
 			/////
-			+ " For 'beta = 0', only the offline estimate is used:" + " 'onlineTT(t) = offlineTT(t)',"
+			+ " For 'beta = 0', only the offline estimate is used:"
+			+ " 'onlineTT(t) = offlineTT(t)',"
 			+ " where 'offlineTT(t)' in the offline estimate for TT at time 't',"
 			/////
 			+ " For 'beta > 0', estimating future TTs at time 't',"
@@ -78,12 +87,14 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	// In DVRP 'time < currentTime' may only happen for backward path search, a adding proper search termination
 	// criterion should prevent this from happening
 
-	@NotNull
+	@NotBlank
 	private String mode = null; // travel mode (passengers'/customers' perspective)
 
 	@Nullable
-	private String networkMode = TransportMode.car; // used for building routes, calculating travel times, etc.
-	// (dispatcher's perspective); null ==> no filtering (routing network equals scenario.network)
+	private String networkMode = TransportMode.car; // used for building route; null ==> no filtering (routing network equals scenario.network)
+
+	@NotBlank
+	private String mobsimMode = TransportMode.car;// used for events throwing and thus calculating travel times, etc.
 
 	@Positive
 	@Max(1)
@@ -101,15 +112,13 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 		Map<String, String> map = super.getComments();
 		map.put(MODE, MODE_EXP);
 		map.put(NETWORK_MODE, NETWORK_MODE_EXP);
-		map.put(TRAVEL_TIME_ESTIMATION_ALPHA, //
-				TRAVEL_TIME_ESTIMATION_ALPHA_EXP);
-		map.put(TRAVEL_TIME_ESTIMATION_BETA,
-				TRAVEL_TIME_ESTIMATION_BETA_EXP);
+		map.put(MOBSIM_MODE, MOBSIM_MODE_EXP);
+		map.put(TRAVEL_TIME_ESTIMATION_ALPHA, TRAVEL_TIME_ESTIMATION_ALPHA_EXP);
+		map.put(TRAVEL_TIME_ESTIMATION_BETA, TRAVEL_TIME_ESTIMATION_BETA_EXP);
 		return map;
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #MODE_EXP}}
 	 */
 	@StringGetter(MODE)
@@ -118,15 +127,14 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @param -- {@value #MODE_EXP}
 	 */
 	@StringSetter(MODE)
 	public void setMode(String mode) {
 		this.mode = mode;
 	}
+
 	/**
-	 * 
 	 * @return -- {@value #NETWORK_MODE_EXP}
 	 */
 	@StringGetter(NETWORK_MODE)
@@ -135,16 +143,30 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @param -- {@value #NETWORK_MODE_EXP}
 	 */
 	@StringSetter(NETWORK_MODE)
-	public void setNetworkMode(String routingMode) {
-		this.networkMode = routingMode;
+	public void setNetworkMode(String networkMode) {
+		this.networkMode = networkMode;
 	}
 
 	/**
-	 * 
+	 * @return -- {@value #MOBSIM_MODE_EXP}
+	 */
+	@StringGetter(MOBSIM_MODE)
+	public String getMobsimMode() {
+		return mobsimMode;
+	}
+
+	/**
+	 * @param -- {@value #MOBSIM_MODE_EXP}
+	 */
+	@StringSetter(MOBSIM_MODE)
+	public void setMobsimMode(String networkMode) {
+		this.mobsimMode = networkMode;
+	}
+
+	/**
 	 * @return -- {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
 	 */
 	@StringGetter(TRAVEL_TIME_ESTIMATION_ALPHA)
@@ -153,7 +175,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @value -- {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
 	 */
 	@StringSetter(TRAVEL_TIME_ESTIMATION_ALPHA)
@@ -162,7 +183,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
 	 */
 	@StringGetter(TRAVEL_TIME_ESTIMATION_BETA)
@@ -171,7 +191,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @param -- {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
 	 */
 	@StringSetter(TRAVEL_TIME_ESTIMATION_BETA)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -21,7 +21,12 @@ package org.matsim.contrib.dvrp.trafficmonitoring;
 
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -31,15 +36,19 @@ public class DvrpTravelTimeModule extends AbstractModule {
 	public static final String DVRP_OBSERVED = "dvrp_observed";
 	public static final String DVRP_ESTIMATED = "dvrp_estimated";
 
+	@Inject
+	private DvrpConfigGroup dvrpCfg;
+
 	public void install() {
 		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).to(QSimFreeSpeedTravelTime.class).asEagerSingleton();
-		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_OBSERVED).to(networkTravelTime());
+		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_OBSERVED).to(
+				Key.get(TravelTime.class, Names.named(dvrpCfg.getMobsimMode())));
 		addTravelTimeBinding(DVRP_ESTIMATED).to(DvrpTravelTimeEstimator.class);
 
 		bind(DvrpOfflineTravelTimeEstimator.class).asEagerSingleton();
 		addMobsimListenerBinding().to(DvrpOfflineTravelTimeEstimator.class);
 
-		if (DvrpConfigGroup.get(getConfig()).getTravelTimeEstimationBeta() > 0) {// online estimation
+		if (dvrpCfg.getTravelTimeEstimationBeta() > 0) {// online estimation
 			bind(DvrpOnlineTravelTimeEstimator.class).asEagerSingleton();
 			addMobsimListenerBinding().to(DvrpOnlineTravelTimeEstimator.class);
 			bind(DvrpTravelTimeEstimator.class).to(DvrpOnlineTravelTimeEstimator.class);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLeg.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLeg.java
@@ -39,9 +39,10 @@ public class VrpLeg implements DivertibleLeg {
 	private int currentLinkIdx = 0;
 	private boolean askedAboutNextLink = false;
 
-	private final String mode = TransportMode.car;// TODO
+	private final String mode;
 
-	public VrpLeg(VrpPath path) {
+	public VrpLeg(String mode, VrpPath path) {
+		this.mode = mode;
 		this.path = path;
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLegFactory.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLegFactory.java
@@ -29,23 +29,22 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
  */
 public interface VrpLegFactory {
 	/**
-	 * @param vehicle
-	 *            for which the leg is created
+	 * @param vehicle for which the leg is created
 	 * @return fully initialised VrpLeg (e.g. with online tracking, etc.)
 	 */
 	VrpLeg create(Vehicle vehicle);
 
-	static VrpLeg createWithOfflineTracker(Vehicle vehicle, MobsimTimer timer) {
+	static VrpLeg createWithOfflineTracker(String mode, Vehicle vehicle, MobsimTimer timer) {
 		DriveTask driveTask = (DriveTask)vehicle.getSchedule().getCurrentTask();
-		VrpLeg leg = new VrpLeg(driveTask.getPath());
+		VrpLeg leg = new VrpLeg(mode, driveTask.getPath());
 		TaskTrackers.initOfflineTaskTracking(driveTask, timer);
 		return leg;
 	}
 
-	static VrpLeg createWithOnlineTracker(Vehicle vehicle, VrpOptimizerWithOnlineTracking optimizer,
+	static VrpLeg createWithOnlineTracker(String mode, Vehicle vehicle, VrpOptimizerWithOnlineTracking optimizer,
 			MobsimTimer timer) {
 		DriveTask driveTask = (DriveTask)vehicle.getSchedule().getCurrentTask();
-		VrpLeg leg = new VrpLeg(driveTask.getPath());
+		VrpLeg leg = new VrpLeg(mode, driveTask.getPath());
 		TaskTrackers.initOnlineDriveTaskTracking(vehicle, leg, optimizer, timer);
 		return leg;
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
@@ -25,9 +25,10 @@ import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
 import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.SinglePassengerDropoffActivity;
 import org.matsim.contrib.dvrp.passenger.SinglePassengerPickupActivity;
-import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.contrib.dynagent.DynAction;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -53,11 +54,11 @@ public class TaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 
 	@Inject
 	public TaxiActionCreator(PassengerEngine passengerEngine, TaxiConfigGroup taxiCfg, VrpOptimizer optimizer,
-			MobsimTimer timer) {
-		this(passengerEngine, //
-				taxiCfg.isOnlineVehicleTracker() //
-						? v -> VrpLegFactory.createWithOnlineTracker(v, (VrpOptimizerWithOnlineTracking)optimizer, timer)
-						: v -> VrpLegFactory.createWithOfflineTracker(v, timer), //
+			MobsimTimer timer, DvrpConfigGroup dvrpCfg) {
+		this(passengerEngine, taxiCfg.isOnlineVehicleTracker() ?
+						v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v,
+								(VrpOptimizerWithOnlineTracking)optimizer, timer) :
+						v -> VrpLegFactory.createWithOfflineTracker(dvrpCfg.getMobsimMode(), v, timer),
 				taxiCfg.getPickupDuration());
 	}
 


### PR DESCRIPTION
Now we can physically simulate truck or bike deliveries.

`RunOneTruckExample` shows how to set up a scenario where we use modes other than "car" and we do not transport passengers.