### PR TITLE
Check if cosine larger than one in angle immissions correction

### DIFF
--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/data/NoiseContext.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/data/NoiseContext.java
@@ -412,6 +412,15 @@ public class NoiseContext {
 							Math.pow(toCoordX - pointCoordX, 2) + Math.pow(toCoordY - pointCoordY, 2)
 							)
 					);
+
+			//due to rounding errors, cosine sometimes is larger than one
+            // TODO: find cleaner way possibly.
+			if (cosAngle > 1.) {
+			    cosAngle = 1.;
+            } else if (cosAngle < -1.) {
+			    cosAngle = -1.;
+            }
+
 			angle = Math.toDegrees(Math.acos(cosAngle));
 
 			if (sc > 0) {


### PR DESCRIPTION
Due to rounding errors, the cosine was sometimes larger than one, leading to a NaN for the computed angle value and hence for the correction and all other subsequent values.
Quick fix, check if value > 1 or < -1 and set to 1 or -1 respectively.