### PR TITLE
Small change to CoordUtils: Mixing 2d and 3d coordinates will not lea…

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/geometry/CoordUtils.java
+++ b/matsim/src/main/java/org/matsim/core/utils/geometry/CoordUtils.java
@@ -23,6 +23,7 @@ package org.matsim.core.utils.geometry;
 import com.vividsolutions.jts.geom.Coordinate;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.core.gbl.Gbl;
 
 public abstract class CoordUtils {
 	final private static Logger LOG = Logger.getLogger(CoordUtils.class);
@@ -319,7 +320,8 @@ public abstract class CoordUtils {
 			throw new RuntimeException("All given coordinates must either be 2D, or 3D. A mix is not allowed.");
 		}
 	}
-	
+
+	private static boolean onlyOnceWarnGiven = false;
 	
 	/**
 	 * Calculates the coordinate of the intersection point of the orthogonal projection
@@ -377,7 +379,12 @@ public abstract class CoordUtils {
 			Coord q = plus(lineFrom, scalarMult(t0, direction));
 			return q;
 		} else{
-			throw new RuntimeException("All given coordinates must either be 2D, or 3D. A mix is not allowed.");
+			if (!onlyOnceWarnGiven) {
+				Logger.getLogger(CoordUtils.class).warn("Mix of 2D / 3D coordinates. Assuming 2D only.\n" + Gbl.ONLYONCE);
+				onlyOnceWarnGiven = true;
+			}
+			return orthogonalProjectionOnLineSegment(new Coord(lineFrom.getX(), lineFrom.getY()), new Coord(lineTo.getX(), lineTo.getY()), new Coord(point.getX(), point.getY()));
+			//throw new RuntimeException("All given coordinates must either be 2D, or 3D. A mix is not allowed.");
 		}
 	}
 }


### PR DESCRIPTION
…d to an Exception anymore, but give a warning. 
I think this is a more desired functionality, as nodes may be 3D coordinates, whereas ACtivity locations are usually only 2D (and adding a third dimension is not really a useful information).
It is also in line with CoordUtils.getDistance.