### PR TITLE
Matsim services iteration number test

### DIFF
--- a/matsim/src/test/java/org/matsim/core/controler/MatsimServicesImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/MatsimServicesImplTest.java
@@ -1,0 +1,47 @@
+package org.matsim.core.controler;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.testcases.MatsimTestUtils;
+
+public class MatsimServicesImplTest {
+	
+    @Rule
+    public MatsimTestUtils utils = new MatsimTestUtils();
+	
+    @Ignore
+    @Test
+    public void testIterationInServicesEqualsIterationInEvent() {
+   	
+    	Config config = ConfigUtils.createConfig();
+		config.controler().setLastIteration(1);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		
+		Controler controler = new Controler( config );
+		
+        controler.addOverridingModule(new AbstractModule() {
+            @Override
+            public void install() {
+                addControlerListenerBinding().toInstance(new IterationStartsListener() {
+
+					@Override
+					public void notifyIterationStarts(IterationStartsEvent event) {
+						Assert.assertSame(event.getIteration(), event.getServices().getIterationNumber());
+						
+					}
+                	
+                });
+            }
+        });
+		
+		controler.run();
+    	
+    }
+
+}


### PR DESCRIPTION
Test for a bug I found today: event.getServices().getIterationNumber() lags behind event.getIteration() starting from iteration 1 (in iteration 1: event.getServices().getIterationNumber() = 0 whereas event.getIteration() = 1) . Set to ignore to merge this test into master.