### PR TITLE
fare computation: use mode from fare config group instead of the taxi config group

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareConfigGroup.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareConfigGroup.java
@@ -29,10 +29,8 @@ import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
  * @author  jbischoff
- * Config Group to set taxi fares.
- */
-/**
- *
+ * Config Group to set taxi or drt fares.
+ * 
  */
 public class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 
@@ -42,12 +40,13 @@ public class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 	public static final String DAILY_FEE = "dailySubscriptionFee";
 	public static final String TIMEFARE = "timeFare_h";
 	public static final String DISTANCEFARE = "distanceFare_m";
+	public static final String MODE = "mode";
 
 	private double basefare;
 	private double dailySubscriptionFee;
 	private double timeFare_h;
 	private double distanceFare_m;
-
+	private String mode = "taxi";
 	
 	public TaxiFareConfigGroup() {
 		super(GROUP_NAME);
@@ -66,6 +65,7 @@ public class TaxiFareConfigGroup extends ReflectiveConfigGroup {
         map.put(DAILY_FEE, "Daily subscription fee (fee = positive value)");
         map.put(TIMEFARE , "taxi fare per hour (fee = positive value)");
         map.put(DISTANCEFARE, "taxi fare per meter (fee = positive value)");
+        map.put(MODE, "taxi / drt mode (passengers'/customers' perspective; default: taxi)");
 		return map;
     }
 
@@ -107,12 +107,18 @@ public class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 		return distanceFare_m;
 	}
 
-
 	@StringSetter(DISTANCEFARE)
 	public void setDistanceFare_m(double distanceFare_m) {
 		this.distanceFare_m = distanceFare_m;
 	}
 	
+	@StringGetter(MODE)
+	public String getMode() {
+		return mode;
+	}
 	
-
+	@StringSetter(MODE)
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
 }

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandler.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/scoring/TaxiFareHandler.java
@@ -40,8 +40,6 @@ import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.vehicles.Vehicle;
@@ -50,13 +48,9 @@ import com.google.inject.Inject;
 
 /**
  * @author  jbischoff
- *	A simple implementation for taxi fares.
+ *	A simple implementation for taxi or drt fares.
  *  Note that these fares are scored in excess to anything set in the modeparams in the config file.
  */
-/**
- *
- */
-
 public class TaxiFareHandler implements LinkEnterEventHandler, PersonEntersVehicleEventHandler,
 		PersonDepartureEventHandler, PersonArrivalEventHandler {
 	
@@ -82,8 +76,8 @@ public class TaxiFareHandler implements LinkEnterEventHandler, PersonEntersVehic
 	@Inject
 	public TaxiFareHandler(Config config, EventsManager events, Network network) {
 		TaxiFareConfigGroup taxiFareConfigGroup = TaxiFareConfigGroup.get(config);
-		this.mode = TaxiConfigGroup.get(config).getMode();
-		this.events= events;
+		this.mode =  taxiFareConfigGroup.getMode();
+		this.events = events;
 		this.network = network;
 		this.distanceFare_Meter = taxiFareConfigGroup.getDistanceFare_m();
 		this.baseFare = taxiFareConfigGroup.getBasefare();


### PR DESCRIPTION
This allows us to use the fare handler for taxi or drt.

Previously it used to be the mode from the dvrp config group, but since the mode was moved to the drt / taxi config group this handler was only working for taxi.