### PR TITLE
replace file access with URL instead of String/filename (AGAIN!!!)

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
@@ -19,28 +19,36 @@
  * *********************************************************************** */
 package org.matsim.contrib.emissions;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.emissions.ColdEmissionAnalysisModule.ColdEmissionAnalysisModuleParameter;
 import org.matsim.contrib.emissions.WarmEmissionAnalysisModule.WarmEmissionAnalysisModuleParameter;
-import org.matsim.contrib.emissions.roadTypeMapping.*;
-import org.matsim.contrib.emissions.types.*;
-import org.matsim.contrib.emissions.utils.EmissionUtils;
+import org.matsim.contrib.emissions.roadTypeMapping.HbefaRoadTypeMapping;
+import org.matsim.contrib.emissions.roadTypeMapping.LinkHbefaMapping;
+import org.matsim.contrib.emissions.roadTypeMapping.OsmHbefaMapping;
+import org.matsim.contrib.emissions.types.ColdPollutant;
+import org.matsim.contrib.emissions.types.HbefaColdEmissionFactor;
+import org.matsim.contrib.emissions.types.HbefaColdEmissionFactorKey;
+import org.matsim.contrib.emissions.types.HbefaTrafficSituation;
+import org.matsim.contrib.emissions.types.HbefaVehicleAttributes;
+import org.matsim.contrib.emissions.types.HbefaVehicleCategory;
+import org.matsim.contrib.emissions.types.HbefaWarmEmissionFactor;
+import org.matsim.contrib.emissions.types.HbefaWarmEmissionFactorKey;
+import org.matsim.contrib.emissions.types.WarmPollutant;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.events.EventsUtils;
-import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.Vehicles;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.matsim.contrib.emissions.utils.EmissionUtils.createIndexFromKey;
 
@@ -60,11 +68,11 @@ public class EmissionModule {
 
 	//===
 
-	private static String averageFleetColdEmissionFactorsFile;
-	private static String averageFleetWarmEmissionFactorsFile;
+	private static URL averageFleetColdEmissionFactorsFile;
+	private static URL averageFleetWarmEmissionFactorsFile;
 
-	private static String detailedWarmEmissionFactorsFile;
-	private static String detailedColdEmissionFactorsFile;
+	private static URL detailedWarmEmissionFactorsFile;
+	private static URL detailedColdEmissionFactorsFile;
 	
 	//===
 	private Vehicles vehicles;
@@ -141,12 +149,12 @@ public class EmissionModule {
 	private void getInputFiles() {
 		URL context = scenario.getConfig().getContext();
 
-		averageFleetWarmEmissionFactorsFile = emissionConfigGroup.getAverageWarmEmissionFactorsFileURL(context).getFile();
-		averageFleetColdEmissionFactorsFile = emissionConfigGroup.getAverageColdEmissionFactorsFileURL(context).getFile();
+		averageFleetWarmEmissionFactorsFile = emissionConfigGroup.getAverageWarmEmissionFactorsFileURL(context);
+		averageFleetColdEmissionFactorsFile = emissionConfigGroup.getAverageColdEmissionFactorsFileURL(context);
 		
 		if(emissionConfigGroup.isUsingDetailedEmissionCalculation()) {
-			detailedWarmEmissionFactorsFile = emissionConfigGroup.getDetailedWarmEmissionFactorsFileURL(context).getFile();
-			detailedColdEmissionFactorsFile = emissionConfigGroup.getDetailedColdEmissionFactorsFileURL(context).getFile();
+			detailedWarmEmissionFactorsFile = emissionConfigGroup.getDetailedWarmEmissionFactorsFileURL(context);
+			detailedColdEmissionFactorsFile = emissionConfigGroup.getDetailedColdEmissionFactorsFileURL(context);
 		}
 	}
 
@@ -192,7 +200,7 @@ public class EmissionModule {
 	}
 
 	
-	private Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> createAvgHbefaWarmTable(String filename){
+	private Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> createAvgHbefaWarmTable(URL filename){
 		logger.info("entering createAvgHbefaWarmTable ...");
 		
 		Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> avgWarmTable = new HashMap<>();
@@ -226,7 +234,7 @@ public class EmissionModule {
 		return avgWarmTable;
 	}
 	
-	private Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> createAvgHbefaColdTable(String filename){
+	private Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> createAvgHbefaColdTable(URL filename){
 		logger.info("entering createAvgHbefaColdTable ...");
 		
 		Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> avgColdTable = new HashMap<>();
@@ -258,7 +266,7 @@ public class EmissionModule {
 		return avgColdTable;
 	}
 	
-	private Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> createDetailedHbefaWarmTable(String filename){
+	private Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> createDetailedHbefaWarmTable(URL filename){
 		logger.info("entering createDetailedHbefaWarmTable ...");
 
 		Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> hbefaWarmTableDetailed = new HashMap<>() ;
@@ -295,7 +303,7 @@ public class EmissionModule {
 		return hbefaWarmTableDetailed;
 	}
 	
-	private Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> createDetailedHbefaColdTable(String filename) {
+	private Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> createDetailedHbefaColdTable(URL filename) {
 		logger.info("entering createDetailedHbefaColdTable ...");
 		
 		Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> hbefaColdTableDetailed = new HashMap<>();


### PR DESCRIPTION
URL.getFile() does not return a valid path to a file in the filesystem, but returns the filename-part of the URL. That filename-part uses a special encoding for certain characters (e.g. a whitespace is encoded as %20) which is only valid in URLs, but not in the local filesystem. Thus file-access in the local filesystem might file when using URL.getFile() when the path or filename contains whitespace or other special characters. Fix this by changing the file access to use the URLs instead of the filename-Strings.