### PR TITLE
Request validator for taxi

### DIFF
--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/TaxiRequest.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/TaxiRequest.java
@@ -40,7 +40,7 @@ public class TaxiRequest implements PassengerRequest {
 		PICKUP, RIDE, DROPOFF,
 
 		PERFORMED, //
-		// REJECTED, // rejected by the DISPATCHER
+		REJECTED, // rejected by the DISPATCHER
 		// CANCELLED, // canceled by the CUSTOMER
 		;
 	}
@@ -49,6 +49,8 @@ public class TaxiRequest implements PassengerRequest {
 	private final double submissionTime;
 	private final double earliestStartTime;
 
+	private boolean rejected = false;
+	
 	private final MobsimPassengerAgent passenger;
 	private final Link fromLink;
 	private final Link toLink;
@@ -94,6 +96,15 @@ public class TaxiRequest implements PassengerRequest {
 	@Override
 	public MobsimPassengerAgent getPassenger() {
 		return passenger;
+	}
+	
+	@Override
+	public boolean isRejected() {
+		return rejected;
+	}
+
+	public void setRejected(boolean rejected) {
+		this.rejected = rejected;
 	}
 
 	public TaxiPickupTask getPickupTask() {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/validator/DefaultTaxiRequestValidator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/validator/DefaultTaxiRequestValidator.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -17,29 +17,25 @@
  *                                                                         *
  * *********************************************************************** */
 
-package org.matsim.contrib.taxi.optimizer.fifo;
+package org.matsim.contrib.taxi.data.validator;
 
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.data.Fleet;
-import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
-import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
+import java.util.Collections;
+import java.util.Set;
+
+import org.matsim.contrib.taxi.data.TaxiRequest;
 
 /**
- * @author michalm
+ * Accepts all taxi requests as long as the start and end link are different.
+ *
+ * @author jbischoff, ikaddoura
  */
-public class FifoTaxiOptimizer extends DefaultTaxiOptimizer {
+public class DefaultTaxiRequestValidator implements TaxiRequestValidator {
+	public static final String EQUAL_FROM_LINK_AND_TO_LINK_CAUSE = "eqal_fromLink_and_toLink";
 
-	public FifoTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			TravelTime travelTime, TravelDisutility travelDisutility, TaxiScheduler scheduler,
-			FifoTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
-		super(taxiCfg, fleet, scheduler, params,
-				new FifoRequestInserter(network, fleet, timer, travelTime, travelDisutility, scheduler),
-				requestValidator, events);
+	@Override
+	public Set<String> validateTaxiRequest(TaxiRequest request) {
+		return request.getFromLink() == request.getToLink() ?
+				Collections.singleton(EQUAL_FROM_LINK_AND_TO_LINK_CAUSE) :
+				Collections.emptySet();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/validator/TaxiRequestValidator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/data/validator/TaxiRequestValidator.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -17,29 +17,27 @@
  *                                                                         *
  * *********************************************************************** */
 
-package org.matsim.contrib.taxi.optimizer.fifo;
+package org.matsim.contrib.taxi.data.validator;
 
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.data.Fleet;
-import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
-import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
+import java.util.Set;
+
+import org.matsim.contrib.taxi.data.TaxiRequest;
 
 /**
- * @author michalm
+ * Validates (for the optimizer), whether a taxi request should be served or not (e.g. for limitations in business area or
+ * distance or time)
+ *
+ * @author jbischoff, ikaddoura
  */
-public class FifoTaxiOptimizer extends DefaultTaxiOptimizer {
-
-	public FifoTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			TravelTime travelTime, TravelDisutility travelDisutility, TaxiScheduler scheduler,
-			FifoTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
-		super(taxiCfg, fleet, scheduler, params,
-				new FifoRequestInserter(network, fleet, timer, travelTime, travelDisutility, scheduler),
-				requestValidator, events);
-	}
+public interface TaxiRequestValidator {
+	/**
+	 * Checks if the request can be served given some spatiotemporal (limited time and area of operations) or other constraints.
+	 * <p>
+	 * Preferred format for causes: underscores instead of spaces.
+	 *
+	 * @param request to be validated
+	 * @return set containing causes of constraint violations. An empty set means the request fulfills all
+	 * constraints and may be considered by the optimizer (although this does not guarantee it will get scheduled)
+	 */
+	Set<String> validateTaxiRequest(TaxiRequest request);
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
@@ -21,8 +21,12 @@ package org.matsim.contrib.taxi.optimizer;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.events.PersonStuckEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.data.Request;
@@ -30,16 +34,21 @@ import org.matsim.contrib.dvrp.data.Vehicle;
 import org.matsim.contrib.dvrp.passenger.PassengerRequests;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.taxi.data.TaxiRequest;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
+import org.matsim.contrib.taxi.passenger.TaxiRequestRejectedEvent;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiTask;
 import org.matsim.contrib.taxi.schedule.TaxiTask.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeSimStepEvent;
 
 /**
  * @author michalm
  */
 public class DefaultTaxiOptimizer implements TaxiOptimizer {
+	private static final Logger log = Logger.getLogger(DefaultTaxiOptimizer.class);
+
 	private final Fleet fleet;
 	private final TaxiScheduler scheduler;
 
@@ -50,15 +59,21 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 	private final boolean destinationKnown;
 	private final boolean vehicleDiversion;
 	private final DefaultTaxiOptimizerParams params;
+	
+	private final EventsManager eventsManager;
+	private final TaxiRequestValidator requestValidator;
 
 	private boolean requiresReoptimization = false;
 
 	public DefaultTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
-			DefaultTaxiOptimizerParams params, UnplannedRequestInserter requestInserter) {
+			DefaultTaxiOptimizerParams params, UnplannedRequestInserter requestInserter,
+			TaxiRequestValidator requestValidator, EventsManager eventsManager) {
 		this.fleet = fleet;
 		this.scheduler = scheduler;
 		this.requestInserter = requestInserter;
 		this.params = params;
+		this.requestValidator = requestValidator;
+		this.eventsManager = eventsManager;
 
 		destinationKnown = taxiCfg.isDestinationKnown();
 		vehicleDiversion = taxiCfg.isVehicleDiversion();
@@ -109,7 +124,22 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 
 	@Override
 	public void requestSubmitted(Request request) {
-		unplannedRequests.add((TaxiRequest)request);
+		TaxiRequest taxiRequest = (TaxiRequest)request;
+		Set<String> violations = requestValidator.validateTaxiRequest(taxiRequest);
+		
+		if (!violations.isEmpty()) {
+			String causes = violations.stream().collect(Collectors.joining(", "));
+			log.warn("Request " + request.getId() + " will not be served. The agent will get stuck. Causes: " + causes);
+			taxiRequest.setRejected(true);
+			eventsManager.processEvent(
+					new TaxiRequestRejectedEvent(taxiRequest.getSubmissionTime(), taxiRequest.getId(), causes));
+			eventsManager.processEvent(
+					new PersonStuckEvent(taxiRequest.getSubmissionTime(), taxiRequest.getPassenger().getId(),
+							taxiRequest.getFromLink().getId(), taxiRequest.getPassenger().getMode()));
+			return;
+		}
+
+		unplannedRequests.add(taxiRequest);
 		requiresReoptimization = true;
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizer;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.fifo.FifoTaxiOptimizer;
@@ -36,6 +37,7 @@ import org.matsim.contrib.taxi.optimizer.zonal.ZonalTaxiOptimizerParams;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.run.Taxi;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -59,12 +61,15 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final TravelTime travelTime;
 	private final TravelDisutility travelDisutility;
 	private final TaxiScheduler scheduler;
+	private final TaxiRequestValidator requestValidator;
+	private final EventsManager events;
 
 	@Inject
 	public DefaultTaxiOptimizerProvider(TaxiConfigGroup taxiCfg, @Taxi Fleet fleet,
 			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, MobsimTimer timer,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			@Named(TAXI_OPTIMIZER) TravelDisutility travelDisutility, TaxiScheduler scheduler) {
+			@Named(TAXI_OPTIMIZER) TravelDisutility travelDisutility, TaxiScheduler scheduler,
+			TaxiRequestValidator requestValidator, EventsManager events) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
 		this.network = network;
@@ -72,6 +77,8 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 		this.travelTime = travelTime;
 		this.travelDisutility = travelDisutility;
 		this.scheduler = scheduler;
+		this.requestValidator = requestValidator;
+		this.events = events;
 	}
 
 	@Override
@@ -82,19 +89,19 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 		switch (type) {
 			case ASSIGNMENT:
 				return new AssignmentTaxiOptimizer(taxiCfg, fleet, network, timer, travelTime, travelDisutility,
-						scheduler, new AssignmentTaxiOptimizerParams(optimizerConfig));
+						scheduler, new AssignmentTaxiOptimizerParams(optimizerConfig), requestValidator, events);
 
 			case FIFO:
 				return new FifoTaxiOptimizer(taxiCfg, fleet, network, timer, travelTime, travelDisutility, scheduler,
-						new FifoTaxiOptimizerParams(optimizerConfig));
+						new FifoTaxiOptimizerParams(optimizerConfig), requestValidator, events);
 
 			case RULE_BASED:
 				return RuleBasedTaxiOptimizer.create(taxiCfg, fleet, scheduler, network, timer, travelTime,
-						travelDisutility, new RuleBasedTaxiOptimizerParams(optimizerConfig));
+						travelDisutility, new RuleBasedTaxiOptimizerParams(optimizerConfig), requestValidator, events);
 
 			case ZONAL:
 				return ZonalTaxiOptimizer.create(taxiCfg, fleet, scheduler, network, timer, travelTime,
-						travelDisutility, new ZonalTaxiOptimizerParams(optimizerConfig));
+						travelDisutility, new ZonalTaxiOptimizerParams(optimizerConfig), requestValidator, events);
 
 			default:
 				throw new IllegalStateException();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizer.java
@@ -21,9 +21,11 @@ package org.matsim.contrib.taxi.optimizer.assignment;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.data.Fleet;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -34,13 +36,15 @@ import org.matsim.core.router.util.TravelTime;
 public class AssignmentTaxiOptimizer extends DefaultTaxiOptimizer {
 	public AssignmentTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
 			TravelTime travelTime, TravelDisutility travelDisutility, TaxiScheduler scheduler,
-			AssignmentTaxiOptimizerParams params) {
+			AssignmentTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
 		this(taxiCfg, fleet, scheduler, params,
-				new AssignmentRequestInserter(fleet, network, timer, travelTime, travelDisutility, scheduler, params));
+				new AssignmentRequestInserter(fleet, network, timer, travelTime, travelDisutility, scheduler, params),
+				requestValidator, events);
 	}
 
 	public AssignmentTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
-			AssignmentTaxiOptimizerParams params, AssignmentRequestInserter requestInserter) {
-		super(taxiCfg, fleet, scheduler, params, requestInserter);
+			AssignmentTaxiOptimizerParams params, AssignmentRequestInserter requestInserter,
+			TaxiRequestValidator requestValidator, EventsManager events) {
+		super(taxiCfg, fleet, scheduler, params, requestInserter, requestValidator, events);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.taxi.data.TaxiRequest;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
 import org.matsim.contrib.taxi.optimizer.UnplannedRequestInserter;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -36,6 +37,7 @@ import org.matsim.contrib.taxi.schedule.TaxiTask.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystem;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -46,20 +48,21 @@ import org.matsim.core.router.util.TravelTime;
 public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 	public static RuleBasedTaxiOptimizer create(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
 			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
-			RuleBasedTaxiOptimizerParams params) {
+			RuleBasedTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
 		return create(taxiCfg, fleet, scheduler, network, timer, travelTime, travelDisutility, params,
-				new SquareGridSystem(network, params.cellSize));
+				new SquareGridSystem(network, params.cellSize), requestValidator, events);
 	}
 
 	public static RuleBasedTaxiOptimizer create(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
 			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
-			RuleBasedTaxiOptimizerParams params, ZonalSystem zonalSystem) {
+			RuleBasedTaxiOptimizerParams params, ZonalSystem zonalSystem,
+			TaxiRequestValidator requestValidator, EventsManager events) {
 		IdleTaxiZonalRegistry idleTaxiRegistry = new IdleTaxiZonalRegistry(zonalSystem, scheduler);
 		UnplannedRequestZonalRegistry unplannedRequestRegistry = new UnplannedRequestZonalRegistry(zonalSystem);
 		RuleBasedRequestInserter requestInserter = new RuleBasedRequestInserter(scheduler, timer, network, travelTime,
 				travelDisutility, params, idleTaxiRegistry, unplannedRequestRegistry);
 		return new RuleBasedTaxiOptimizer(taxiCfg, fleet, scheduler, params, idleTaxiRegistry, unplannedRequestRegistry,
-				requestInserter);
+				requestInserter, requestValidator, events);
 	}
 
 	private final TaxiScheduler scheduler;
@@ -68,8 +71,9 @@ public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 
 	public RuleBasedTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
 			RuleBasedTaxiOptimizerParams params, IdleTaxiZonalRegistry idleTaxiRegistry,
-			UnplannedRequestZonalRegistry unplannedRequestRegistry, UnplannedRequestInserter requestInserter) {
-		super(taxiCfg, fleet, scheduler, params, requestInserter);
+			UnplannedRequestZonalRegistry unplannedRequestRegistry, UnplannedRequestInserter requestInserter,
+			TaxiRequestValidator requestValidator, EventsManager events) {
+		super(taxiCfg, fleet, scheduler, params, requestInserter, requestValidator, events);
 
 		this.scheduler = scheduler;
 		this.idleTaxiRegistry = idleTaxiRegistry;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/zonal/ZonalTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/zonal/ZonalTaxiOptimizer.java
@@ -21,6 +21,7 @@ package org.matsim.contrib.taxi.optimizer.zonal;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.data.Fleet;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.contrib.taxi.optimizer.rules.IdleTaxiZonalRegistry;
 import org.matsim.contrib.taxi.optimizer.rules.RuleBasedTaxiOptimizer;
 import org.matsim.contrib.taxi.optimizer.rules.UnplannedRequestZonalRegistry;
@@ -28,6 +29,7 @@ import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystem;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -35,25 +37,27 @@ import org.matsim.core.router.util.TravelTime;
 public class ZonalTaxiOptimizer extends RuleBasedTaxiOptimizer {
 	public static ZonalTaxiOptimizer create(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
 			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
-			ZonalTaxiOptimizerParams params) {
+			ZonalTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
 		return create(taxiCfg, fleet, scheduler, network, timer, travelTime, travelDisutility, params,
-				new SquareGridSystem(network, params.cellSize));
+				new SquareGridSystem(network, params.cellSize), requestValidator, events);
 	}
 
 	public static ZonalTaxiOptimizer create(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler,
 			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
-			ZonalTaxiOptimizerParams params, ZonalSystem zonalSystem) {
+			ZonalTaxiOptimizerParams params, ZonalSystem zonalSystem,
+			TaxiRequestValidator requestValidator, EventsManager events) {
 		IdleTaxiZonalRegistry idleTaxiRegistry = new IdleTaxiZonalRegistry(zonalSystem, scheduler);
 		UnplannedRequestZonalRegistry unplannedRequestRegistry = new UnplannedRequestZonalRegistry(zonalSystem);
 		ZonalRequestInserter requestInserter = new ZonalRequestInserter(fleet, scheduler, timer, network, travelTime,
 				travelDisutility, params, idleTaxiRegistry, unplannedRequestRegistry);
 		return new ZonalTaxiOptimizer(taxiCfg, fleet, scheduler, network, params, idleTaxiRegistry,
-				unplannedRequestRegistry, requestInserter);
+				unplannedRequestRegistry, requestInserter, requestValidator, events);
 	}
 
 	public ZonalTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduler scheduler, Network network,
 			ZonalTaxiOptimizerParams params, IdleTaxiZonalRegistry idleTaxiRegistry,
-			UnplannedRequestZonalRegistry unplannedRequestRegistry, ZonalRequestInserter requestInserter) {
-		super(taxiCfg, fleet, scheduler, params, idleTaxiRegistry, unplannedRequestRegistry, requestInserter);
+			UnplannedRequestZonalRegistry unplannedRequestRegistry, ZonalRequestInserter requestInserter,
+			TaxiRequestValidator requestValidator, EventsManager events) {
+		super(taxiCfg, fleet, scheduler, params, idleTaxiRegistry, unplannedRequestRegistry, requestInserter, requestValidator, events);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequestRejectedEvent.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequestRejectedEvent.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -17,29 +17,54 @@
  *                                                                         *
  * *********************************************************************** */
 
-package org.matsim.contrib.taxi.optimizer.fifo;
+package org.matsim.contrib.taxi.passenger;
 
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.data.Fleet;
-import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
-import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.contrib.dvrp.data.Request;
 
 /**
  * @author michalm
  */
-public class FifoTaxiOptimizer extends DefaultTaxiOptimizer {
+public class TaxiRequestRejectedEvent extends Event {
+	public static final String EVENT_TYPE = "TaxiRequest rejected";
 
-	public FifoTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			TravelTime travelTime, TravelDisutility travelDisutility, TaxiScheduler scheduler,
-			FifoTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
-		super(taxiCfg, fleet, scheduler, params,
-				new FifoRequestInserter(network, fleet, timer, travelTime, travelDisutility, scheduler),
-				requestValidator, events);
+	public static final String ATTRIBUTE_REQUEST = "request";
+	public static final String ATTRIBUTE_CAUSE = "cause";
+
+	private final Id<Request> requestId;
+
+	private final String cause;
+
+	public TaxiRequestRejectedEvent(double time, Id<Request> requestId, String cause) {
+		super(time);
+		this.requestId = requestId;
+		this.cause = cause;
+	}
+
+	@Override
+	public String getEventType() {
+		return EVENT_TYPE;
+	}
+
+	/**
+	 * the ID of the initial request submitted
+	 */
+	public Id<Request> getRequestId() {
+		return requestId;
+	}
+
+	public String getCause() {
+		return cause;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_REQUEST, requestId + "");
+		attr.put(ATTRIBUTE_CAUSE, cause);
+		return attr;
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequestRejectedEventHandler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequestRejectedEventHandler.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -17,29 +17,17 @@
  *                                                                         *
  * *********************************************************************** */
 
-package org.matsim.contrib.taxi.optimizer.fifo;
+/**
+ * 
+ */
+package org.matsim.contrib.taxi.passenger;
 
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.data.Fleet;
-import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
-import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizer;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.events.handler.EventHandler;
 
 /**
- * @author michalm
+ * @author jbischoff
+ *
  */
-public class FifoTaxiOptimizer extends DefaultTaxiOptimizer {
-
-	public FifoTaxiOptimizer(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			TravelTime travelTime, TravelDisutility travelDisutility, TaxiScheduler scheduler,
-			FifoTaxiOptimizerParams params, TaxiRequestValidator requestValidator, EventsManager events) {
-		super(taxiCfg, fleet, scheduler, params,
-				new FifoRequestInserter(network, fleet, timer, travelTime, travelDisutility, scheduler),
-				requestValidator, events);
-	}
+public interface TaxiRequestRejectedEventHandler extends EventHandler {
+	public void handleEvent(final TaxiRequestRejectedEvent event);
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModule.java
@@ -23,6 +23,8 @@ import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.data.file.FleetProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dynagent.run.DynRoutingModule;
+import org.matsim.contrib.taxi.data.validator.DefaultTaxiRequestValidator;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizerProvider;
 import org.matsim.contrib.taxi.passenger.SubmittedTaxiRequestsCollector;
 import org.matsim.contrib.taxi.util.TaxiSimulationConsistencyChecker;
@@ -63,5 +65,7 @@ public final class TaxiModule extends AbstractModule {
 			addMobsimListenerBinding().toProvider(TaxiStatusTimeProfileCollectorProvider.class);
 			// add more time profiles if necessary
 		}
+		
+		bind(TaxiRequestValidator.class).to(DefaultTaxiRequestValidator.class);
 	}
 }

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
@@ -19,11 +19,18 @@
 
 package org.matsim.contrib.taxi.run;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.taxi.data.TaxiRequest;
+import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
@@ -40,6 +47,11 @@ public class RunTaxiScenarioTestIT {
 	public void testRunMielecHighDemandLowSupply() {
 		runMielec("plans_taxi_4.0.xml.gz", "taxis-25.xml");
 	}
+	
+	@Test
+	public void testRunWithRejection() {
+		runMielecWithRejection("plans_taxi_4.0.xml.gz", "taxis-25.xml");
+	}
 
 	private void runMielec(String plansFile, String taxisFile) {
 		String configFile = "mielec_2014_02/mielec_taxi_config.xml";
@@ -50,5 +62,32 @@ public class RunTaxiScenarioTestIT {
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		config.controler().setDumpDataAtEnd(false);
 		TaxiControlerCreator.createControler(config, false).run();
+	}
+	
+	private void runMielecWithRejection(String plansFile, String taxisFile) {
+		String configFile = "mielec_2014_02/mielec_taxi_config.xml";
+		TaxiConfigGroup taxiCfg = new TaxiConfigGroup();
+		Config config = ConfigUtils.loadConfig(configFile, taxiCfg, new DvrpConfigGroup(), new OTFVisConfigGroup());
+		config.plans().setInputFile(plansFile);
+		taxiCfg.setTaxisFile(taxisFile);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		config.controler().setDumpDataAtEnd(false);
+		Controler controler = TaxiControlerCreator.createControler(config, false);
+		
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				this.bind(TaxiRequestValidator.class).toInstance(new TaxiRequestValidator() {
+					@Override
+					public Set<String> validateTaxiRequest(TaxiRequest request) {
+						return request.getPassenger().getId().toString().equals("0000009") ?
+								Collections.singleton("REJECT_0000009") :
+								Collections.emptySet();
+					}
+				});
+			}
+		});
+		
+		controler.run();
 	}
 }

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
@@ -22,8 +22,10 @@ package org.matsim.contrib.taxi.run;
 import java.util.Collections;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.taxi.data.TaxiRequest;
 import org.matsim.contrib.taxi.data.validator.TaxiRequestValidator;
@@ -70,8 +72,10 @@ public class RunTaxiScenarioTestIT {
 		Config config = ConfigUtils.loadConfig(configFile, taxiCfg, new DvrpConfigGroup(), new OTFVisConfigGroup());
 		config.plans().setInputFile(plansFile);
 		taxiCfg.setTaxisFile(taxisFile);
+		taxiCfg.setBreakSimulationIfNotAllRequestsServed(false);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		config.controler().setDumpDataAtEnd(false);
+		config.qsim().setEndTime(36. * 3600);
 		Controler controler = TaxiControlerCreator.createControler(config, false);
 		
 		controler.addOverridingModule(new AbstractModule() {
@@ -89,5 +93,7 @@ public class RunTaxiScenarioTestIT {
 		});
 		
 		controler.run();
+		
+		Assert.assertEquals(-476.003472470419, controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("0000009")).getSelectedPlan().getScore(), utils.EPSILON);
 	}
 }


### PR DESCRIPTION
adding the request validation functionality to the taxi module, similar to the drt module

@michalmac, I know you are planning to slim down the taxi contrib and reuse drt functionality. However, I need the request validation functionality right now and didn't really see an easy way other than copy-paste from the DRT module and rename + adjust.

I also added a test where a single agent's request is rejected.

Hope you are ok with my changes in the taxi module, at least for a temporary solution.