### PR TITLE
[do not merge] Allows overriding

### DIFF
--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/qsim/CarsharingQsimFactoryNew.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/qsim/CarsharingQsimFactoryNew.java
@@ -28,11 +28,11 @@ public class CarsharingQsimFactoryNew implements Provider<Mobsim>{
 	@Override
 	public Mobsim get() {
 		return new QSimBuilder(config) //
-				.useDefaults() //
-				.removeModule(PopulationModule.class) //
-				.addOverridingQSimModule(new CarSharingQSimModule(carsharingSupply, carsharingManager)) //
-				.configureComponents(CarSharingQSimModule::configureComponents) //
-				.build(scenario, eventsManager);
+							 .useDefaults() //
+							 .removeModule(PopulationModule.class) //
+							 .addOverridingQSimModule(new CarSharingQSimModule(carsharingSupply, carsharingManager)) //
+							 .configureQSimComponents(CarSharingQSimModule::configureComponents ) //
+							 .build(scenario, eventsManager);
 	}
 
 }

--- a/contribs/hybridsim/src/main/java/org/matsim/contrib/hybridsim/simulation/HybridMobsimProvider.java
+++ b/contribs/hybridsim/src/main/java/org/matsim/contrib/hybridsim/simulation/HybridMobsimProvider.java
@@ -53,10 +53,10 @@ public class HybridMobsimProvider implements Provider<Mobsim> {
 		Config config = this.sc.getConfig();
 
 		return new QSimBuilder(config) //
-				.useDefaults() //
-				.addQSimModule(new HybridQSimModule()) //
-				.configureComponents(HybridQSimModule::configureComponents) //
-				.build(sc, em);
+							 .useDefaults() //
+							 .addQSimModule(new HybridQSimModule()) //
+							 .configureQSimComponents(HybridQSimModule::configureComponents ) //
+							 .build(sc, em);
 	}
 
 }

--- a/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
+++ b/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
@@ -70,7 +70,6 @@ import org.matsim.core.mobsim.framework.MobsimDriverAgent;
 import org.matsim.core.mobsim.qsim.PopulationModule;
 import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.QSimBuilder;
