### PR TITLE
 move 'mode' from dvrp config down to taxi and drt configs

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
@@ -18,7 +18,7 @@
  * *********************************************************************** */
 
 /**
- * 
+ *
  */
 package org.matsim.contrib.av.intermodal;
 
@@ -40,9 +40,9 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 /**
- * @author  jbischoff
- *
+ * @author jbischoff
  */
+
 /**
  *
  */
@@ -84,12 +84,15 @@ public class RunTaxiPTIntermodalExample {
 
 		config.addConfigConsistencyChecker(new TaxiConfigConsistencyChecker());
 		config.checkConsistency();
+
+		String mode = TaxiConfigGroup.get(config).getMode();
+
 		// ---
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 
 		Controler controler = new Controler(scenario);
 
-		controler.addOverridingModule(TaxiDvrpModules.create());
+		controler.addOverridingModule(TaxiDvrpModules.create(mode));
 
 		controler.addOverridingModule(new TaxiModule());
 

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
@@ -41,9 +41,7 @@ import org.matsim.vis.otfvis.OTFVisConfigGroup;
  * should run out of the box without any additional files. If required, you may find all input files in the resource
  * path or in the jar maven has downloaded). There are two vehicle files: 2000 vehicles and 5000, which may be set in
  * the config. Different fleet sizes can be created using
