### PR TITLE
Small bug in MergeNoiseCSVFile

### DIFF
--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/utils/MergeNoiseCSVFile.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/utils/MergeNoiseCSVFile.java
@@ -309,7 +309,7 @@ public final class MergeNoiseCSVFile {
 						String lineToWrite = rp.toString() + ";" + rp2Coord.get(rp).getX() + ";" + rp2Coord.get(rp).getY() + ";" + String.valueOf(time);
 
 						for (String label : this.label2time2rp2value.keySet()) {
-							double value = this.label2time2rp2value.get(label).get(time).get(rp);
+							double value = this.label2time2rp2value.get(label).get(time).get(rp.toString());
 							if (value > this.threshold) {
 								writeThisLine = true;
 							}


### PR DESCRIPTION
label2time2rp2value stores rp id's as strings, but while filling the table in the xyt case, the writeFileReceiverPoint method was trying to access an id, producing a null point exception. 
Changed to this.label2time2rp2value.get(label).get(time).get(rp.toString()) as it should be.