### PR TITLE
adding a config parameter to taxi config group

### DIFF
--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
@@ -62,6 +62,7 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 	
 	private final EventsManager eventsManager;
 	private final TaxiRequestValidator requestValidator;
+	private final boolean printDetailedWarnings;
 
 	private boolean requiresReoptimization = false;
 
@@ -77,6 +78,7 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 
 		destinationKnown = taxiCfg.isDestinationKnown();
 		vehicleDiversion = taxiCfg.isVehicleDiversion();
+		this.printDetailedWarnings = taxiCfg.isPrintDetailedWarnings();
 	}
 
 	@Override
@@ -129,7 +131,7 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 		
 		if (!violations.isEmpty()) {
 			String causes = violations.stream().collect(Collectors.joining(", "));
-			log.warn("Request " + request.getId() + " will not be served. The agent will get stuck. Causes: " + causes);
+			if (printDetailedWarnings) log.warn("Request " + request.getId() + " will not be served. The agent will get stuck. Causes: " + causes);
 			taxiRequest.setRejected(true);
 			eventsManager.processEvent(
 					new TaxiRequestRejectedEvent(taxiRequest.getSubmissionTime(), taxiRequest.getId(), causes));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -90,6 +90,9 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	public static final String DETAILED_STATS = "detailedStats";
 	static final String DETAILED_STATS_EXP = "If true, detailed hourly taxi stats are dumped after each iteration."
 			+ " False by default.";
+	
+	public static final String PRINT_WARNINGS = "plotDetailedWarnings";
+	static final String PRINT_WARNINGS_EXP = "Prints detailed warnings for taxi customers that cannot be served or routed. True by default.";
 
 	public static final String BREAK_IF_NOT_ALL_REQUESTS_SERVED = "breakIfNotAllRequestsServed";
 	static final String BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP =
@@ -126,6 +129,8 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 	private boolean detailedStats = false;
 
 	private boolean breakSimulationIfNotAllRequestsServed = true;
+	
+	private boolean printDetailedWarnings = true;
 
 	public TaxiConfigGroup() {
 		super(GROUP_NAME);
@@ -147,6 +152,7 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 		map.put(DETAILED_STATS, DETAILED_STATS_EXP);
 		map.put(BREAK_IF_NOT_ALL_REQUESTS_SERVED, BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP);
 		map.put(OPTIMIZER_PARAMETER_SET, OPTIMIZER_PARAMETER_SET_EXP);
+		map.put(PRINT_WARNINGS, PRINT_WARNINGS_EXP);
 		return map;
 	}
 
@@ -353,5 +359,15 @@ public class TaxiConfigGroup extends ReflectiveConfigGroup {
 
 	public URL getTaxisFileUrl(URL context) {
 		return ConfigGroup.getInputFileURL(context, this.taxisFile);
+	}
+
+	@StringGetter(PRINT_WARNINGS)
+	public boolean isPrintDetailedWarnings() {
+		return printDetailedWarnings;
+	}
+
+	@StringSetter(PRINT_WARNINGS)
+	public void setPrintDetailedWarnings(boolean printDetailedWarnings) {
+		this.printDetailedWarnings = printDetailedWarnings;
 	}
 }


### PR DESCRIPTION
allows to switch off detailed print out of warnings in case of passenger
request rejections