### PR TITLE
replace file access with URL instead of String/filename

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunEmissionToolOnlineExampleV2.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunEmissionToolOnlineExampleV2.java
@@ -65,7 +65,7 @@ public class RunEmissionToolOnlineExampleV2 {
 		//load emissions config
 		EmissionsConfigGroup emissionsConfigGroup =  (EmissionsConfigGroup) config.getModules().get(EmissionsConfigGroup.GROUP_NAME);
 		URL context = scenario.getConfig().getContext();
-		String mappingFile = emissionsConfigGroup.getEmissionRoadTypeMappingFileURL(context).getFile();
+		URL mappingFile = emissionsConfigGroup.getEmissionRoadTypeMappingFileURL(context);
 
 		//add Hbefa mappings to the network
 		HbefaRoadTypeMapping vhtm = VisumHbefaRoadTypeMapping.createVisumRoadTypeMapping(mappingFile);

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/archive/RunEmissionToolOfflineExample.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/archive/RunEmissionToolOfflineExample.java
@@ -23,12 +23,11 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.emissions.EmissionModule;
 import org.matsim.contrib.emissions.roadTypeMapping.HbefaRoadTypeMapping;
 import org.matsim.contrib.emissions.roadTypeMapping.VisumHbefaRoadTypeMapping;
-import org.matsim.contrib.emissions.utils.EmissionUtils;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigReader;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.events.algorithms.EventWriterXML;
@@ -68,7 +67,7 @@ public class RunEmissionToolOfflineExample {
 
 		EventsManager eventsManager = EventsUtils.createEventsManager();
 
-		HbefaRoadTypeMapping roadTypeMapping = VisumHbefaRoadTypeMapping.createVisumRoadTypeMapping(ecg.getEmissionRoadTypeMappingFile());
+		HbefaRoadTypeMapping roadTypeMapping = VisumHbefaRoadTypeMapping.createVisumRoadTypeMapping(ecg.getEmissionRoadTypeMappingFileURL(scenario.getConfig().getContext()));
 		EmissionModule emissionModule = new EmissionModule(scenario, eventsManager);
 
 		EventWriterXML emissionEventWriter = new EventWriterXML(emissionEventOutputFile);

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/archive/RunEmissionToolOnlineExample.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/archive/RunEmissionToolOnlineExample.java
@@ -74,7 +74,7 @@ public class RunEmissionToolOnlineExample {
 
 		//load emissions config
 		EmissionsConfigGroup emissionsConfigGroup =  (EmissionsConfigGroup) config.getModules().get(EmissionsConfigGroup.GROUP_NAME);
-		String mappingFile = emissionsConfigGroup.getEmissionRoadTypeMappingFileURL(context).getFile();
+		URL mappingFile = emissionsConfigGroup.getEmissionRoadTypeMappingFileURL(context);
 
 		//add Hbefa mappings to the network
 		HbefaRoadTypeMapping vhtm = VisumHbefaRoadTypeMapping.createVisumRoadTypeMapping(mappingFile);

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/roadTypeMapping/VisumHbefaRoadTypeMapping.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/roadTypeMapping/VisumHbefaRoadTypeMapping.java
@@ -8,6 +8,7 @@ import org.matsim.core.utils.io.IOUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ public class VisumHbefaRoadTypeMapping extends HbefaRoadTypeMapping {
         return new VisumHbefaRoadTypeMapping();
     }
 
-    public static HbefaRoadTypeMapping createVisumRoadTypeMapping(String filename){
+    public static HbefaRoadTypeMapping createVisumRoadTypeMapping(URL filename){
         logger.info("entering createRoadTypeMapping ...") ;
 
         VisumHbefaRoadTypeMapping mapping = new VisumHbefaRoadTypeMapping();


### PR DESCRIPTION
URL.getFile() does not return a valid path to a file in the filesystem, but returns the filename-part of the URL. That filename-part uses a special encoding for certain characters (e.g. a whitespace is encoded as %20) which is only valid in URLs, but not in the local filesystem. Thus file-access in the local filesystem might file when using URL.getFile() when the path or filename contains whitespace or other special characters. Fix this by changing the file access to use the URLs instead of the filename-Strings.