### PR TITLE
QuadTree performance and memory improvements

### DIFF
--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
@@ -93,15 +93,15 @@ public class AccessibilityIntegrationTest {
 	            	
 	            	if (x == 50) {
 	            		if (y == 50) {
-	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", value, 2.1486094237531126, utils.EPSILON);
+	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", 2.1486094237531126, value, utils.EPSILON);
 	            		} else if (y == 150){
-	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", value, 2.1766435716006005, utils.EPSILON);
+	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", 2.1766435716006005, value, utils.EPSILON);
 	            		} 
 	            	} else if (x == 150) {
 	            		if (y == 50) {
-	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", value, 2.1486094237531126, utils.EPSILON);
+	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", 2.1486094237531126, value, utils.EPSILON);
 	            		} else if (y == 150){
-	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", value, 2.2055702759681273, utils.EPSILON);
+	            			Assert.assertEquals("Wrong work accessibility value at x=" + x + ", y=" + y + ":", 2.2055702759681273, value, utils.EPSILON);
 	            		}
 	            	}
             	}
@@ -441,63 +441,63 @@ public class AccessibilityIntegrationTest {
 
 					if (!useOpportunityWeights) {
 						if (x == 50 && y == 50) {
-							expected.accessibilityFreespeed = 2.1486094237531126;
-							expected.accessibilityCar = 2.1482840466191093;
-							expected.accessibilityBike = 2.2257398663221;
-							expected.accessibilityWalk = 1.70054725728361;
+							expected.accessibilityFreespeed = 2.14486658890362;
+							expected.accessibilityCar = 2.14486658890362;
+							expected.accessibilityBike = 2.224157412491891;
+							expected.accessibilityWalk = 1.6634857793433138;
 							expected.accessibilityPt = 2.1581641260040683;
-							expected.accessibilityMatrixBasedPt = 0.461863556339195;
+							expected.accessibilityMatrixBasedPt = 1.6542905235735796;
 						} else if (x == 150 && y == 50) {
-							expected.accessibilityFreespeed = 2.1486094237531126;
-							expected.accessibilityCar = 2.1482840466191093;
-							expected.accessibilityBike = 2.2257398663221;
-							expected.accessibilityWalk = 1.70054725728361;
+							expected.accessibilityFreespeed = 2.14486658890362;
+							expected.accessibilityCar = 2.14486658890362;
+							expected.accessibilityBike = 2.224157412491891;
+							expected.accessibilityWalk = 1.6634857793433138;
 							expected.accessibilityPt = 2.0032465393091434;
-							expected.accessibilityMatrixBasedPt = 0.461863556339195;
+							expected.accessibilityMatrixBasedPt = 1.6542905235735796;
 						} else if (x == 50 && y == 150) {
-							expected.accessibilityFreespeed = 2.1766435716006005;
-							expected.accessibilityCar = 2.176238564675181;
-							expected.accessibilityBike = 2.2445468698643367;
-							expected.accessibilityWalk = 1.7719146868026079;
-							expected.accessibilityPt = 2.057596373646452;
-							expected.accessibilityMatrixBasedPt = 0.461863556339195;
+							expected.accessibilityFreespeed = 2.207441799716032;
+							expected.accessibilityCar = 2.207441799716032;
+							expected.accessibilityBike = 2.2645288908389554;
+							expected.accessibilityWalk = 1.8697283849051263;
+							expected.accessibilityPt = 2.1581641260040683;
+							expected.accessibilityMatrixBasedPt = 1.6542905235735796;
 						} else if (x == 150 && y == 150) {
-							expected.accessibilityFreespeed = 2.2055702759681273;
-							expected.accessibilityCar = 2.2052225231109226;
-							expected.accessibilityBike = 2.2637376515333636;
-							expected.accessibilityWalk = 1.851165291193725;
-							expected.accessibilityPt = 1.9202710265495115;
-							expected.accessibilityMatrixBasedPt = 0.624928280738513;
+							expected.accessibilityFreespeed = 2.235503385314382;
+							expected.accessibilityCar = 2.235503385314382;
+							expected.accessibilityBike = 2.2833435568892395;
+							expected.accessibilityWalk = 1.9418539664691532;
+							expected.accessibilityPt = 2.0032465393091434;
+							expected.accessibilityMatrixBasedPt = 1.5073890466447624;
 						}
 					} else {
 						if (x == 50 && y == 50) {
-							expected.accessibilityFreespeed = 3.534903784873003;
-							expected.accessibilityCar = 3.534578407739;
-							expected.accessibilityBike = 3.6120342274419914;
-							expected.accessibilityWalk = 3.086841618403501;
+							expected.accessibilityFreespeed = 3.531160950023511;
+							expected.accessibilityCar = 3.531160950023511;
+							expected.accessibilityBike = 3.610451773611781;
+							expected.accessibilityWalk = 3.0497801404632043;
 							expected.accessibilityPt = 3.5444584871239586;
-							expected.accessibilityMatrixBasedPt = 1.8481579174590859;
+							expected.accessibilityMatrixBasedPt = 3.0405848846934704;
 						} else if (x == 150 && y == 50) {
-							expected.accessibilityFreespeed = 3.534903784873003;
-							expected.accessibilityCar = 3.534578407739;
-							expected.accessibilityBike = 3.6120342274419914;
-							expected.accessibilityWalk = 3.086841618403501;
+							expected.accessibilityFreespeed = 3.531160950023511;
+							expected.accessibilityCar = 3.531160950023511;
+							expected.accessibilityBike = 3.610451773611781;
+							expected.accessibilityWalk = 3.0497801404632043;
 							expected.accessibilityPt = 3.389540900429034;
-							expected.accessibilityMatrixBasedPt = 1.8481579174590859;
+							expected.accessibilityMatrixBasedPt = 3.0405848846934704;
 						} else if (x == 50 && y == 150) {
-							expected.accessibilityFreespeed = 3.562937932720491;
-							expected.accessibilityCar = 3.5625329257950717;
-							expected.accessibilityBike = 3.6308412309842275;
-							expected.accessibilityWalk = 3.1582090479224982;
-							expected.accessibilityPt = 3.443890734766343;
-							expected.accessibilityMatrixBasedPt = 1.8481579174590859;
+							expected.accessibilityFreespeed = 3.5937361608359226;
+							expected.accessibilityCar = 3.5937361608359226;
+							expected.accessibilityBike = 3.650823251958846;
+							expected.accessibilityWalk = 3.256022746025017;
+							expected.accessibilityPt = 3.5444584871239586;
+							expected.accessibilityMatrixBasedPt = 3.0405848846934704;
 						} else if (x == 150 && y == 150) {
-							expected.accessibilityFreespeed = 3.5918646370880176;
-							expected.accessibilityCar = 3.591516884230813;
-							expected.accessibilityBike = 3.6500320126532544;
-							expected.accessibilityWalk = 3.2374596523136154;
-							expected.accessibilityPt = 3.3065653876694023;
-							expected.accessibilityMatrixBasedPt = 2.0112226418584043;
+							expected.accessibilityFreespeed = 3.621797746434273;
+							expected.accessibilityCar = 3.621797746434273;
+							expected.accessibilityBike = 3.66963791800913;
+							expected.accessibilityWalk = 3.328148327589044;
+							expected.accessibilityPt = 3.389540900429034;
+							expected.accessibilityMatrixBasedPt = 2.893683407764653;
 						}
 					}
 

--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
@@ -433,7 +433,7 @@ public class AccessibilityIntegrationTest {
 		@Override
 		public void setAndProcessSpatialGrids( Map<String,SpatialGrid> spatialGrids ){
 
-			LOG.info("Evaluating resuts ...");
+			LOG.info("Evaluating results ...");
 
 			for(double x = 50; x < 200; x += 100){
 				for(double y = 50; y < 200; y += 100){

--- a/contribs/minibus/src/test/java/org/matsim/contrib/minibus/integration/SubsidyTestIT.java
+++ b/contribs/minibus/src/test/java/org/matsim/contrib/minibus/integration/SubsidyTestIT.java
@@ -49,8 +49,6 @@ import org.matsim.testcases.MatsimTestUtils;
 
 public class SubsidyTestIT implements TabularFileHandler {
 	
-	
-
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils();
 
 	private final ArrayList<String[]> pStatsResults = new ArrayList<>();
@@ -105,7 +103,7 @@ public class SubsidyTestIT implements TabularFileHandler {
 		new TabularFileParser().parse(tabFileParserConfig, this);
 
 		// Check final iteration
-		Assert.assertEquals("Number of budget (final iteration)", "196899309.0522222500", this.pStatsResults.get(2)[9]);	
+		Assert.assertEquals("Number of budget (final iteration)", "196339177.8632777600", this.pStatsResults.get(2)[9]);
 	}
 	
 	@Override

--- a/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
@@ -726,7 +726,6 @@ public class QuadTree<T> implements Serializable {
 			}
 			// no more childs, so we must contain the closest object
 			T closest = null;
-			Leaf<T> closestLeaf = null;
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
 					double distance = Math.sqrt(
@@ -735,75 +734,10 @@ public class QuadTree<T> implements Serializable {
 					if (distance < bestDistance.value) {
 						bestDistance.value = distance;
 						closest = leaf.value != null ? leaf.value : leaf.values.get(0);
-						closestLeaf = leaf;
-					} else if (distance == bestDistance.value) {
-						closestLeaf = backwardsCompatibleSort(x, y, closestLeaf, leaf);
-						closest = closestLeaf.value != null ? closestLeaf.value : closestLeaf.values.get(0);
 					}
 				}
 			}
 			return closest;
-		}
-
-		private Leaf<T> backwardsCompatibleSort(double x, double y, Leaf<T> leaf1, Leaf<T> leaf2) {
-			/*
-			 * In the old quadtree, the first closest object encountered was the one that was inside the same
-			 * quadrant than the search coordinate. If no such object existed, the remaining quadrants were
-			 * searched in the fixed order of NW (0), NE (1), SE (2) and SW (3).
-			 * Try to figure out according to this scheme if first leaf1 or leaf2 would have been found.
-			 */
-			double minX = this.bounds.minX;
-			double minY = this.bounds.minY;
-			double maxX = this.bounds.maxX;
-			double maxY = this.bounds.maxY;
-			double ctrX = this.bounds.centerX;
-			double ctrY = this.bounds.centerY;
-
-			while (true) {
-				int childQ = getChildIndex(ctrX, ctrY, x, y);
-				int child1 = getChildIndex(ctrX, ctrY, leaf1.x, leaf1.y);
-				int child2 = getChildIndex(ctrX, ctrY, leaf2.x, leaf2.y);
-
-				if (child1 == child2) {
-					if (child1 == 0) {
-						maxX = ctrX;
-						minY = ctrY;
-					}
-					if (child1 == 1) {
-						minX = ctrX;
-						minY = ctrY;
-					}
-					if (child1 == 2) {
-						minX = ctrX;
-						maxY = ctrY;
-					}
-					if (child1 == 3) {
-						maxX = ctrX;
-						maxY = ctrY;
-					}
-					ctrX = (maxX + minX) / 2.0;
-					ctrY = (maxY + minY) / 2.0;
-				} else {
-					if (childQ == child1) {
-						return leaf1;
-					}
-					if (childQ == child2) {
-						return leaf2;
-					}
-					return (child1 < child2) ? leaf1 : leaf2;
-				}
-			}
-		}
-
-		private static int getChildIndex(double centerX, double centerY, double x, double y) {
-			if (x < centerX) {
-				if (y < centerY)
-					return 3; // south west
-				return 0; // north west
-			}
-			if (y < centerY)
-				return 2; // south east
-			return 1; // north eath
 		}
 
 		/* default */ Collection<T> getElliptical(

--- a/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
@@ -185,7 +185,7 @@ public class QuadTree<T> implements Serializable {
 					+" y2="+y2
 					+" distance="+distance );
 		}
-		return this.top.getElliptical(x1, y1, x2, y2, distance, new ArrayList<T>());
+		return this.top.getElliptical(x1, y1, x2, y2, distance, new ArrayList<>());
 	}
 
 
@@ -323,9 +323,10 @@ public class QuadTree<T> implements Serializable {
 						private void loadNext() {
 							boolean searching = true;
 							while (searching) {
-								if (this.nextIndex < this.currentLeaf.values.size()) {
+								int size = this.currentLeaf.value != null ? 1 : this.currentLeaf.values.size();
+								if (this.nextIndex < size) {
 									this.nextIndex++;
-									this.next = this.currentLeaf.values.get(this.nextIndex - 1);
+									this.next = this.currentLeaf.value != null ? this.currentLeaf.value : this.currentLeaf.values.get(this.nextIndex - 1);
 									searching = false;
 								} else {
 									this.currentLeaf = nextLeaf(this.currentLeaf);
@@ -574,13 +575,21 @@ public class QuadTree<T> implements Serializable {
 		private static final long serialVersionUID = -6527830222532634476L;
 		final public double x;
 		final public double y;
-		final public ArrayList<T> values;
+		/* a leaf can contain one more multiple objects at the same coordinate.
+		 * in many cases it will be only one, so to save memory, we'll store it in "value".
+		 * only if actually multiple objects at the same coordinate need to be stored,
+		 * we create the values-list and add all objects there.
+		 * So either value or values is non-null. it should never be the case that both are null
+		 * or both are non-null. mrieser/oct2018
+		 */
+		public T value;
+		public ArrayList<T> values;
 
 		public Leaf(final double x, final double y, final T value) {
 			this.x = x;
 			this.y = y;
-			this.values = new ArrayList<>(1);
-			this.values.add(value);
+			this.value = value;
+			this.values = null;
 		}
 	}
 
@@ -611,13 +620,26 @@ public class QuadTree<T> implements Serializable {
 			}
 			for (Leaf<T> l : this.leaves) {
 				if (l.x == leaf.x && l.y == leaf.y) {
-					boolean changed = false;
-					for (T value : leaf.values) {
-						if (!l.values.contains(value)) {
-							changed = l.values.add(value) || changed;
-						}
+					if (leaf.value == l.value) {
+						return false;
 					}
-					return changed;
+					if (l.values != null) {
+						if (l.values.contains(leaf.value)) {
+							return false;
+						}
+						l.values.add(leaf.value);
+						return true;
+					}
+					if (l.value == null) {
+						l.value = leaf.value;
+						return true;
+					} else {
+						l.values = new ArrayList<>(3);
+						l.values.add(l.value);
+						l.value = null;
+						l.values.add(leaf.value);
+						return true;
+					}
 				}
 
 			}
@@ -638,11 +660,18 @@ public class QuadTree<T> implements Serializable {
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
 					if (leaf.x == x && leaf.y == y) {
-						if (leaf.values.remove(value)) {
-							if (leaf.values.size() == 0) {
-								this.leaves.remove(leaf);
-							}
+						if (leaf.value == value) {
+							leaf.value = null;
+							this.leaves.remove(leaf);
 							return true;
+						}
+						if (leaf.values != null) {
+							if (leaf.values.remove(value)) {
+								if (leaf.values.size() == 0) {
+									this.leaves.remove(leaf);
+								}
+								return true;
+							}
 						}
 					}
 				}
@@ -699,14 +728,12 @@ public class QuadTree<T> implements Serializable {
 			T closest = null;
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf.values.size() > 0) {
-						double distance = Math.sqrt(
-								(leaf.x - x) * (leaf.x - x)
-										+ (leaf.y - y) * (leaf.y - y));
-						if (distance < bestDistance.value) {
-							bestDistance.value = distance;
-							closest = leaf.values.get(0);
-						}
+					double distance = Math.sqrt(
+							(leaf.x - x) * (leaf.x - x)
+									+ (leaf.y - y) * (leaf.y - y));
+					if (distance < bestDistance.value) {
+						bestDistance.value = distance;
+						closest = leaf.value != null ? leaf.value : leaf.values.get(0);
 					}
 				}
 			}
@@ -758,17 +785,19 @@ public class QuadTree<T> implements Serializable {
 			// no more childs, so we must contain the closest object
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf.values.size() > 0) {
-						final double distance1 = Math.sqrt(
-								(leaf.x - x1) * (leaf.x - x1)
-										+ (leaf.y - y1) * (leaf.y - y1));
-						// same trick as above, though it should not be useul in the vast
-						// majority of cases
-						if (distance1 <= maxDistance) {
-							final double distance2 = Math.sqrt(
-									(leaf.x - x2) * (leaf.x - x2)
-											+ (leaf.y - y2) * (leaf.y - y2));
-							if (distance1 + distance2 <= maxDistance) {
+					final double distance1 = Math.sqrt(
+							(leaf.x - x1) * (leaf.x - x1)
+									+ (leaf.y - y1) * (leaf.y - y1));
+					// same trick as above, though it should not be useul in the vast
+					// majority of cases
+					if (distance1 <= maxDistance) {
+						final double distance2 = Math.sqrt(
+								(leaf.x - x2) * (leaf.x - x2)
+										+ (leaf.y - y2) * (leaf.y - y2));
+						if (distance1 + distance2 <= maxDistance) {
+							if (leaf.value != null) {
+								values.add(leaf.value);
+							} else {
 								values.addAll(leaf.values);
 							}
 						}
@@ -797,11 +826,13 @@ public class QuadTree<T> implements Serializable {
 			// no more childs, so we must contain the closest object
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf != null && leaf.values.size() > 0) {
-						double distance = Math.sqrt(
-								(leaf.x - x) * (leaf.x - x)
-										+ (leaf.y - y) * (leaf.y - y));
-						if (distance <= maxDistance) {
+					double distance = Math.sqrt(
+							(leaf.x - x) * (leaf.x - x)
+									+ (leaf.y - y) * (leaf.y - y));
+					if (distance <= maxDistance) {
+						if (leaf.value != null) {
+							values.add(leaf.value);
+						} else {
 							values.addAll(leaf.values);
 						}
 					}
@@ -822,11 +853,13 @@ public class QuadTree<T> implements Serializable {
 			// no more childs, so we must contain the closest object
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf.values.size() > 0) {
-						double distance = Math.sqrt(
-								(leaf.x - x) * (leaf.x - x)
-										+ (leaf.y - y) * (leaf.y - y));
-						if (distance <= r_max && distance >= r_min) {
+					double distance = Math.sqrt(
+							(leaf.x - x) * (leaf.x - x)
+									+ (leaf.y - y) * (leaf.y - y));
+					if (distance <= r_max && distance >= r_min) {
+						if (leaf.value != null) {
+							values.add(leaf.value);
+						} else {
 							values.addAll(leaf.values);
 						}
 					}
@@ -863,8 +896,12 @@ public class QuadTree<T> implements Serializable {
 			// no more childs, so we must contain the closest object
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf.values.size() > 0 && bounds.containsOrEquals(leaf.x, leaf.y)) {
-						values.addAll(leaf.values);
+					if (bounds.containsOrEquals(leaf.x, leaf.y)) {
+						if (leaf.value != null) {
+							values.add(leaf.value);
+						} else {
+							values.addAll(leaf.values);
+						}
 					}
 				}
 			}
@@ -891,9 +928,14 @@ public class QuadTree<T> implements Serializable {
 			// no more childs, so we must contain the closest object
 			if (this.leaves != null) {
 				for (Leaf<T> leaf : this.leaves) {
-					if (leaf.values.size() > 0 && globalBounds.contains(leaf.x, leaf.y)) {
-						count += leaf.values.size();
-						for (T object : leaf.values) executor.execute(leaf.x, leaf.y, object);
+					if (globalBounds.contains(leaf.x, leaf.y)) {
+						if (leaf.value != null) {
+							count++;
+							executor.execute(leaf.x, leaf.y, leaf.value);
+						} else {
+							count += leaf.values.size();
+							for (T object : leaf.values) executor.execute(leaf.x, leaf.y, object);
+						}
 					}
 				}
 			}
@@ -984,7 +1026,7 @@ public class QuadTree<T> implements Serializable {
 		}
 
 		public Leaf<T> nextLeaf(final Leaf<T> currentLeaf) {
-			MutableLeaf<T> nextLeaf = new MutableLeaf<T>(null);
+			MutableLeaf<T> nextLeaf = new MutableLeaf<>(null);
 			nextLeaf(currentLeaf, nextLeaf);
 			return nextLeaf.value;
 		}

--- a/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/QuadTree.java
@@ -84,6 +84,9 @@ public class QuadTree<T> implements Serializable {
 	 *         false otherwise.
 	 */
 	public boolean put(final double x, final double y, final T value) {
+		if (!this.top.bounds.containsOrEquals(x, y)) {
+			throw new IllegalArgumentException("cannot add a point at x=" + x + ", y=" + y + " with bounds " + this.top.bounds);
+		}
 		if (this.top.put(x, y, value)) {
 			incrementSize();
 			return true;
@@ -600,9 +603,6 @@ public class QuadTree<T> implements Serializable {
 		}
 
 		public boolean put(final Leaf<T> leaf) {
-			if ( !this.bounds.containsOrEquals( leaf.x , leaf.y ) ) {
-				throw new IllegalArgumentException( "cannot add a point at x="+leaf.x+", y="+leaf.y+" with bounds "+bounds );
-			}
 			if (this.hasChilds) return getChild(leaf.x, leaf.y).put(leaf);
 			if (this.leaves == null) {
 				this.leaves = new ArrayList<>();

--- a/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
@@ -57,7 +57,7 @@ public class QuadTreeTest {
 	 * @return A simple QuadTree with 6 entries for tests.
 	 */
 	private QuadTree<String> getTestTree() {
-		QuadTree<String> qt = new QuadTree<String>(-50.0, -50.0, +150.0, +150.0);
+		QuadTree<String> qt = new QuadTree<>(-50.0, -50.0, +150.0, +150.0);
 
 		qt.put(10.0, 10.0, "10.0, 10.0");
 		qt.put(15.0, 15.0, "15.0, 15.0");
@@ -74,7 +74,7 @@ public class QuadTreeTest {
 	 */
 	@Test
 	public void testConstructor() {
-		QuadTree<String> qt = new QuadTree<String>(-50.0, -40.0, +30.0, +20.0);
+		QuadTree<String> qt = new QuadTree<>(-50.0, -40.0, +30.0, +20.0);
 		assertEquals(-50.0, qt.getMinEasting(), 0.0);
 		assertEquals(-40.0, qt.getMinNorthing(), 0.0);
 		assertEquals(+30.0, qt.getMaxEasting(), 0.0);
@@ -86,7 +86,7 @@ public class QuadTreeTest {
 	 */
 	@Test
 	public void testPut() {
-		QuadTree<String> qt = new QuadTree<String>(-50.0, -50.0, +150.0, +150.0);
+		QuadTree<String> qt = new QuadTree<>(-50.0, -50.0, +150.0, +150.0);
 		assertEquals(0, qt.size());
 		qt.put(10.0, 10.0, "10.0, 10.0");
 		assertEquals(1, qt.size());
@@ -106,7 +106,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testPutOutsideBounds() {
-		QuadTree<String> qt = new QuadTree<String>(-50.0, -50.0, 50.0, 50.0);
+		QuadTree<String> qt = new QuadTree<>(-50.0, -50.0, 50.0, 50.0);
 		try {
 			qt.put( -100 , 0 , "-100 0" );
 			Assert.fail( "no exception when adding an element on the left" );
@@ -217,7 +217,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetXY_EntryOnDividingBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0, 0, 40, 60);
+		QuadTree<String> qt = new QuadTree<>(0, 0, 40, 60);
 		qt.put(10.0, 10.0, "10.0, 10.0");
 		qt.put(20.0, 20.0, "20.0, 20.0"); // on vertical border
 		qt.put(20.0, 30.0, "20.0, 30.0"); // exactly on center
@@ -230,7 +230,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetXY_EntryOnOutsideBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0.0, 0.0, 40.0, 60.0);
+		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
 		// the 4 corners
 		qt.put(0.0, 0.0, "SW");
 		qt.put(40.0, 0.0, "SE");
@@ -263,7 +263,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetDistance_EntryOnDividingBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0, 0, 40, 60);
+		QuadTree<String> qt = new QuadTree<>(0, 0, 40, 60);
 		qt.put(10.0, 10.0, "10.0, 10.0");
 		qt.put(20.0, 20.0, "20.0, 20.0"); // on vertical border
 		qt.put(20.0, 30.0, "20.0, 30.0"); // exactly on center
@@ -285,7 +285,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetDistance_EntryOnOutsideBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0.0, 0.0, 40.0, 60.0);
+		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
 		// the 4 corners
 		qt.put(0.0, 0.0, "SW");
 		qt.put(40.0, 0.0, "SE");
@@ -310,8 +310,8 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetElliptical() {
-		final Collection<Coord> all = new ArrayList<Coord>();
-		QuadTree<Coord> qt = new QuadTree<Coord>(0, 0, 40, 60);
+		final Collection<Coord> all = new ArrayList<>();
+		QuadTree<Coord> qt = new QuadTree<>(0, 0, 40, 60);
 
 		all.add(new Coord(10.0, 10.0));
 		all.add(new Coord(20.0, 20.0));
@@ -347,7 +347,7 @@ public class QuadTreeTest {
 
 						for ( double distance : distances ) {
 							if ( distance < interfoci ) continue;
-							final Collection<Coord> expected = new ArrayList<Coord>();
+							final Collection<Coord> expected = new ArrayList<>();
 							for ( Coord coord : all ) {
 								if ( CoordUtils.calcEuclideanDistance( coord , f1 ) + CoordUtils.calcEuclideanDistance( coord , f2 ) <= distance ) {
 									expected.add( coord );
@@ -378,13 +378,13 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetRect() {
-		QuadTree<String> qt = new QuadTree<String>(0, 0, 1000, 1000);
+		QuadTree<String> qt = new QuadTree<>(0, 0, 1000, 1000);
 		qt.put(100, 200, "node1");
 		qt.put(400, 900, "node2");
 		qt.put(700, 300, "node3");
 		qt.put(900, 400, "node4");
 		
-		Collection<String> values = new ArrayList<String>();
+		Collection<String> values = new ArrayList<>();
 		qt.getRectangle(new Rect(400, 300, 700, 900), values);
 		Assert.assertEquals(2, values.size());
 		Assert.assertTrue(values.contains("node2"));
@@ -393,19 +393,19 @@ public class QuadTreeTest {
 
 	@Test
 	public void testGetRect_flatNetwork() {
-		QuadTree<String> qt = new QuadTree<String>(0, 0, 1000, 0);
+		QuadTree<String> qt = new QuadTree<>(0, 0, 1000, 0);
 		qt.put(0, 0, "node1");
 		qt.put(100, 0, "node2");
 		qt.put(500, 0, "node3");
 		qt.put(900, 0, "node4");
 
-		Collection<String> values = new ArrayList<String>();
+		Collection<String> values = new ArrayList<>();
 		qt.getRectangle(new Rect(90, -10, 600, +10), values);
 		Assert.assertEquals(2, values.size());
 		Assert.assertTrue(values.contains("node2"));
 		Assert.assertTrue(values.contains("node3"));
 
-		Collection<String> values2 = new ArrayList<String>();
+		Collection<String> values2 = new ArrayList<>();
 		qt.getRectangle(new Rect(90, 0, 600, 0), values2);
 		Assert.assertEquals(2, values2.size());
 		Assert.assertTrue(values2.contains("node2"));
@@ -497,7 +497,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testValues_EntryOnDividingBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0.0, 0.0, 40.0, 60.0);
+		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
 		qt.put(10.0, 10.0, "10.0, 10.0");
 		qt.put(20.0, 20.0, "20.0, 20.0"); // on vertical border
 		qt.put(20.0, 30.0, "20.0, 30.0"); // exactly on center
@@ -517,7 +517,7 @@ public class QuadTreeTest {
 
 	@Test
 	public void testValues_EntryOnOutsideBorder() {
-		QuadTree<String> qt = new QuadTree<String>(0.0, 0.0, 40.0, 60.0);
+		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
 		// the 4 corners
 		qt.put(0.0, 0.0, "SW");
 		qt.put(40.0, 0.0, "SE");
@@ -678,11 +678,11 @@ public class QuadTreeTest {
 	 */
 	static class TestExecutor implements QuadTree.Executor<String> {
 
-		public final Collection<Tuple<Coord, String>> objects = new ArrayList<Tuple<Coord, String>>();
+		public final Collection<Tuple<Coord, String>> objects = new ArrayList<>();
 
 		@Override
 		public void execute(final double x, final double y, final String object) {
-			this.objects.add(new Tuple<Coord, String>(new Coord(x, y), object));
+			this.objects.add(new Tuple<>(new Coord(x, y), object));
 		}
 
 	}

--- a/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -681,6 +682,36 @@ public class QuadTreeTest {
 	}
 
 	/**
+	 * tests that also for a large number of entries, values() returns the correct result.
+	 */
+	@Test
+	public void testGetValues() {
+		double minX = -1000;
+		double minY = -5000;
+		double maxX = 20000;
+		double maxY = 12000;
+
+		Random r = new Random(20181017L);
+		List<String> expected = new ArrayList<>(1000);
+		QuadTree<String> qt = new QuadTree<>(minX, minY, maxX, maxY);
+		for (int i = 0; i < 1000; i++) {
+			double x = minX + r.nextDouble() * (maxX - minX);
+			double y = minY + r.nextDouble() * (maxY - minY);
+			String value = "ITEM_" + i;
+			qt.put(x, y, value);
+			expected.add(value);
+		}
+
+		List<String> items = new ArrayList<>(qt.values());
+		Assert.assertEquals(1000, items.size());
+		items.sort(String::compareTo);
+		expected.sort(String::compareTo);
+		for (int i = 0; i < 1000; i++) {
+			Assert.assertEquals(expected.get(i), items.get(i));
+		}
+	}
+
+	/**
 	 * A kind of performance test, but not marked as test, as there is no need
 	 * to run it in every check as there is not assert statement.
 	 *
@@ -696,8 +727,6 @@ public class QuadTreeTest {
 		double minY = -5000;
 		double maxX = 20000;
 		double maxY = 12000;
-
-
 
 		QuadTree<Coord> qt = new QuadTree<>(minX, minY, maxX, maxY);
 		System.gc();

--- a/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/collections/QuadTreeTest.java
@@ -495,62 +495,6 @@ public class QuadTreeTest {
 		} catch (UnsupportedOperationException expected) {}
 	}
 
-	@Test
-	public void testValues_EntryOnDividingBorder() {
-		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
-		qt.put(10.0, 10.0, "10.0, 10.0");
-		qt.put(20.0, 20.0, "20.0, 20.0"); // on vertical border
-		qt.put(20.0, 30.0, "20.0, 30.0"); // exactly on center
-		qt.put(20.0, 30.0, "30.0, 30.0"); // on horizontal border
-		qt.put(20.0, 30.0, "30.0, 30.0"); // on horizontal border
-		qt.put(10.0, 40.0, "10.0, 40.0"); // on 2nd-level border
-		assertEquals(5, qt.size());
-		valuesTester(5, qt.values());
-		Iterator<String> iter = qt.values().iterator();
-		assertEquals("10.0, 10.0", iter.next());
-		assertEquals("10.0, 40.0", iter.next());
-		assertEquals("20.0, 20.0", iter.next());
-		assertEquals("20.0, 30.0", iter.next());
-		assertEquals("30.0, 30.0", iter.next());
-		assertFalse(iter.hasNext());
-	}
-
-	@Test
-	public void testValues_EntryOnOutsideBorder() {
-		QuadTree<String> qt = new QuadTree<>(0.0, 0.0, 40.0, 60.0);
-		// the 4 corners
-		qt.put(0.0, 0.0, "SW");
-		qt.put(40.0, 0.0, "SE");
-		qt.put(0.0, 60.0, "NW");
-		qt.put(40.0, 60.0, "NE");
-		// the 4 sides
-		qt.put(10.0, 60.0, "N");
-		qt.put(40.0, 10.0, "E");
-		qt.put(10.0, 0.0, "S");
-		qt.put(0.0, 10.0, "W");
-
-		assertEquals(8, qt.size());
-		valuesTester(8, qt.values());
-		assertTrue(qt.values().contains("SW"));
-		assertTrue(qt.values().contains("SE"));
-		assertTrue(qt.values().contains("NW"));
-		assertTrue(qt.values().contains("NE"));
-		assertTrue(qt.values().contains("N"));
-		assertTrue(qt.values().contains("E"));
-		assertTrue(qt.values().contains("S"));
-		assertTrue(qt.values().contains("W"));
-		Iterator<String> iter = qt.values().iterator();
-		assertEquals("SW", iter.next());
-		assertEquals("W", iter.next());
-		assertEquals("S", iter.next());
-		assertEquals("NW", iter.next());
-		assertEquals("N", iter.next());
-		assertEquals("SE", iter.next());
-		assertEquals("E", iter.next());
-		assertEquals("NE", iter.next());
-		assertFalse(iter.hasNext());
-	}
-
 	/**
 	 * Tests that a once obtained values-collection is indeed a live view
 	 * on the QuadTree, so when the QuadTree changes, the view is updated


### PR DESCRIPTION
Reduce memory consumption of QuadTree by not wrapping every single Leaf in a Node, but store multiple Leafs per Node (known as fan-out in tree data structures). Due to less random memory access, and less object creation, put- and get-performance actually improves measurably, as does the memory overhead imposed by the QuadTree.