-import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicleImpl;
@@ -239,9 +238,9 @@ public class CreateAutomatedFDTest {
 			
 			final QSim qSim = new QSimBuilder(config) //
 					.useDefaults()
-					.configureComponents(components -> {
+					.configureQSimComponents( components -> {
 						components.removeNamedComponent(PopulationModule.COMPONENT_NAME);
-					})
+					} )
 					.build(scenario, events);
 
 			final Map<String, VehicleType> travelModesTypes = new HashMap<>();

--- a/contribs/multimodal/src/main/java/org/matsim/contrib/multimodal/MultimodalQSimFactory.java
+++ b/contribs/multimodal/src/main/java/org/matsim/contrib/multimodal/MultimodalQSimFactory.java
@@ -49,9 +49,9 @@ public class MultimodalQSimFactory implements Provider<Mobsim> {
 	@Override
 	public Mobsim get() {
 		return new QSimBuilder(scenario.getConfig()) //
-				.useDefaults()
-				.addQSimModule(new MultiModalQSimModule(multiModalTravelTimes))
-				.configureComponents(MultiModalQSimModule::configureComponents) //
-				.build(scenario, eventsManager);
+									   .useDefaults()
+									   .addQSimModule(new MultiModalQSimModule(multiModalTravelTimes))
+									   .configureQSimComponents(MultiModalQSimModule::configureComponents ) //
+									   .build(scenario, eventsManager);
 	}
 }

--- a/contribs/otfvis/src/main/java/org/matsim/pt/demo/AccessEgressDemo.java
+++ b/contribs/otfvis/src/main/java/org/matsim/pt/demo/AccessEgressDemo.java
@@ -199,13 +199,13 @@ public class AccessEgressDemo {
 
 		final QSim sim = new QSimBuilder(scenario.getConfig()) //
 				.useDefaults() //
-				.addOverridingControllerModule(new AbstractModule() {
+				.addOverridingModule( new AbstractModule() {
 					@Override
 					public void install() {
 						bind(TransitStopHandlerFactory.class).to(SimpleTransitStopHandlerFactory.class)
 								.asEagerSingleton();
 					}
-				}) //
+				} ) //
 				.build(scenario, events);
 		
 		OnTheFlyServer server = OTFVis.startServerAndRegisterWithQSim(this.scenario.getConfig(), this.scenario, events, sim);

--- a/contribs/otfvis/src/main/java/org/matsim/pt/demo/BlockingStopDemo.java
+++ b/contribs/otfvis/src/main/java/org/matsim/pt/demo/BlockingStopDemo.java
@@ -292,13 +292,13 @@ public class BlockingStopDemo {
 
 		final QSim sim = new QSimBuilder(scenario.getConfig()) //
 				.useDefaults() //
-				.addOverridingControllerModule(new AbstractModule() {
+				.addOverridingModule( new AbstractModule() {
 					@Override
 					public void install() {
 						bind(TransitStopHandlerFactory.class).to(SimpleTransitStopHandlerFactory.class)
 								.asEagerSingleton();
 					}
-				}) //
+				} ) //
 				.build(scenario, events);
 
 		OnTheFlyServer server = OTFVis.startServerAndRegisterWithQSim(this.scenario.getConfig(), this.scenario, events, sim);

--- a/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
+++ b/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
@@ -1,11 +1,11 @@
 package org.matsim.contrib.signals.builder;
 
 import org.matsim.contrib.signals.controller.SignalControllerFactory;
-import org.matsim.core.controler.AllowsOverriding;
+import org.matsim.core.controler.AllowsConfiguration;
 
 public class Signals{
 
-    public static void configure( AllowsOverriding ao ){
+    public static void configure( AllowsConfiguration ao ){
 
         ao.addOverridingModule( new SignalsModule() );
 

--- a/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
+++ b/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
@@ -1,15 +1,25 @@
 package org.matsim.contrib.signals.builder;
 
+import org.matsim.contrib.signals.controller.SignalControllerFactory;
 import org.matsim.core.controler.AllowsOverriding;
 
-public class SignalsBuilder{
+public class Signals{
 
-    public static void configure( AllowsOverriding ao ) {
+    public static void configure( AllowsOverriding ao ){
 
         ao.addOverridingModule( new SignalsModule() );
 
         ao.addOverridingQSimModule( new SignalsQSimModule() );
+    }
 
+    public static class Configurator{
+        private final SignalsModule signalsModule;
+        private Configurator( SignalsModule signalsModule ){
+            this.signalsModule = signalsModule;
+        }
+        public final void addSignalControllerFactory( String key, Class<? extends SignalControllerFactory> signalControllerFactoryClassName ) {
+            signalsModule.addSignalControllerFactory( key, signalControllerFactoryClassName );
+        }
     }
 
 }

--- a/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
+++ b/contribs/signals/src/main/java/org/matsim/contrib/signals/builder/Signals.java
@@ -1,15 +1,14 @@
 package org.matsim.contrib.signals.builder;
 
-import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.AllowsOverriding;
 
-public class Signals{
-    private Signals(){} // do not instantiate
+public class SignalsBuilder{
 
-    public static void configure( Controler c ) {
+    public static void configure( AllowsOverriding ao ) {
 
-        c.addOverridingModule( new SignalsModule() );
+        ao.addOverridingModule( new SignalsModule() );
 
-        c.addOverridingQSimModule( new SignalsQSimModule() );
+        ao.addOverridingQSimModule( new SignalsQSimModule() );
 
     }
 

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
@@ -217,7 +217,7 @@ public class QSimSignalTest implements
 		PrepareForSimUtils.createDefaultPrepareForSim(scenario).run();
 		new QSimBuilder(scenario.getConfig())
 				.useDefaults()
-				.addOverridingControllerModule(new SignalsModule())
+				.addOverridingModule(new SignalsModule() )
 				.addOverridingQSimModule( new SignalsQSimModule() )
 				.build(scenario, events)
 				.run();

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/TravelTimeFourWaysTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/TravelTimeFourWaysTest.java
@@ -20,14 +20,11 @@
 
 package org.matsim.contrib.signals.builder;
 
-import java.util.Collections;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.signals.SignalSystemsConfigGroup;
-import org.matsim.contrib.signals.builder.SignalsModule;
 import org.matsim.contrib.signals.data.SignalsData;
 import org.matsim.contrib.signals.data.SignalsDataLoader;
 import org.matsim.core.api.experimental.events.EventsManager;
@@ -35,12 +32,9 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.*;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
-import org.matsim.core.controler.corelisteners.ControlerDefaultCoreListenersModule;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.algorithms.EventWriterXML;
-import org.matsim.core.mobsim.framework.Mobsim;
 import org.matsim.core.mobsim.qsim.QSimBuilder;
-import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.utils.eventsfilecomparison.EventsFileComparator;
@@ -123,7 +117,7 @@ public class TravelTimeFourWaysTest {
 
 		new QSimBuilder( scenario.getConfig() )
 				.useDefaults()
-				.addOverridingControllerModule( new SignalsModule() )
+				.addOverridingModule( new SignalsModule() )
 				.addOverridingQSimModule( new SignalsQSimModule() )
 				.build( scenario, events ).run();
 		

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/qsim/JointQSimFactory.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/qsim/JointQSimFactory.java
@@ -32,7 +32,6 @@ import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.mobsim.framework.MobsimFactory;
 import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.QSimBuilder;
-import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -81,10 +80,10 @@ public class JointQSimFactory implements MobsimFactory, Provider<QSim> {
 		}
 		
 		return new QSimBuilder(config) //
-				.useDefaults() //
-				.addQSimModule(new JointQSimModule()) //
-				.configureComponents(JointQSimModule::configureComponents) //
-				.build(sc1, eventsManager);
+							 .useDefaults() //
+							 .addQSimModule(new JointQSimModule()) //
+							 .configureQSimComponents(JointQSimModule::configureComponents ) //
+							 .build(sc1, eventsManager);
 	}
 }
 

--- a/matsim/src/main/java/org/matsim/core/controler/AllowsConfiguration.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AllowsConfiguration.java
@@ -1,0 +1,11 @@
+package org.matsim.core.controler;
+
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
+
+public interface AllowsConfiguration{
+	AllowsConfiguration addOverridingModule( AbstractModule abstractModule );
+	AllowsConfiguration addOverridingQSimModule( AbstractQSimModule qsimModule );
+	AllowsConfiguration addQSimModule( AbstractQSimModule qsimModule ) ;
+	AllowsConfiguration configureQSimComponents( QSimComponentsConfigurator configurator ) ;
+}

--- a/matsim/src/main/java/org/matsim/core/controler/AllowsOverriding.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AllowsOverriding.java
@@ -1,0 +1,8 @@
+package org.matsim.core.controler;
+
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+
+public interface AllowsOverriding{
+	AllowsOverriding addOverridingModule( AbstractModule abstractModule );
+	AllowsOverriding addOverridingQSimModule( AbstractQSimModule qsimModule );
+}

--- a/matsim/src/main/java/org/matsim/core/controler/AllowsOverriding.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AllowsOverriding.java
@@ -1,8 +1,0 @@
-package org.matsim.core.controler;
-
-import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-
-public interface AllowsOverriding{
-	AllowsOverriding addOverridingModule( AbstractModule abstractModule );
-	AllowsOverriding addOverridingQSimModule( AbstractQSimModule qsimModule );
-}

--- a/matsim/src/main/java/org/matsim/core/controler/Controler.java
+++ b/matsim/src/main/java/org/matsim/core/controler/Controler.java
@@ -73,7 +73,7 @@ import java.util.function.Consumer;
  *
  * @author mrieser
  */
-public final class Controler implements ControlerI, MatsimServices {
+public final class Controler implements ControlerI, MatsimServices, AllowsOverriding {
 	// yyyy Design thoughts:
 	// * Seems to me that we should try to get everything here final.  Flexibility is provided by the ability to set or add factories.  If this is
 	// not sufficient, people should use AbstractController.  kai, jan'13
@@ -452,13 +452,14 @@ public final class Controler implements ControlerI, MatsimServices {
 			}
         });
 	}
-
-    public final void addOverridingModule(AbstractModule abstractModule) {
-        if (this.injectorCreated) {
-            throw new RuntimeException("Too late for configuring the Controler. This can only be done before calling run.");
-        }
-        this.overrides = AbstractModule.override(Collections.singletonList(this.overrides), abstractModule);
-    }
+	@Override
+	public final Controler addOverridingModule( AbstractModule abstractModule ) {
+		if (this.injectorCreated) {
+			throw new RuntimeException("Too late for configuring the Controler. This can only be done before calling run.");
+		}
+		this.overrides = AbstractModule.override(Collections.singletonList(this.overrides), abstractModule);
+		return this ;
+	}
 
     public final void setModules(AbstractModule... modules) {
         if (this.injectorCreated) {
@@ -467,12 +468,13 @@ public final class Controler implements ControlerI, MatsimServices {
         this.modules = Arrays.asList(modules);
     }
 
-    public final void addOverridingQSimModule(AbstractQSimModule qsimModule) {
-        if (this.injectorCreated) {
-            throw new RuntimeException("Too late for configuring the Controler. This can only be done before calling run.");
-        }
-        
-    	overridingQSimModules.add(qsimModule);
+    @Override
+    public final Controler addOverridingQSimModule( AbstractQSimModule qsimModule ) {
+	    if (this.injectorCreated) {
+		    throw new RuntimeException("Too late for configuring the Controler. This can only be done before calling run.");
+	    }
+	    overridingQSimModules.add(qsimModule);
+	    return this ;
     }
     
     public final void addQSimModule(AbstractQSimModule qsimModule) {

--- a/matsim/src/main/java/org/matsim/core/controler/Controler.java
+++ b/matsim/src/main/java/org/matsim/core/controler/Controler.java
@@ -46,7 +46,6 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
-import org.matsim.core.mobsim.qsim.components.QSimComponentsModule;
 import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.StrategyManager;
@@ -64,7 +63,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * The Controler is responsible for complete simulation runs, including the
@@ -73,7 +71,7 @@ import java.util.function.Consumer;
  *
  * @author mrieser
  */
-public final class Controler implements ControlerI, MatsimServices, AllowsOverriding {
+public final class Controler implements ControlerI, MatsimServices, AllowsConfiguration{
 	// yyyy Design thoughts:
 	// * Seems to me that we should try to get everything here final.  Flexibility is provided by the ability to set or add factories.  If this is
 	// not sufficient, people should use AbstractController.  kai, jan'13
@@ -476,17 +474,18 @@ public final class Controler implements ControlerI, MatsimServices, AllowsOverri
 	    overridingQSimModules.add(qsimModule);
 	    return this ;
     }
-    
-    public final void addQSimModule(AbstractQSimModule qsimModule) {
+    @Override
+    public final Controler addQSimModule(AbstractQSimModule qsimModule) {
     	this.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
 				installQSimModule(qsimModule);
 			}
 		});
+    	return this ;
     }
-    
-    public final void configureQSimComponents(QSimComponentsConfigurator configurator) {
+    @Override
+    public final Controler configureQSimComponents(QSimComponentsConfigurator configurator) {
     	this.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
@@ -496,5 +495,6 @@ public final class Controler implements ControlerI, MatsimServices, AllowsOverri
 				bind(QSimComponentsConfig.class).toInstance(components);
 			}
 		});
+    	return this ;
     }
 }

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
@@ -10,7 +10,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
-import org.matsim.core.controler.AllowsOverriding;
+import org.matsim.core.controler.AllowsConfiguration;
 import org.matsim.core.mobsim.framework.Mobsim;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
@@ -62,7 +62,7 @@ import com.google.inject.name.Names;
  *
  * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
  */
-public class QSimBuilder implements AllowsOverriding {
+public class QSimBuilder implements AllowsConfiguration{
 	private final Config config;
 
 	private final Collection<AbstractQSimModule> qsimModules = new LinkedList<>();
@@ -125,7 +125,7 @@ public class QSimBuilder implements AllowsOverriding {
 	/**
 	 * Configures the current active QSim components.
 	 */
-	public QSimBuilder configureComponents(QSimComponentsConfigurator configurator) {
+	public QSimBuilder configureQSimComponents( QSimComponentsConfigurator configurator ) {
 		configurator.configure(components);
 		return this;
 	}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
@@ -10,6 +10,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.AllowsOverriding;
 import org.matsim.core.mobsim.framework.Mobsim;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
@@ -61,7 +62,7 @@ import com.google.inject.name.Names;
  *
  * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
  */
-public class QSimBuilder {
+public class QSimBuilder implements AllowsOverriding {
 	private final Config config;
 
 	private final Collection<AbstractQSimModule> qsimModules = new LinkedList<>();
@@ -89,7 +90,8 @@ public class QSimBuilder {
 	 * Adds a module that overrides existing bindings from MATSim (i.e. mainly those
 	 * from the {@link StandaloneQSimModule} and derived stages).
 	 */
-	public QSimBuilder addOverridingControllerModule(AbstractModule module) {
+	@Override
+	public QSimBuilder addOverridingModule( AbstractModule module ) {
 		overridingControllerModules.add(module);
 		return this;
 	}
@@ -105,6 +107,7 @@ public class QSimBuilder {
 	/**
 	 * Adds a QSim module that overrides previously defined elements.
 	 */
+	@Override
 	public QSimBuilder addOverridingQSimModule(AbstractQSimModule module) {
 		this.overridingQSimModules.add(module);
 		return this;

--- a/matsim/src/main/java/org/matsim/withinday/mobsim/WithinDayQSimFactory.java
+++ b/matsim/src/main/java/org/matsim/withinday/mobsim/WithinDayQSimFactory.java
@@ -59,10 +59,10 @@ public class WithinDayQSimFactory implements Provider<Mobsim> {
 
 		log.info("Adding WithinDayEngine to Mobsim.");
 		return new QSimBuilder(config) //
-				.useDefaults() //
-				.addQSimModule(
+							 .useDefaults() //
+							 .addQSimModule(
 						new WithinDayQSimModule(withinDayEngine, fixedOrderSimulationListener, withinDayTravelTime)) //
-				.configureComponents(WithinDayQSimModule::configureComponents) //
-				.build(scenario, eventsManager);
+							 .configureQSimComponents(WithinDayQSimModule::configureComponents ) //
+							 .build(scenario, eventsManager);
 	}
 }

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/AgentNotificationTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/AgentNotificationTest.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import com.google.inject.Provider;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Test;
@@ -48,7 +47,6 @@ import org.matsim.core.mobsim.qsim.agents.PopulationAgentSource;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
 import org.matsim.core.mobsim.qsim.interfaces.Netsim;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngineModule;
-import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicleFactory;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicleImpl;
 import org.matsim.core.population.routes.RouteUtils;
@@ -261,9 +259,9 @@ public class AgentNotificationTest {
 					bind( QVehicleFactory.class ).toProvider( () -> QVehicleImpl::new ) ;
 				}
 			})
-			.configureComponents(components -> {
+			.configureQSimComponents( components -> {
 				components.removeNamedComponent(QNetsimEngineModule.COMPONENT_NAME);
-			}) //
+			} ) //
 			.build(scenario, eventsManager) //
 			.run();
 		

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/components/QSimComponentsTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/components/QSimComponentsTest.java
@@ -17,8 +17,6 @@ import org.matsim.core.mobsim.qsim.components.mock.MockMobsimListener;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimEngine;
 import org.matsim.core.scenario.ScenarioUtils;
 
-import com.google.inject.Key;
-
 public class QSimComponentsTest {
 	@Test
 	public void testGenericAddComponentMethod() {
@@ -35,9 +33,9 @@ public class QSimComponentsTest {
 		
 		new QSimBuilder(config) //
 		.addQSimModule(module) //
-		.configureComponents(components -> {
+		.configureQSimComponents( components -> {
 			components.addComponent(MockComponentAnnotation.class);
-		}) //
+		} ) //
 		.build(scenario, eventsManager) //
 		.run();
 	}
@@ -59,9 +57,9 @@ public class QSimComponentsTest {
 						bind(MockEngineB.class).annotatedWith(MockComponentAnnotation.class).toInstance(mockEngineB);
 					}
 				}) //
-				.configureComponents(components -> {
+				.configureQSimComponents( components -> {
 					components.addComponent(MockComponentAnnotation.class);
-				}) //
+				} ) //
 				.build(scenario, eventsManager) //
 				.run();
 
@@ -92,9 +90,9 @@ public class QSimComponentsTest {
 						bindComponent(MockEngine.class, MockComponentAnnotation.class).toInstance(mockEngine);
 					}
 				}) //
-				.configureComponents(components -> {
+				.configureQSimComponents( components -> {
 					components.addComponent(MockComponentAnnotation.class);
-				}) //
+				} ) //
 				.build(scenario, eventsManager) //
 				.run();
 
@@ -116,9 +114,9 @@ public class QSimComponentsTest {
 						bindNamedComponent(MockEngine.class, "MockEngine").toInstance(mockEngine);
 					}
 				}) //
-				.configureComponents(components -> {
+				.configureQSimComponents( components -> {
 					components.addNamedComponent("MockEngine");
-				}) //
+				} ) //
 				.build(scenario, eventsManager) //
 				.run();
 

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/jdeqsimengine/JDEQSimPluginTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/jdeqsimengine/JDEQSimPluginTest.java
@@ -17,9 +17,9 @@ public class JDEQSimPluginTest extends MatsimTestCase {
 	private QSim prepareQSim(Scenario scenario, EventsManager eventsManager) {
         return new QSimBuilder(scenario.getConfig()) //
         	.addQSimModule(new JDEQSimModule()) //
-        	.configureComponents(components -> {
+        	.configureQSimComponents( components -> {
         		components.addNamedComponent(JDEQSimModule.COMPONENT_NAME);
-        	}) //
+        	} ) //
         	.build(scenario, eventsManager);
 	}
 


### PR DESCRIPTION
A proposal to deal with the missing capability to add overriding QSimModules from overriding ControlerModules.
The main thing is that this proposal standardizes the syntax between Controler and QSimBuilder, so that they can be pulled behind the same interface.
A consequence is that it would be addOverridingModule instead of addOverridingControlerModule in QSimBuilder.  I don't see this as a change to the better, but it is a necessity if I want to unify syntax, plus leave the older API unchanged.