- * {@link org.matsim.contrib.robotaxi.vehicles.CreateTaxiVehicles}
- * 
- * 
+ * {@link org.matsim.contrib.av.robotaxi.vehicles.CreateTaxiVehicles}
  */
 public class RunRobotaxiExample {
 
@@ -61,6 +59,7 @@ public class RunRobotaxiExample {
 	public static Controler createControler(Config config, boolean otfvis) {
 		config.addConfigConsistencyChecker(new TaxiConfigConsistencyChecker());
 		config.checkConsistency();
+		String mode = TaxiConfigGroup.get(config).getMode();
 
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 
@@ -71,7 +70,7 @@ public class RunRobotaxiExample {
 				addEventHandlerBinding().to(TaxiFareHandler.class).asEagerSingleton();
 			}
 		});
-		controler.addOverridingModule(TaxiDvrpModules.create());
+		controler.addOverridingModule(TaxiDvrpModules.create(mode));
 		controler.addOverridingModule(new TaxiModule());
 
 		if (otfvis) {

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandler.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandler.java
@@ -41,6 +41,7 @@ import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.vehicles.Vehicle;
@@ -81,7 +82,7 @@ public class TaxiFareHandler implements LinkEnterEventHandler, PersonEntersVehic
 	@Inject
 	public TaxiFareHandler(Config config, EventsManager events, Network network) {
 		TaxiFareConfigGroup taxiFareConfigGroup = TaxiFareConfigGroup.get(config);
-		this.mode = DvrpConfigGroup.get(config).getMode();
+		this.mode = TaxiConfigGroup.get(config).getMode();
 		this.events= events;
 		this.network = network;
 		this.distanceFare_Meter = taxiFareConfigGroup.getDistanceFare_m();

--- a/contribs/av/src/main/resources/cottbus_robotaxi/config.xml
+++ b/contribs/av/src/main/resources/cottbus_robotaxi/config.xml
@@ -17,9 +17,6 @@
 	</module>
 
 	<module name="dvrp">
-	<!-- Mode of which the agent is traveling on-->
-		<param name="mode" value="taxi" />
-		
 		<!-- Mode of which the network will be used for routing vehicles, calculating trave times etc. (fleet operator's perspective).
 					If null, no mode filtering is done; the standard network (Scenario.getNetwork()) is used - usually, car -->
 		<param name="networkMode" value="null"/>

--- a/contribs/av/src/main/resources/intermodal/config.xml
+++ b/contribs/av/src/main/resources/intermodal/config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">

--- a/contribs/av/src/test/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandlerTest.java
+++ b/contribs/av/src/test/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandlerTest.java
@@ -22,8 +22,6 @@
  */
 package org.matsim.contrib.av.robotaxi.scoring;
 
-import static org.junit.Assert.*;
-
 import org.apache.commons.lang.mutable.MutableDouble;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,8 +36,7 @@ import org.matsim.api.core.v01.events.handler.PersonMoneyEventHandler;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.taxi.run.*;
+import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -51,13 +48,10 @@ import org.matsim.vehicles.Vehicle;
  * @author  jbischoff
  *
  */
-/**
- *
- */
 public class TaxiFareHandlerTest {
 
 	/**
-	 * Test method for {@link org.matsim.contrib.av.robotaxi.scoring.TaxiFareHandler#TaxiFareHandler(org.matsim.core.config.Config)}.
+	 * Test method for {@link TaxiFareHandler#TaxiFareHandler(Config, EventsManager, Network)}.
 	 */
 	@Test
 	public void testTaxiFareHandler() {
@@ -69,10 +63,9 @@ public class TaxiFareHandlerTest {
 		tccg.setDailySubscriptionFee(1);
 		tccg.setDistanceFare_m(1.0/1000.0);
 		tccg.setTimeFare_h(36);
-		DvrpConfigGroup dvrp = new DvrpConfigGroup();
-		dvrp.setMode("taxi");
-		config.addModule(dvrp);
-		final MutableDouble fare = new MutableDouble(0); 
+		TaxiConfigGroup taxiCfg = new TaxiConfigGroup();
+		config.addModule(taxiCfg);
+		final MutableDouble fare = new MutableDouble(0);
 		EventsManager events = EventsUtils.createEventsManager();
 		TaxiFareHandler tfh = new TaxiFareHandler(config, events, network);
 		events.addHandler(tfh);
@@ -89,15 +82,15 @@ public class TaxiFareHandlerTest {
 		});
 		Id<Person> p1 = Id.createPersonId("p1");
 		Id<Vehicle> t1= Id.createVehicleId("v1"); 
-		events.processEvent(new PersonDepartureEvent(0.0, p1 , Id.createLinkId("12"), dvrp.getMode()));
+		events.processEvent(new PersonDepartureEvent(0.0, p1 , Id.createLinkId("12"), taxiCfg.getMode()));
 		events.processEvent(new PersonEntersVehicleEvent(60.0, p1 , t1));
 		events.processEvent(new LinkEnterEvent(61,t1,Id.createLinkId("23")));
-		events.processEvent(new PersonArrivalEvent(120.0, p1, Id.createLinkId("23"), dvrp.getMode()));
+		events.processEvent(new PersonArrivalEvent(120.0, p1, Id.createLinkId("23"), taxiCfg.getMode()));
 		
-		events.processEvent(new PersonDepartureEvent(180.0, p1 , Id.createLinkId("12"), dvrp.getMode()));
+		events.processEvent(new PersonDepartureEvent(180.0, p1 , Id.createLinkId("12"), taxiCfg.getMode()));
 		events.processEvent(new PersonEntersVehicleEvent(240.0, p1 , t1));
 		events.processEvent(new LinkEnterEvent(241,t1,Id.createLinkId("23")));
-		events.processEvent(new PersonArrivalEvent(300.0, p1, Id.createLinkId("23"), dvrp.getMode()));
+		events.processEvent(new PersonArrivalEvent(300.0, p1, Id.createLinkId("23"), taxiCfg.getMode()));
 		
 		//fare: 1 (daily fee) +2*1(basefare)+ 2*1 (distance) + (36/60)*2 = -(1+2+2+0,12) = -6.2 
 		Assert.assertEquals(-6.2, fare.getValue());

--- a/contribs/av/src/test/resources/intermodal_scenario/config.xml
+++ b/contribs/av/src/test/resources/intermodal_scenario/config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModePassengerStats.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DynModePassengerStats.java
@@ -49,12 +49,11 @@ import org.matsim.contrib.drt.passenger.events.DrtRequestRejectedEvent;
 import org.matsim.contrib.drt.passenger.events.DrtRequestRejectedEventHandler;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEventHandler;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.data.Request;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.config.Config;
 import org.matsim.vehicles.Vehicle;
 
 import com.google.inject.Inject;
@@ -91,8 +90,8 @@ public class DynModePassengerStats
 	 *
 	 */
 	@Inject
-	public DynModePassengerStats(Network network, EventsManager events, Config config, Fleet fleet) {
-		this.mode = ((DvrpConfigGroup)config.getModules().get(DvrpConfigGroup.GROUP_NAME)).getMode();
+	public DynModePassengerStats(Network network, EventsManager events, DrtConfigGroup drtCfg, Fleet fleet) {
+		this.mode = drtCfg.getMode();
 		this.network = network;
 		events.addHandler(this);
 		maxcap = DynModeTripsAnalyser.findMaxCap(fleet);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregator.java
@@ -18,7 +18,7 @@
  * *********************************************************************** */
 
 /**
- * 
+ *
  */
 package org.matsim.contrib.drt.analysis.zonal;
 
@@ -33,13 +33,11 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.events.PersonDepartureEvent;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.utils.misc.Time;
 
 /**
  * @author jbischoff
- *
  */
 public class ZonalDemandAggregator implements PersonDepartureEventHandler {
 
@@ -50,10 +48,9 @@ public class ZonalDemandAggregator implements PersonDepartureEventHandler {
 	private final Map<Double, Map<String, MutableInt>> previousIterationDepartures = new HashMap<>();
 
 	@Inject
-	public ZonalDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, DvrpConfigGroup dvrpCfg,
-			DrtConfigGroup drtCfg) {
+	public ZonalDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
-		mode = dvrpCfg.getMode();
+		mode = drtCfg.getMode();
 		timeBinSize = drtCfg.getMinCostFlowRebalancing().getInterval();
 		events.addHandler(this);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtMainModeIdentifier.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtMainModeIdentifier.java
@@ -4,8 +4,7 @@ import java.util.List;
 
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.PlanElement;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.core.config.Config;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.MainModeIdentifierImpl;
 
@@ -16,8 +15,8 @@ public class DrtMainModeIdentifier implements MainModeIdentifier{
 	private final MainModeIdentifier delegate = new MainModeIdentifierImpl();
 	private final String mode;
 	@Inject
-	public DrtMainModeIdentifier(Config config) {
-		mode = DvrpConfigGroup.get(config).getMode();
+	public DrtMainModeIdentifier(DrtConfigGroup drtCfg) {
+		mode = drtCfg.getMode();
 	}
 	
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -86,7 +86,8 @@ public class DrtRoutingModule implements RoutingModule {
 		Link toLink = getLink(toFacility);
 		if (toLink == fromLink) {
 			if (drtCfg.isPrintDetailedWarnings()) {
-				LOGGER.error("Start and end stop are the same, agent will walk using mode " + DrtStageActivityType.DRT_WALK + ". Agent Id:\t" + person.getId());
+				LOGGER.error("Start and end stop are the same, agent will walk using mode "
+						+ DrtStageActivityType.DRT_WALK + ". Agent Id:\t" + person.getId());
 			}
             Leg leg = (Leg) walkRouter.calcRoute(fromFacility, toFacility, departureTime, person).get(0);
             leg.setMode(DrtStageActivityType.DRT_WALK);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
@@ -78,18 +78,18 @@ public class StopBasedDrtRoutingModule implements RoutingModule {
 		TransitStopFacility accessFacility = stops.getLeft();
 		if (accessFacility == null) {
 			printError(() -> "No access stop found, agent will walk, using mode " + DrtStageActivityType.DRT_WALK + ". Agent Id:\t" + person.getId());
-            return (Collections.singletonList((createDrtWalkLeg(fromFacility, toFacility, departureTime, person))));
+            return Collections.singletonList(createDrtWalkLeg(fromFacility, toFacility, departureTime, person));
 		}
 
 		TransitStopFacility egressFacility = stops.getRight();
 		if (egressFacility == null) {
 			printError(() -> "No egress stop found, agent will walk, using mode " + DrtStageActivityType.DRT_WALK + ". Agent Id:\t" + person.getId());
-            return (Collections.singletonList((createDrtWalkLeg(fromFacility, toFacility, departureTime, person))));
+            return Collections.singletonList(createDrtWalkLeg(fromFacility, toFacility, departureTime, person));
 		}
 
 		if (accessFacility.getLinkId() == egressFacility.getLinkId()) {
 			printError(() -> "Start and end stop are the same, agent will walk, using mode " + DrtStageActivityType.DRT_WALK + ". Agent Id:\t" + person.getId());
-            return (Collections.singletonList((createDrtWalkLeg(fromFacility, toFacility, departureTime, person))));
+            return Collections.singletonList(createDrtWalkLeg(fromFacility, toFacility, departureTime, person));
 		}
 
 		List<PlanElement> trip = new ArrayList<>();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -19,20 +19,23 @@
 
 package org.matsim.contrib.drt.run;
 
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
-import java.net.URL;
-import java.util.Collection;
-import java.util.Map;
 
 public class DrtConfigGroup extends ReflectiveConfigGroup {
 
@@ -43,6 +46,10 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 		return (DrtConfigGroup)config.getModule(GROUP_NAME);
 	}
 
+	public static final String MODE = "mode";
+	static final String MODE_EXP = "Mode which will be handled by PassengerEngine and VrpOptimizer "
+			+ "(passengers'/customers' perspective)";
+
 	public static final String STOP_DURATION = "stopDuration";
 	static final String STOP_DURATION_EXP = "Bus stop duration.";
 
@@ -50,14 +57,16 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	static final String MAX_WAIT_TIME_EXP = "Max wait time for the bus to come (optimisation constraint).";
 
 	public static final String MAX_TRAVEL_TIME_ALPHA = "maxTravelTimeAlpha";
-	static final String MAX_TRAV_ALPHA_EXP = "Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. "
-			+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
-			+ "Alpha should not be smaller than 1.";
+	static final String MAX_TRAV_ALPHA_EXP =
+			"Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. "
+					+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
+					+ "Alpha should not be smaller than 1.";
 
 	public static final String MAX_TRAVEL_TIME_BETA = "maxTravelTimeBeta";
-	static final String MAX_TRAVEL_TIME_BETA_EXP = "Defines the shift of the maxTravelTime estimation function (optimisation constraint), i.e. "
-			+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
-			+ "Beta should not be smaller than 0.";
+	static final String MAX_TRAVEL_TIME_BETA_EXP =
+			"Defines the shift of the maxTravelTime estimation function (optimisation constraint), i.e. "
+					+ "maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. "
+					+ "Beta should not be smaller than 0.";
 
 	public static final String REQUEST_REJECTION = "requestRejection";
 	static final String REQUEST_REJECTION_EXP = "If true, the max travel and wait times of a submitted request"
@@ -67,10 +76,10 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 			+ " it relatively less attractive). Penalisation of insertions can be customised by injecting a customised"
 			+ " InsertionCostCalculator.PenaltyCalculator";
 
-
 	public static final String CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE = "changeStartLinkToLastLinkInSchedule";
-	static final String CHANGE_START_EXP = "If true, the startLink is changed to last link in the current schedule, so the taxi starts the next "
-			+ "day at the link where it stopped operating the day before. False by default.";
+	static final String CHANGE_START_EXP =
+			"If true, the startLink is changed to last link in the current schedule, so the taxi starts the next "
+					+ "day at the link where it stopped operating the day before. False by default.";
 
 	public static final String IDLE_VEHICLES_RETURN_TO_DEPOTS = "idleVehiclesReturnToDepots";
 	static final String IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP = "Idle vehicles return to the nearest of all start links. See: Vehicle.getStartLink()";
@@ -82,8 +91,9 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	static final String MAX_WALK_EXP = "Maximum desired walk distance (in meters) to next stop location in stopbased system. If no suitable stop is found in that range, the search radius will be extended in steps of maxWalkDistance until a stop is found.";
 
 	public static final String ESTIMATED_DRT_SPEED = "estimatedDrtSpeed";
-	static final String ESTIMATED_DRT_SPEED_EXP = "Beeline-speed estimate for DRT. Used in analysis, optimisation constraints "
-			+ "and in plans file, [m/s]. The default value is 25 km/h";
+	static final String ESTIMATED_DRT_SPEED_EXP =
+			"Beeline-speed estimate for DRT. Used in analysis, optimisation constraints "
+					+ "and in plans file, [m/s]. The default value is 25 km/h";
 
 	public static final String ESTIMATED_BEELINE_DISTANCE_FACTOR = "estimatedBeelineDistanceFactor";
 	static final String ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP = "Beeline distance factor for DRT. Used in analyis and in plans file. The default value is 1.3.";
@@ -92,8 +102,9 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	static final String VEH_FILE_EXP = "An XML file specifying the vehicle fleet. The file format according to dvrp_vehicles_v1.dtd";
 
 	public static final String TRANSIT_STOP_FILE = "transitStopFile";
-	static final String TRANSIT_STOP_FILE_EXP = "Stop locations file (transit schedule format, but without lines) for DRT stops. "
-			+ "Used only for the stopbased mode";
+	static final String TRANSIT_STOP_FILE_EXP =
+			"Stop locations file (transit schedule format, but without lines) for DRT stops. "
+					+ "Used only for the stopbased mode";
 
 	public static final String PLOT_CUST_STATS = "writeDetailedCustomerStats";
 	static final String PLOT_CUST_STATS_EXP = "Writes out detailed DRT customer stats in each iteration. True by default.";
@@ -102,9 +113,13 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	static final String PRINT_WARNINGS_EXP = "Prints detailed warnings for DRT customers that cannot be served or routed. Default is false.";
 
 	public static final String NUMBER_OF_THREADS = "numberOfThreads";
-	static final String NUMBER_OF_THREADS_EXP = "Number of threads used for parallel evaluation of request insertion into existing schedules."
-			+ " Scales well up to 4, due to path data provision, the most computationally intensive part,"
-			+ " using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)'";
+	static final String NUMBER_OF_THREADS_EXP =
+			"Number of threads used for parallel evaluation of request insertion into existing schedules."
+					+ " Scales well up to 4, due to path data provision, the most computationally intensive part,"
+					+ " using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)'";
+
+	@NotBlank
+	private String mode = TransportMode.drt; // travel mode (passengers'/customers' perspective)
 
 	@PositiveOrZero
 	private double stopDuration = Double.NaN;// seconds
@@ -164,6 +179,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
+		map.put(MODE, MODE_EXP);
 		map.put(STOP_DURATION, STOP_DURATION_EXP);
 		map.put(MAX_WAIT_TIME, MAX_WAIT_TIME_EXP);
 		map.put(MAX_TRAVEL_TIME_ALPHA, MAX_TRAV_ALPHA_EXP);
@@ -184,6 +200,22 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
+	 * @return {@value #MODE_EXP}
+	 */
+	@StringGetter(MODE)
+	public String getMode() {
+		return mode;
+	}
+
+	/**
+	 * @param mode {@value #MODE_EXP}
+	 */
+	@StringSetter(MODE)
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+
+	/**
 	 * @return -- {@value #STOP_DURATION_EXP}
 	 */
 	@StringGetter(STOP_DURATION)
@@ -192,8 +224,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param --
-	 *            {@value #STOP_DURATION_EXP}
+	 * @param -- {@value #STOP_DURATION_EXP}
 	 */
 	@StringSetter(STOP_DURATION)
 	public void setStopDuration(double stopDuration) {
@@ -209,8 +240,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param --
-	 *            {@value #MAX_WAIT_TIME_EXP}
+	 * @param -- {@value #MAX_WAIT_TIME_EXP}
 	 */
 	@StringSetter(MAX_WAIT_TIME)
 	public void setMaxWaitTime(double maxWaitTime) {
@@ -226,8 +256,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param maxTravelTimeAlpha
-	 *            {@value #MAX_TRAV_ALPHA_EXP}
+	 * @param maxTravelTimeAlpha {@value #MAX_TRAV_ALPHA_EXP}
 	 */
 	@StringSetter(MAX_TRAVEL_TIME_ALPHA)
 	public void setMaxTravelTimeAlpha(double maxTravelTimeAlpha) {
@@ -243,8 +272,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param maxTravelTimeBeta
-	 *            -- {@value #MAX_TRAVEL_TIME_BETA_EXP}
+	 * @param maxTravelTimeBeta -- {@value #MAX_TRAVEL_TIME_BETA_EXP}
 	 */
 	@StringSetter(MAX_TRAVEL_TIME_BETA)
 	public void setMaxTravelTimeBeta(double maxTravelTimeBeta) {
@@ -260,8 +288,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param requestRejection
-	 *            -- {@value #REQUEST_REJECTION_EXP}
+	 * @param requestRejection -- {@value #REQUEST_REJECTION_EXP}
 	 */
 	@StringSetter(REQUEST_REJECTION)
 	public void setRequestRejection(boolean requestRejection) {
@@ -277,8 +304,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param changeStartLinkToLastLinkInSchedule
-	 *            -- {@value #CHANGE_START_EXP}
+	 * @param changeStartLinkToLastLinkInSchedule -- {@value #CHANGE_START_EXP}
 	 */
 	@StringSetter(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE)
 	public void setChangeStartLinkToLastLinkInSchedule(boolean changeStartLinkToLastLinkInSchedule) {
@@ -294,8 +320,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param vehiclesFile
-	 *            -- {@value #VEH_FILE_EXP}
+	 * @param vehiclesFile -- {@value #VEH_FILE_EXP}
 	 */
 	@StringSetter(VEHICLES_FILE)
 	public void setVehiclesFile(String vehiclesFile) {
@@ -318,8 +343,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param idleVehiclesReturnToDepots
-	 *            -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP}
+	 * @param idleVehiclesReturnToDepots -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP}
 	 */
 	@StringSetter(IDLE_VEHICLES_RETURN_TO_DEPOTS)
 	public void setIdleVehiclesReturnToDepots(boolean idleVehiclesReturnToDepots) {
@@ -335,8 +359,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param operationalScheme
-	 *            -- {@value #OP_SCHEME_EXP}
+	 * @param operationalScheme -- {@value #OP_SCHEME_EXP}
 	 */
 	@StringSetter(OPERATIONAL_SCHEME)
 	public void setOperationalScheme(String operationalScheme) {
@@ -384,7 +407,6 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return -- {@value #ESTIMATED_DRT_SPEED_EXP}
 	 */
 	@StringGetter(ESTIMATED_DRT_SPEED)
@@ -425,8 +447,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param --
-	 *            {@value #PLOT_CUST_STATS_EXP}
+	 * @param -- {@value #PLOT_CUST_STATS_EXP}
 	 */
 	@StringSetter(PLOT_CUST_STATS)
 	public void setPlotDetailedCustomerStats(boolean plotDetailedCustomerStats) {
@@ -458,8 +479,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param --
-	 *            {@value #PRINT_WARNINGS_EXP}
+	 * @param -- {@value #PRINT_WARNINGS_EXP}
 	 */
 	@StringSetter(PRINT_WARNINGS)
 	public void setPrintDetailedWarnings(boolean printDetailedWarnings) {
@@ -467,9 +487,8 @@ public class DrtConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * 
 	 * @return 'minCostFlowRebalancing' parameter set defined in the DRT config or null if the parameters were not
-	 *         specified
+	 * specified
 	 */
 	@Valid
 	public MinCostFlowRebalancingParams getMinCostFlowRebalancing() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -18,9 +18,12 @@
  * *********************************************************************** */
 
 /**
- * 
+ *
  */
 package org.matsim.contrib.drt.run;
+
+import java.util.Arrays;
+import java.util.function.Function;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
@@ -61,12 +64,9 @@ import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.population.routes.RouteFactories;
 import org.matsim.core.scenario.ScenarioUtils;
 
-import java.util.Arrays;
-import java.util.function.Function;
-
 /**
  * @author jbischoff
- *
+ * @author michalm (Michal Maciejewski)
  */
 public final class DrtControlerCreator {
 
@@ -118,8 +118,9 @@ public final class DrtControlerCreator {
 	}
 
 	public static void addDrtToControler(Controler controler) {
-		controler.addOverridingModule(new DvrpModule(DrtControlerCreator::createModuleForQSimPlugin, Arrays
-				.asList(DrtOptimizer.class, DefaultUnplannedRequestInserter.class, ParallelPathDataProvider.class)));
+		controler.addOverridingModule(new DvrpModule(DrtControlerCreator::createModuleForQSimPlugin,
+				Arrays.asList(DrtOptimizer.class, DefaultUnplannedRequestInserter.class,
+						ParallelPathDataProvider.class)));
 		controler.addOverridingModule(new DrtModule());
 		controler.addOverridingModule(new DrtAnalysisModule());
 	}
@@ -131,25 +132,28 @@ public final class DrtControlerCreator {
 				ActivityParams params = new ActivityParams(DrtStageActivityType.DRT_STAGE_ACTIVITY);
 				params.setTypicalDuration(1);
 				params.setScoringThisActivityAtAll(false);
-				config.planCalcScore().getScoringParametersPerSubpopulation().values()
+				config.planCalcScore()
+						.getScoringParametersPerSubpopulation()
+						.values()
 						.forEach(k -> k.addActivityParams(params));
 				config.planCalcScore().addActivityParams(params);
-				Logger.getLogger(DrtControlerCreator.class).info(
-						"drt interaction scoring parameters not set. Adding default values (activity will not be scored).");
+				Logger.getLogger(DrtControlerCreator.class)
+						.info("drt interaction scoring parameters not set. Adding default values (activity will not be scored).");
 			}
 		}
 		if (!config.planCalcScore().getModes().containsKey(DrtStageActivityType.DRT_WALK)) {
-				ModeParams drtWalk = new ModeParams(DrtStageActivityType.DRT_WALK);
-				ModeParams walk = config.planCalcScore().getModes().get(TransportMode.walk);
-				drtWalk.setConstant(walk.getConstant());
-				drtWalk.setMarginalUtilityOfDistance(walk.getMarginalUtilityOfDistance());
-				drtWalk.setMarginalUtilityOfTraveling(walk.getMarginalUtilityOfTraveling());
-				drtWalk.setMonetaryDistanceRate(walk.getMonetaryDistanceRate());
-				config.planCalcScore().getScoringParametersPerSubpopulation().values()
-						.forEach(k -> k.addModeParams(drtWalk));
-				Logger.getLogger(DrtControlerCreator.class)
-						.info("drt_walk scoring parameters not set. Adding default values (same as for walk mode).");
-
+			ModeParams drtWalk = new ModeParams(DrtStageActivityType.DRT_WALK);
+			ModeParams walk = config.planCalcScore().getModes().get(TransportMode.walk);
+			drtWalk.setConstant(walk.getConstant());
+			drtWalk.setMarginalUtilityOfDistance(walk.getMarginalUtilityOfDistance());
+			drtWalk.setMarginalUtilityOfTraveling(walk.getMarginalUtilityOfTraveling());
+			drtWalk.setMonetaryDistanceRate(walk.getMonetaryDistanceRate());
+			config.planCalcScore()
+					.getScoringParametersPerSubpopulation()
+					.values()
+					.forEach(k -> k.addModeParams(drtWalk));
+			Logger.getLogger(DrtControlerCreator.class)
+					.info("drt_walk scoring parameters not set. Adding default values (same as for walk mode).");
 		}
 
 		config.addConfigConsistencyChecker(new DrtConfigConsistencyChecker());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -118,7 +118,8 @@ public final class DrtControlerCreator {
 	}
 
 	public static void addDrtToControler(Controler controler) {
-		controler.addOverridingModule(new DvrpModule(DrtControlerCreator::createModuleForQSimPlugin,
+		String mode = DrtConfigGroup.get(controler.getConfig()).getMode();
+		controler.addOverridingModule(DvrpModule.createModule(mode, DrtControlerCreator::createModuleForQSimPlugin,
 				Arrays.asList(DrtOptimizer.class, DefaultUnplannedRequestInserter.class,
 						ParallelPathDataProvider.class)));
 		controler.addOverridingModule(new DrtModule());

--- a/contribs/drt/src/main/resources/drt_example/drtconfig_door2door.xml
+++ b/contribs/drt/src/main/resources/drt_example/drtconfig_door2door.xml
@@ -38,9 +38,6 @@
 	
 	<module name="dvrp" >
 
-		<!-- Mode which will be handled by PassengerEngine and VrpOptimizer (passengers'/customers' perspective) -->
-		<param name="mode" value="drt" />
-
 		<!-- Mode of which the network will be used for routing vehicles, calculating travel times, etc. (fleet operator's perspective). If null, no mode filtering is done; the standard network (Scenario.getNetwork()) is used -->
 		<param name="networkMode" value="car" />
 

--- a/contribs/drt/src/main/resources/drt_example/drtconfig_stopbased.xml
+++ b/contribs/drt/src/main/resources/drt_example/drtconfig_stopbased.xml
@@ -42,10 +42,6 @@
 	</module>
 	
 	<module name="dvrp" >
-
-		<!-- Mode which will be handled by PassengerEngine and VrpOptimizer (passengers'/customers' perspective) -->
-		<param name="mode" value="drt" />
-
 		<!-- Mode of which the network will be used for routing vehicles, calculating travel times, etc. (fleet operator's perspective). If null, no mode filtering is done; the standard network (Scenario.getNetwork()) is used -->
 		<param name="networkMode" value="car" />
 

--- a/contribs/drt/src/main/resources/mielec_2014_02/mielec_drt_config.xml
+++ b/contribs/drt/src/main/resources/mielec_2014_02/mielec_drt_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="drt" />
 	</module>
 
 	<module name="drt">

--- a/contribs/drt/src/main/resources/one_shared_taxi/one_shared_taxi_config.xml
+++ b/contribs/drt/src/main/resources/one_shared_taxi/one_shared_taxi_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="drt" />
 	</module>
 
 	<module name="drt">

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtMainModeIdentifierTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtMainModeIdentifierTest.java
@@ -1,6 +1,5 @@
 package org.matsim.contrib.drt.routing;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +10,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.PlanElement;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.PopulationUtils;
@@ -22,11 +21,11 @@ public class DrtMainModeIdentifierTest {
 
 	@Test
 	public void test() {
-		DvrpConfigGroup dvrp = new DvrpConfigGroup();
-		dvrp.setMode("drt");
+		DrtConfigGroup drtConfigGroup= new DrtConfigGroup();
+		drtConfigGroup.setMode("drt");
 		Config config = ConfigUtils.createConfig();
-		config.addModule(dvrp);
-		MainModeIdentifier mmi = new DrtMainModeIdentifier(config);
+		config.addModule(drtConfigGroup);
+		MainModeIdentifier mmi = new DrtMainModeIdentifier(drtConfigGroup);
 		{
 		List<PlanElement> testElements = new ArrayList<>();
 		Leg l1 = PopulationUtils.createLeg(TransportMode.car);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
-import org.matsim.contrib.dvrp.run.DvrpQSimComponentsConfigurator;
 import org.matsim.contrib.dvrp.run.DvrpQSimModuleBuilder;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
@@ -42,12 +41,13 @@ import com.google.inject.name.Names;
 public class DvrpBenchmarkModule extends AbstractModule {
 	private final DvrpQSimModuleBuilder qsimModuleBuilder;
 
-	public DvrpBenchmarkModule(Function<Config, AbstractQSimModule> moduleCreator,
+	public static DvrpBenchmarkModule createModule(String mode, Function<Config, AbstractQSimModule> moduleCreator,
 			Collection<Class<? extends MobsimListener>> listeners) {
-		this(new DvrpQSimModuleBuilder(moduleCreator).addListeners(listeners));
+		return new DvrpBenchmarkModule(
+				new DvrpQSimModuleBuilder(moduleCreator).addListeners(listeners).setPassengerEngineMode(mode));
 	}
 
-	public DvrpBenchmarkModule(DvrpQSimModuleBuilder qsimModuleBuilder) {
+	private DvrpBenchmarkModule(DvrpQSimModuleBuilder qsimModuleBuilder) {
 		this.qsimModuleBuilder = qsimModuleBuilder;
 	}
 
@@ -65,8 +65,9 @@ public class DvrpBenchmarkModule extends AbstractModule {
 		install(new DvrpBenchmarkTravelTimeModule());// fixed travel times
 
 		bind(Network.class).annotatedWith(Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING))
-				.toProvider(DvrpRoutingNetworkProvider.class).asEagerSingleton();
-		
+				.toProvider(DvrpRoutingNetworkProvider.class)
+				.asEagerSingleton();
+
 		installQSimModule(qsimModuleBuilder.build(getConfig()));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/RunOneTaxiExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/RunOneTaxiExample.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.dvrp.examples.onetaxi;
 import java.util.Collections;
 
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dvrp.data.file.FleetProvider;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
@@ -57,8 +58,7 @@ public final class RunOneTaxiExample {
 
 		// setup controler
 		Controler controler = new Controler(scenario);
-		controler.addOverridingModule(new DvrpModule(//
-				cfg -> new AbstractQSimModule() {
+		controler.addOverridingModule(DvrpModule.createModule(TransportMode.taxi, cfg -> new AbstractQSimModule() {
 					@Override
 					protected void configureQSim() {
 						// optimizer that dispatches taxis

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
@@ -19,6 +19,7 @@
 
 package org.matsim.contrib.dvrp.examples.onetruck;
 
+import java.nio.channels.NonWritableChannelException;
 import java.util.Arrays;
 
 import org.matsim.api.core.v01.Id;
@@ -120,8 +121,7 @@ public final class RunOneTruckExample {
 					bind(DynActionCreator.class).to(OneTruckActionCreator.class).asEagerSingleton();
 				}
 			};
-		}).addListener(OneTruckRequestCreator.class)//
-				.setAddPassengerEnginePlugin(false);
+		}).addListener(OneTruckRequestCreator.class);
 	}
 
 	public static void main(String... args) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
@@ -125,6 +125,6 @@ public final class RunOneTruckExample {
 	}
 
 	public static void main(String... args) {
-		run(true, 0); // switch to 'false' to turn off visualisation
+		run(false, 0); // switch to 'false' to turn off visualisation
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -40,10 +40,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 		return (DvrpConfigGroup)config.getModule(GROUP_NAME);// will fail if not in the config
 	}
 
-	public static final String MODE = "mode";
-	static final String MODE_EXP = "Mode which will be handled by PassengerEngine and VrpOptimizer "
-			+ "(passengers'/customers' perspective)";
-
 	public static final String NETWORK_MODE = "networkMode";
 	static final String NETWORK_MODE_EXP = "Mode of which the network will be used for routing vehicles. "
 			+ "Default is car, i.e. the car network is used. "
@@ -87,9 +83,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	// In DVRP 'time < currentTime' may only happen for backward path search, a adding proper search termination
 	// criterion should prevent this from happening
 
-	@NotBlank
-	private String mode = null; // travel mode (passengers'/customers' perspective)
-
 	@Nullable
 	private String networkMode = TransportMode.car; // used for building route; null ==> no filtering (routing network equals scenario.network)
 
@@ -110,7 +103,6 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
-		map.put(MODE, MODE_EXP);
 		map.put(NETWORK_MODE, NETWORK_MODE_EXP);
 		map.put(MOBSIM_MODE, MOBSIM_MODE_EXP);
 		map.put(TRAVEL_TIME_ESTIMATION_ALPHA, TRAVEL_TIME_ESTIMATION_ALPHA_EXP);
@@ -119,23 +111,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @return -- {@value #MODE_EXP}
-	 */
-	@StringGetter(MODE)
-	public String getMode() {
-		return mode;
-	}
-
-	/**
-	 * @param -- {@value #MODE_EXP}
-	 */
-	@StringSetter(MODE)
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	/**
-	 * @return -- {@value #NETWORK_MODE_EXP}
+	 * @return {@value #NETWORK_MODE_EXP}
 	 */
 	@StringGetter(NETWORK_MODE)
 	public String getNetworkMode() {
@@ -143,7 +119,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param -- {@value #NETWORK_MODE_EXP}
+	 * @param networkMode {@value #NETWORK_MODE_EXP}
 	 */
 	@StringSetter(NETWORK_MODE)
 	public void setNetworkMode(String networkMode) {
@@ -151,7 +127,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @return -- {@value #MOBSIM_MODE_EXP}
+	 * @return {@value #MOBSIM_MODE_EXP}
 	 */
 	@StringGetter(MOBSIM_MODE)
 	public String getMobsimMode() {
@@ -159,7 +135,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param -- {@value #MOBSIM_MODE_EXP}
+	 * @param networkMode {@value #MOBSIM_MODE_EXP}
 	 */
 	@StringSetter(MOBSIM_MODE)
 	public void setMobsimMode(String networkMode) {
@@ -167,7 +143,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @return -- {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
+	 * @return {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
 	 */
 	@StringGetter(TRAVEL_TIME_ESTIMATION_ALPHA)
 	public double getTravelTimeEstimationAlpha() {
@@ -175,7 +151,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @value -- {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
+	 * @param travelTimeEstimationAlpha {@value #TRAVEL_TIME_ESTIMATION_ALPHA_EXP}
 	 */
 	@StringSetter(TRAVEL_TIME_ESTIMATION_ALPHA)
 	public void setTravelTimeEstimationAlpha(double travelTimeEstimationAlpha) {
@@ -183,7 +159,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @return -- {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
+	 * @return {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
 	 */
 	@StringGetter(TRAVEL_TIME_ESTIMATION_BETA)
 	public double getTravelTimeEstimationBeta() {
@@ -191,7 +167,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @param -- {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
+	 * @param travelTimeEstimationBeta {@value #TRAVEL_TIME_ESTIMATION_BETA_EXP}
 	 */
 	@StringSetter(TRAVEL_TIME_ESTIMATION_BETA)
 	public void setTravelTimeEstimationBeta(double travelTimeEstimationBeta) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -119,7 +119,7 @@ public class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	/**
-	 * @return -- {@value #MODE_EXP}}
+	 * @return -- {@value #MODE_EXP}
 	 */
 	@StringGetter(MODE)
 	public String getMode() {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dynagent/run/DynRoutingModule.java
@@ -19,27 +19,40 @@
 
 package org.matsim.contrib.dynagent.run;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
-import com.google.inject.Inject;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.population.*;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
-import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.RouteUtils;
-import org.matsim.core.router.*;
+import org.matsim.core.router.EmptyStageActivityTypes;
+import org.matsim.core.router.NetworkRoutingInclAccessEgressModule;
+import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.StageActivityTypes;
+import org.matsim.core.router.StageActivityTypesImpl;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
 
+import com.google.inject.Inject;
+
 public class DynRoutingModule implements RoutingModule {
 	private final String stageActivityType;
-	@Inject Network network ;
-	@Inject Population population ;
-	@Inject PlansCalcRouteConfigGroup calcRouteConfig ;
-	
+	@Inject
+	Network network;
+	@Inject
+	Population population;
+	@Inject
+	PlansCalcRouteConfigGroup calcRouteConfig;
+
 	private final String mode;
 	private StageActivityTypes stageActivityTypes;
 
@@ -50,52 +63,47 @@ public class DynRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime,
-								    Person person) {
-		
-		Gbl.assertNotNull(fromFacility);
-		Gbl.assertNotNull(toFacility);
-		
-		Link accessActLink = FacilitiesUtils.decideOnLink(fromFacility, network );
-		
-		Link egressActLink = FacilitiesUtils.decideOnLink(toFacility, network );
-		
-		List<PlanElement> result = new ArrayList<>() ;
-		
+	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
+			Person person) {
+		Link accessActLink = FacilitiesUtils.decideOnLink(Objects.requireNonNull(fromFacility), network);
+		Link egressActLink = FacilitiesUtils.decideOnLink(Objects.requireNonNull(toFacility), network);
+
+		List<PlanElement> result = new ArrayList<>();
+
 		// access leg:
-		if ( calcRouteConfig.isInsertingAccessEgressWalk() ) {
+		if (calcRouteConfig.isInsertingAccessEgressWalk()) {
 			departureTime += NetworkRoutingInclAccessEgressModule.addBushwhackingLegFromFacilityToLinkIfNecessary(
-					fromFacility, person, accessActLink, departureTime, result, population.getFactory(), stageActivityType ) ;
+					fromFacility, person, accessActLink, departureTime, result, population.getFactory(),
+					stageActivityType);
 		}
-		
+
 		// leg proper:
 		{
-			Route route = RouteUtils.createGenericRouteImpl( fromFacility.getLinkId(), toFacility.getLinkId() );
-			route.setDistance( Double.NaN );
-			route.setTravelTime( Double.NaN );
-			
-			Leg leg = PopulationUtils.createLeg( mode );
-			leg.setDepartureTime( departureTime );
-			leg.setTravelTime( Double.NaN );
-			leg.setRoute( route );
-			if ( fromFacility.getLinkId().equals( toFacility.getLinkId() ) ) {
-				leg.setMode( TransportMode.walk );
+			Route route = RouteUtils.createGenericRouteImpl(fromFacility.getLinkId(), toFacility.getLinkId());
+			route.setDistance(Double.NaN);
+			route.setTravelTime(Double.NaN);
+
+			Leg leg = PopulationUtils.createLeg(mode);
+			leg.setDepartureTime(departureTime);
+			leg.setTravelTime(Double.NaN);
+			leg.setRoute(route);
+			if (fromFacility.getLinkId().equals(toFacility.getLinkId())) {
+				leg.setMode(TransportMode.walk);
 			}
-			result.add( leg );
+			result.add(leg);
 		}
 
 		// egress leg:
-		if ( calcRouteConfig.isInsertingAccessEgressWalk(  ) ) {
-			NetworkRoutingInclAccessEgressModule.addBushwhackingLegFromLinkToFacilityIfNecessary(
-					toFacility, person, egressActLink, departureTime, result, population.getFactory(), stageActivityType );
+		if (calcRouteConfig.isInsertingAccessEgressWalk()) {
+			NetworkRoutingInclAccessEgressModule.addBushwhackingLegFromLinkToFacilityIfNecessary(toFacility, person,
+					egressActLink, departureTime, result, population.getFactory(), stageActivityType);
 		}
 
-		return result ;
+		return result;
 	}
 
 	/**
-	 * @param stageActivityTypes
-	 *            the stageActivityTypes to set
+	 * @param stageActivityTypes the stageActivityTypes to set
 	 */
 	public void setStageActivityTypes(StageActivityTypes stageActivityTypes) {
 		this.stageActivityTypes = stageActivityTypes;

--- a/contribs/dvrp/src/main/resources/one_taxi/one_taxi_config.xml
+++ b/contribs/dvrp/src/main/resources/one_taxi/one_taxi_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="network">

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
@@ -66,11 +66,12 @@ public class RunTaxiBenchmark {
 		config.addConfigConsistencyChecker(new TaxiBenchmarkConfigConsistencyChecker());
 		config.checkConsistency();
 
+		String mode = TaxiConfigGroup.get(config).getMode();
 		Scenario scenario = loadBenchmarkScenario(config, 15 * 60, 30 * 3600);
 
 		Controler controler = new Controler(scenario);
 		controler.setModules(new DvrpBenchmarkControlerModule());
-		controler.addOverridingModule(new DvrpBenchmarkModule(
+		controler.addOverridingModule(DvrpBenchmarkModule.createModule(mode,
 				cfg -> TaxiDvrpModules.createModuleForQSimPlugin(DefaultTaxiOptimizerProvider.class),
 				Collections.singleton(TaxiOptimizer.class)));
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/RunTaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/RunTaxiScenario.java
@@ -39,11 +39,12 @@ public class RunTaxiScenario {
 	public static Controler createControler(Config config, boolean otfvis) {
 		config.addConfigConsistencyChecker(new TaxiConfigConsistencyChecker());
 		config.checkConsistency();
+		String mode = TaxiConfigGroup.get(config).getMode();
 
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 
 		Controler controler = new Controler(scenario);
-		controler.addOverridingModule(TaxiDvrpModules.create());
+		controler.addOverridingModule(TaxiDvrpModules.create(mode));
 		controler.addOverridingModule(new TaxiModule());
 
 		if (otfvis) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -23,7 +23,7 @@ import java.net.URL;
 import java.util.Map;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.Config;
@@ -36,45 +36,82 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	@SuppressWarnings("deprecation")
 	public static TaxiConfigGroup get(Config config) {
 		return (TaxiConfigGroup)config.getModule(GROUP_NAME);
-		// yy this will fail if the module is not in the config. Is this intended? If not, use
-		// ConfigUtils.addOrCreateModule(...). kai, jan'17
 	}
 
 	public static final String DESTINATION_KNOWN = "destinationKnown";
+	static final String DESTINATION_KNOWN_EXP =
+			"If false, the drop-off location remains unknown to the optimizer and scheduler"
+					+ " until the end of pickup. False by default.";
+
 	public static final String VEHICLE_DIVERSION = "vehicleDiversion";
+	static final String VEHICLE_DIVERSION_EXP = "If true, vehicles can be diverted during empty trips."
+			+ " Requires online tracking. False by default.";
+
 	public static final String PICKUP_DURATION = "pickupDuration";
+	static final String PICKUP_DURATION_EXP = "Typically, 120 seconds";
+
 	public static final String DROPOFF_DURATION = "dropoffDuration";
+	static final String DROPOFF_DURATION_EXP = "Typically, 60 seconds";
+
 	public static final String A_STAR_EUCLIDEAN_OVERDO_FACTOR = "AStarEuclideanOverdoFactor";
+	static final String A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP =
+			"Used in AStarEuclidean for shortest path search for occupied drives. Default value is 1.0. "
+					+ "Values above 1.0 (typically, 1.5 to 3.0) speed up search, "
+					+ "but at the cost of obtaining longer paths";
+
 	public static final String ONLINE_VEHICLE_TRACKER = "onlineVehicleTracker";
+	static final String ONLINE_VEHICLE_TRACKER_EXP =
+			"If true, vehicles are (GPS-like) monitored while moving. This helps in getting more accurate "
+					+ "estimates on the time of arrival. Online tracking is necessary for vehicle diversion. "
+					+ "False by default.";
+
 	public static final String CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE = "changeStartLinkToLastLinkInSchedule";
+	static final String CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP =
+			"If true, the startLink is changed to last link in the current schedule, so the taxi starts the next "
+					+ "day at the link where it stopped operating the day before. False by default.";
 
 	// input
 	public static final String TAXIS_FILE = "taxisFile";
+	static final String TAXIS_FILE_EXP = "An XML file specifying the taxi fleet."
+			+ " The file format according to dvrp_vehicles_v1.dtd";
 
 	// output
 	public static final String TIME_PROFILES = "timeProfiles";
+	static final String TIME_PROFILES_EXP =
+			"If true, writes time profiles of vehicle statuses (i.e. current task type) and the number of unplanned "
+					+ "requests are written to a text file (taxi_status_time_profiles) and saved as plots. "
+					+ "False by default.";
+
 	public static final String DETAILED_STATS = "detailedStats";
+	static final String DETAILED_STATS_EXP = "If true, detailed hourly taxi stats are dumped after each iteration."
+			+ " False by default.";
 
 	public static final String BREAK_IF_NOT_ALL_REQUESTS_SERVED = "breakIfNotAllRequestsServed";
+	static final String BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP =
+			"Specifies whether the simulation should interrupt if not all requests were performed when"
+					+ " an interation ends. Otherwise, a warning is given. True by default.";
 
 	public static final String OPTIMIZER_PARAMETER_SET = "optimizer";
+	static final String OPTIMIZER_PARAMETER_SET_EXP =
+			"Specifies the type and parameters of the TaxiOptimizer. See: TaxiOptimizerParams and classes"
+					+ " implementing it, e.g. AbstractTaxiOptimizerParams.";
 
 	private boolean destinationKnown = false;
 	private boolean vehicleDiversion = false;
-	
+
 	@PositiveOrZero
 	private double pickupDuration = Double.NaN;// seconds
 
 	@PositiveOrZero
 	private double dropoffDuration = Double.NaN;// seconds
-	
+
 	@Min(1)
 	private double AStarEuclideanOverdoFactor = 1.;
-	
+
 	private boolean onlineVehicleTracker = false;
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
-	@NotNull
+	@NotBlank
 	private String taxisFile = null;
 
 	private boolean timeProfiles = false;
@@ -89,144 +126,192 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
-		map.put(DESTINATION_KNOWN, "If false, the drop-off location remains unknown to the optimizer and scheduler"
-				+ " until the end of pickup. False by default.");
-		map.put(VEHICLE_DIVERSION, "If true, vehicles can be diverted during empty trips. Requires online tracking."
-				+ " False by default.");
-		map.put(PICKUP_DURATION, "Typically, 120 seconds");
-		map.put(DROPOFF_DURATION, "Typically, 60 seconds");
-		map.put(A_STAR_EUCLIDEAN_OVERDO_FACTOR,
-				"Used in AStarEuclidean for shortest path search for occupied drives. Default value is 1.0. "
-						+ "Values above 1.0 (typically, 1.5 to 3.0) speed up search, "
-						+ "but at the cost of obtaining longer paths");
-		map.put(ONLINE_VEHICLE_TRACKER,
-				"If true, vehicles are (GPS-like) monitored while moving. This helps in getting more accurate "
-						+ "estimates on the time of arrival. Online tracking is necessary for vehicle diversion. "
-						+ "False by default.");
-		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE,
-				"If true, the startLink is changed to last link in the current schedule, so the taxi starts the next "
-						+ "day at the link where it stopped operating the day before. False by default.");
-		map.put(TAXIS_FILE, "An XML file specifying the taxi fleet. The file format according to dvrp_vehicles_v1.dtd");
-		map.put(TIME_PROFILES,
-				"If true, writes time profiles of vehicle statuses (i.e. current task type) and the number of unplanned "
-						+ "requests are written to a text file (taxi_status_time_profiles) and saved as plots. "
-						+ "False by default.");
-		map.put(DETAILED_STATS,
-				"If true, detailed hourly taxi stats are dumped after each iteration. False by default.");
-		map.put(BREAK_IF_NOT_ALL_REQUESTS_SERVED,
-				"Specifies whether the simulation should interrupt if not all requests were performed when"
-						+ " an interation ends. Otherwise, a warning is given. True by default.");
-		map.put(OPTIMIZER_PARAMETER_SET, // currently, comments for parameter sets are not printed
-				"Specifies the type and parameters of the TaxiOptimizer. See: TaxiOptimizerParams and classes"
-						+ " implementing it, e.g. AbstractTaxiOptimizerParams.");
+		map.put(DESTINATION_KNOWN, DESTINATION_KNOWN_EXP);
+		map.put(VEHICLE_DIVERSION, VEHICLE_DIVERSION_EXP);
+		map.put(PICKUP_DURATION, PICKUP_DURATION_EXP);
+		map.put(DROPOFF_DURATION, DROPOFF_DURATION_EXP);
+		map.put(A_STAR_EUCLIDEAN_OVERDO_FACTOR, A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP);
+		map.put(ONLINE_VEHICLE_TRACKER, ONLINE_VEHICLE_TRACKER_EXP);
+		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE, CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP);
+		map.put(TAXIS_FILE, TAXIS_FILE_EXP);
+		map.put(TIME_PROFILES, TIME_PROFILES_EXP);
+		map.put(DETAILED_STATS, DETAILED_STATS_EXP);
+		map.put(BREAK_IF_NOT_ALL_REQUESTS_SERVED, BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP);
+		map.put(OPTIMIZER_PARAMETER_SET, OPTIMIZER_PARAMETER_SET_EXP);
 		return map;
 	}
 
+	/**
+	 * @return {@value #DESTINATION_KNOWN_EXP}
+	 */
 	@StringGetter(DESTINATION_KNOWN)
 	public boolean isDestinationKnown() {
 		return destinationKnown;
 	}
 
+	/**
+	 * @param destinationKnown {@value #DESTINATION_KNOWN_EXP}
+	 */
 	@StringSetter(DESTINATION_KNOWN)
 	public void setDestinationKnown(boolean destinationKnown) {
 		this.destinationKnown = destinationKnown;
 	}
 
+	/**
+	 * @return {@value #VEHICLE_DIVERSION_EXP}
+	 */
 	@StringGetter(VEHICLE_DIVERSION)
 	public boolean isVehicleDiversion() {
 		return vehicleDiversion;
 	}
 
+	/**
+	 * @param vehicleDiversion {@value #VEHICLE_DIVERSION_EXP}
+	 */
 	@StringSetter(VEHICLE_DIVERSION)
 	public void setVehicleDiversion(boolean vehicleDiversion) {
 		this.vehicleDiversion = vehicleDiversion;
 	}
 
+	/**
+	 * @return {@value #PICKUP_DURATION_EXP}
+	 */
 	@StringGetter(PICKUP_DURATION)
 	public double getPickupDuration() {
 		return pickupDuration;
 	}
 
+	/**
+	 * @param pickupDuration {@value #PICKUP_DURATION_EXP}
+	 */
 	@StringSetter(PICKUP_DURATION)
 	public void setPickupDuration(double pickupDuration) {
 		this.pickupDuration = pickupDuration;
 	}
 
+	/**
+	 * @return {@value #DROPOFF_DURATION_EXP}
+	 */
 	@StringGetter(DROPOFF_DURATION)
 	public double getDropoffDuration() {
 		return dropoffDuration;
 	}
 
+	/**
+	 * @param dropoffDuration {@value #DROPOFF_DURATION_EXP}
+	 */
 	@StringSetter(DROPOFF_DURATION)
 	public void setDropoffDuration(double dropoffDuration) {
 		this.dropoffDuration = dropoffDuration;
 	}
 
+	/**
+	 * @return {@value #A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP}
+	 */
 	@StringGetter(A_STAR_EUCLIDEAN_OVERDO_FACTOR)
 	public double getAStarEuclideanOverdoFactor() {
 		return AStarEuclideanOverdoFactor;
 	}
 
+	/**
+	 * @param aStarEuclideanOverdoFactor {@value #A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP}
+	 */
 	@StringSetter(A_STAR_EUCLIDEAN_OVERDO_FACTOR)
 	public void setAStarEuclideanOverdoFactor(double aStarEuclideanOverdoFactor) {
 		AStarEuclideanOverdoFactor = aStarEuclideanOverdoFactor;
 	}
 
+	/**
+	 * @return {@value #ONLINE_VEHICLE_TRACKER_EXP}
+	 */
 	@StringGetter(ONLINE_VEHICLE_TRACKER)
 	public boolean isOnlineVehicleTracker() {
 		return onlineVehicleTracker;
 	}
 
+	/**
+	 * @param onlineVehicleTracker {@value #ONLINE_VEHICLE_TRACKER_EXP}
+	 */
 	@StringSetter(ONLINE_VEHICLE_TRACKER)
 	public void setOnlineVehicleTracker(boolean onlineVehicleTracker) {
 		this.onlineVehicleTracker = onlineVehicleTracker;
 	}
 
+	/**
+	 * @return {@value #CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP}
+	 */
 	@StringGetter(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE)
 	public boolean isChangeStartLinkToLastLinkInSchedule() {
 		return changeStartLinkToLastLinkInSchedule;
 	}
 
+	/**
+	 * @param changeStartLinkToLastLinkInSchedule {@value #CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP}
+	 */
 	@StringSetter(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE)
 	public void setChangeStartLinkToLastLinkInSchedule(boolean changeStartLinkToLastLinkInSchedule) {
 		this.changeStartLinkToLastLinkInSchedule = changeStartLinkToLastLinkInSchedule;
 	}
 
+	/**
+	 * @return {@value #TAXIS_FILE_EXP}
+	 */
 	@StringGetter(TAXIS_FILE)
 	public String getTaxisFile() {
 		return taxisFile;
 	}
 
+	/**
+	 * @param taxisFile {@value #TAXIS_FILE_EXP}
+	 */
 	@StringSetter(TAXIS_FILE)
 	public void setTaxisFile(String taxisFile) {
 		this.taxisFile = taxisFile;
 	}
 
+	/**
+	 * @return {@value #TIME_PROFILES_EXP}
+	 */
 	@StringGetter(TIME_PROFILES)
 	public boolean getTimeProfiles() {
 		return timeProfiles;
 	}
 
+	/**
+	 * @param timeProfiles {@value #TIME_PROFILES_EXP}
+	 */
 	@StringSetter(TIME_PROFILES)
 	public void setTimeProfiles(boolean timeProfiles) {
 		this.timeProfiles = timeProfiles;
 	}
 
+	/**
+	 * @return {@value #DETAILED_STATS_EXP}
+	 */
 	@StringGetter(DETAILED_STATS)
 	public boolean getDetailedStats() {
 		return detailedStats;
 	}
 
+	/**
+	 * @param detailedStats {@value #DETAILED_STATS_EXP}
+	 */
 	@StringSetter(DETAILED_STATS)
 	public void setDetailedStats(boolean detailedStats) {
 		this.detailedStats = detailedStats;
 	}
 
+	/**
+	 * @return {@value #BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP}
+	 */
 	@StringGetter(BREAK_IF_NOT_ALL_REQUESTS_SERVED)
 	public boolean isBreakSimulationIfNotAllRequestsServed() {
 		return breakSimulationIfNotAllRequestsServed;
 	}
 
+	/**
+	 * @param breakSimulationIfNotAllRequestsServed {@value #BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP}
+	 */
 	@StringSetter(BREAK_IF_NOT_ALL_REQUESTS_SERVED)
 	public void setBreakSimulationIfNotAllRequestsServed(boolean breakSimulationIfNotAllRequestsServed) {
 		this.breakSimulationIfNotAllRequestsServed = breakSimulationIfNotAllRequestsServed;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.PositiveOrZero;
 
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -37,6 +38,10 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	public static TaxiConfigGroup get(Config config) {
 		return (TaxiConfigGroup)config.getModule(GROUP_NAME);
 	}
+
+	public static final String MODE = "mode";
+	static final String MODE_EXP = "Mode which will be handled by PassengerEngine and VrpOptimizer "
+			+ "(passengers'/customers' perspective)";
 
 	public static final String DESTINATION_KNOWN = "destinationKnown";
 	static final String DESTINATION_KNOWN_EXP =
@@ -96,6 +101,9 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 			"Specifies the type and parameters of the TaxiOptimizer. See: TaxiOptimizerParams and classes"
 					+ " implementing it, e.g. AbstractTaxiOptimizerParams.";
 
+	@NotBlank
+	private String mode = TransportMode.taxi; // travel mode (passengers'/customers' perspective)
+
 	private boolean destinationKnown = false;
 	private boolean vehicleDiversion = false;
 
@@ -126,6 +134,7 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
+		map.put(MODE, MODE_EXP);
 		map.put(DESTINATION_KNOWN, DESTINATION_KNOWN_EXP);
 		map.put(VEHICLE_DIVERSION, VEHICLE_DIVERSION_EXP);
 		map.put(PICKUP_DURATION, PICKUP_DURATION_EXP);
@@ -139,6 +148,22 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 		map.put(BREAK_IF_NOT_ALL_REQUESTS_SERVED, BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP);
 		map.put(OPTIMIZER_PARAMETER_SET, OPTIMIZER_PARAMETER_SET_EXP);
 		return map;
+	}
+
+	/**
+	 * @return {@value #MODE_EXP}
+	 */
+	@StringGetter(MODE)
+	public String getMode() {
+		return mode;
+	}
+
+	/**
+	 * @param mode {@value #MODE_EXP}
+	 */
+	@StringSetter(MODE)
+	public void setMode(String mode) {
+		this.mode = mode;
 	}
 
 	/**

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
@@ -48,6 +48,7 @@ public class RunTaxiExample {
 		config.controler().setLastIteration(lastIteration);
 		config.addConfigConsistencyChecker(new TaxiConfigConsistencyChecker());
 		config.checkConsistency();
+		String mode = TaxiConfigGroup.get(config).getMode();
 
 		// load scenario
 		Scenario scenario = ScenarioUtils.loadScenario(config);
@@ -57,10 +58,10 @@ public class RunTaxiExample {
 
 		final boolean ownTaxiOptimizer = false;
 		if (!ownTaxiOptimizer) {
-			controler.addOverridingModule(TaxiDvrpModules.create());
+			controler.addOverridingModule(TaxiDvrpModules.create(mode));
 			// (default taxi optimizer)
 		} else {
-			controler.addOverridingModule(TaxiDvrpModules.create(MyTaxiOptimizerProvider.class));
+			controler.addOverridingModule(TaxiDvrpModules.create(mode, MyTaxiOptimizerProvider.class));
 			// (implement your own taxi optimizer)
 		}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/TaxiDvrpModules.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/TaxiDvrpModules.java
@@ -34,23 +34,23 @@ import org.matsim.contrib.taxi.vrpagent.TaxiActionCreator;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 
-import com.google.inject.Module;
 import com.google.inject.Provider;
 
 /**
  * @author michalm
  */
 public class TaxiDvrpModules {
-	public static DvrpModule create() {
-		return create(DefaultTaxiOptimizerProvider.class);
+	public static DvrpModule create(String mode) {
+		return create(mode, DefaultTaxiOptimizerProvider.class);
 	}
 
-	public static DvrpModule create(Class<? extends Provider<? extends TaxiOptimizer>> providerClass) {
-		return new DvrpModule(cfg -> createModuleForQSimPlugin(providerClass),
+	public static DvrpModule create(String mode, Class<? extends Provider<? extends TaxiOptimizer>> providerClass) {
+		return DvrpModule.createModule(mode, cfg -> createModuleForQSimPlugin(providerClass),
 				Collections.singleton(TaxiOptimizer.class));
 	}
 
-	public static AbstractQSimModule createModuleForQSimPlugin(Class<? extends Provider<? extends TaxiOptimizer>> providerClass) {
+	public static AbstractQSimModule createModuleForQSimPlugin(
+			Class<? extends Provider<? extends TaxiOptimizer>> providerClass) {
 		return new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {

--- a/contribs/taxi/src/main/resources/mielec_2014_02/mielec_taxi_benchmark_config.xml
+++ b/contribs/taxi/src/main/resources/mielec_2014_02/mielec_taxi_benchmark_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">

--- a/contribs/taxi/src/main/resources/mielec_2014_02/mielec_taxi_config.xml
+++ b/contribs/taxi/src/main/resources/mielec_2014_02/mielec_taxi_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">

--- a/contribs/taxi/src/main/resources/one_taxi/one_taxi_config.xml
+++ b/contribs/taxi/src/main/resources/one_taxi/one_taxi_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">

--- a/contribs/taxi/src/main/resources/one_taxi_benchmark/one_taxi_benchmark_config.xml
+++ b/contribs/taxi/src/main/resources/one_taxi_benchmark/one_taxi_benchmark_config.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="dvrp">
-		<param name="mode" value="taxi" />
 	</module>
 
 	<module name="taxi">


### PR DESCRIPTION
The aim is to be able to run more than one dynamic service (UPDATE: but we are not yet there).

**Backward compatibility issue:** this change requires moving the line specifying the dvrp mode inside the config file from the `dvrp` config group to either `drt` or `taxi` (depending on which is used). Otherwise loading the config will end up with an error.