### PR TITLE
move qsim component activation outside Dvrp(Benchmark)Module

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
@@ -28,6 +28,7 @@ import org.matsim.contrib.av.intermodal.router.config.VariableAccessConfigGroup;
 import org.matsim.contrib.av.intermodal.router.config.VariableAccessModeConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.TaxiConfigConsistencyChecker;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -92,7 +93,8 @@ public class RunTaxiPTIntermodalExample {
 
 		Controler controler = new Controler(scenario);
 
-		controler.addOverridingModule(new DvrpModule(mode));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
 
 		controler.addOverridingModule(new TaxiModule());
 

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
@@ -24,6 +24,7 @@ import org.matsim.contrib.av.robotaxi.fares.taxi.TaxiFareModule;
 import org.matsim.contrib.av.robotaxi.fares.taxi.TaxiFaresConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.TaxiConfigConsistencyChecker;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -64,8 +65,9 @@ public class RunRobotaxiExample {
 
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new TaxiFareModule());
-		controler.addOverridingModule(new DvrpModule(mode));
+		controler.addOverridingModule(new DvrpModule());
 		controler.addOverridingModule(new TaxiModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifier.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifier.java
@@ -43,11 +43,11 @@ public class MultiModeDrtMainModeIdentifier implements MainModeIdentifier {
 
 	@Inject
 	public MultiModeDrtMainModeIdentifier(MultiModeDrtConfigGroup drtCfg) {
-		drtStageActivityTypes = drtCfg.getDrtConfigGroups()
+		drtStageActivityTypes = drtCfg.getModalElements()
 				.stream()
 				.map(drtConfigGroup -> drtConfigGroup.getMode())
 				.collect(Collectors.toMap(s -> new DrtStageActivityType(s).drtStageActivity, s -> s));
-		drtWalkTypes = drtCfg.getDrtConfigGroups()
+		drtWalkTypes = drtCfg.getModalElements()
 				.stream()
 				.map(drtConfigGroup -> drtConfigGroup.getMode())
 				.collect(Collectors.toMap(s -> new DrtStageActivityType(s).drtWalk, s -> s));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
@@ -24,7 +24,7 @@ import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebal
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParamsConsistencyChecker;
 import org.matsim.contrib.drt.run.DrtConfigGroup.OperationalScheme;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
-import org.matsim.contrib.dvrp.run.HasMode;
+import org.matsim.contrib.dvrp.run.MultiModal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 import org.matsim.core.config.groups.GlobalConfigGroup;
@@ -50,7 +50,7 @@ public class DrtConfigConsistencyChecker implements ConfigConsistencyChecker {
 				throw new RuntimeException("Either DrtConfigGroup or MultiModeDrtConfigGroup must be defined");
 			}
 			multiModeDrtCfg.getDrtConfigGroups().stream().forEach(c -> checkDrtConfigConsistency(c, config.global()));
-			if (!HasMode.areModesUnique(multiModeDrtCfg.getDrtConfigGroups().stream())) {
+			if (!MultiModal.areModesUnique(multiModeDrtCfg)) {
 				throw new RuntimeException("Drt modes are not unique");
 			}
 		}
@@ -59,9 +59,9 @@ public class DrtConfigConsistencyChecker implements ConfigConsistencyChecker {
 			// Not an issue if all request rejections are immediate (i.e. happen during request submission)
 			log.warn("qsim.endTime should be specified and qsim.simEndtimeInterpretation should be 'onlyUseEndtime'"
 					+ " if postponed request rejection is allowed. Otherwise, rejected passengers"
-                    + " (who are stuck endlessly waiting for a DRT vehicle) will prevent QSim from stopping."
-                    + " Keep also in mind that not setting an end time may result in agents " +
-                    "attempting to travel without vehicles being available.");
+					+ " (who are stuck endlessly waiting for a DRT vehicle) will prevent QSim from stopping."
+					+ " Keep also in mind that not setting an end time may result in agents "
+					+ "attempting to travel without vehicles being available.");
 		}
 		if (config.qsim().getNumberOfThreads() != 1) {
 			throw new RuntimeException("Only a single-threaded QSim allowed");

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigConsistencyChecker.java
@@ -23,8 +23,8 @@ import org.apache.log4j.Logger;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParamsConsistencyChecker;
 import org.matsim.contrib.drt.run.DrtConfigGroup.OperationalScheme;
+import org.matsim.contrib.dvrp.run.ConfigConsistencyCheckers;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
-import org.matsim.contrib.dvrp.run.MultiModal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 import org.matsim.core.config.groups.GlobalConfigGroup;
@@ -38,22 +38,9 @@ public class DrtConfigConsistencyChecker implements ConfigConsistencyChecker {
 	public void checkConsistency(Config config) {
 		new DvrpConfigConsistencyChecker().checkConsistency(config);
 
-		DrtConfigGroup drtCfg = DrtConfigGroup.get(config);
-		MultiModeDrtConfigGroup multiModeDrtCfg = MultiModeDrtConfigGroup.get(config);
-		if (drtCfg != null) {
-			if (multiModeDrtCfg != null) {
-				throw new RuntimeException("Either DrtConfigGroup or MultiModeDrtConfigGroup must be defined");
-			}
-			checkDrtConfigConsistency(drtCfg, config.global());
-		} else {
-			if (multiModeDrtCfg == null) {
-				throw new RuntimeException("Either DrtConfigGroup or MultiModeDrtConfigGroup must be defined");
-			}
-			multiModeDrtCfg.getDrtConfigGroups().stream().forEach(c -> checkDrtConfigConsistency(c, config.global()));
-			if (!MultiModal.areModesUnique(multiModeDrtCfg)) {
-				throw new RuntimeException("Drt modes are not unique");
-			}
-		}
+		ConfigConsistencyCheckers.checkSingleOrMultiModeConsistency(DrtConfigGroup.get(config),
+				MultiModeDrtConfigGroup.get(config), drtCfg -> checkDrtConfigConsistency(drtCfg, config.global()));
+
 		if (Time.isUndefinedTime(config.qsim().getEndTime())
 				&& config.qsim().getSimEndtimeInterpretation() != EndtimeInterpretation.onlyUseEndtime) {
 			// Not an issue if all request rejections are immediate (i.e. happen during request submission)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -33,12 +33,12 @@ import javax.validation.constraints.PositiveOrZero;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
-import org.matsim.contrib.dvrp.run.HasMode;
+import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
-public class DrtConfigGroup extends ReflectiveConfigGroup implements HasMode {
+public class DrtConfigGroup extends ReflectiveConfigGroup implements Modal {
 
 	public static final String GROUP_NAME = "drt";
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
@@ -33,7 +33,7 @@ public class DrtConfigs {
 
 	public static void adjustMultiModeDrtConfig(MultiModeDrtConfigGroup multiModeDrtCfg,
 			PlanCalcScoreConfigGroup planCalcScoreCfg) {
-		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getDrtConfigGroups()) {
+		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			DrtConfigs.adjustDrtConfig(drtCfg, planCalcScoreCfg);
 		}
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -30,6 +30,7 @@ import org.matsim.contrib.drt.analysis.DrtAnalysisModule;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.Controler;
@@ -102,8 +103,9 @@ public final class DrtControlerCreator {
 
 	public static void addDrtAsSingleDvrpModeToControler(Controler controler) {
 		addDrtWithoutDvrpModuleToControler(controler);
-		controler.addOverridingModule(new DvrpModule(
-				DrtConfigGroup.get(controler.getConfig()).getMode()));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(
+				DvrpQSimComponents.activateModes(DrtConfigGroup.get(controler.getConfig()).getMode()));
 	}
 
 	public static void addDrtWithoutDvrpModuleToControler(Controler controler) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtConfigGroup.java
@@ -50,13 +50,9 @@ public class MultiModeDrtConfigGroup extends ReflectiveConfigGroup implements Mu
 		throw new IllegalArgumentException(type);
 	}
 
-	@SuppressWarnings("unchecked")
-	public Collection<DrtConfigGroup> getDrtConfigGroups() {
-		return (Collection<DrtConfigGroup>)getParameterSets(DrtConfigGroup.GROUP_NAME);
-	}
-
 	@Override
+	@SuppressWarnings("unchecked")
 	public Collection<DrtConfigGroup> getModalElements() {
-		return getDrtConfigGroups();
+		return (Collection<DrtConfigGroup>)getParameterSets(DrtConfigGroup.GROUP_NAME);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
@@ -20,9 +20,6 @@
 
 package org.matsim.contrib.drt.run;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.matsim.contrib.drt.analysis.DrtModeAnalysisModule;
 import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
@@ -48,14 +45,12 @@ public final class MultiModeDrtModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		List<String> modes = new ArrayList<>();
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getDrtConfigGroups()) {
-			modes.add(drtCfg.getMode());
 			install(new DrtModeModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}
 
-		install(new DvrpModule(modes.stream().toArray(String[]::new)));
+		install(new DvrpModule());
 
 		bind(TravelDisutilityFactory.class).annotatedWith(Drt.class)
 				.toInstance(travelTime -> new TimeAsTravelDisutility(travelTime));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
@@ -45,7 +45,7 @@ public final class MultiModeDrtModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getDrtConfigGroups()) {
+		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			install(new DrtModeModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunMultiModeDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunMultiModeDrtExample.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -55,6 +56,7 @@ public class RunMultiModeDrtExample {
 		Controler controler = new Controler(scenario);
 
 		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeDrtConfigGroup.get(config)));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule());

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
@@ -20,37 +20,15 @@ package org.matsim.contrib.dvrp.benchmark;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
-import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dynagent.run.DynActivityEngineModule;
-import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
-import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
-import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 /**
  * @author michalm
  */
 public class DvrpBenchmarkModule extends AbstractModule {
-	private final String mode;
-
-	public DvrpBenchmarkModule(String mode) {
-		this.mode = mode;
-	}
-
-	@Provides
-	@Singleton
-	public QSimComponentsConfig provideQSimComponentsConfig(Config config) {
-		QSimComponentsConfig components = new QSimComponentsConfig();
-		new StandardQSimComponentConfigurator(config).configure(components);
-		DynActivityEngineModule.configureComponents(components);
-		components.addComponent(DvrpModes.mode(mode));
-		return components;
-	}
-
 	@Override
 	public void install() {
 		install(new DvrpBenchmarkTravelTimeModule());// fixed travel times

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/RunOneTaxiExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/RunOneTaxiExample.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -51,7 +52,8 @@ public final class RunOneTaxiExample {
 		// setup controler
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new OneTaxiModule(TAXIS_FILE));
-		controler.addOverridingModule(new DvrpModule(TransportMode.taxi));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.taxi));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxionetruck/RunOneTaxiOneTruckExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxionetruck/RunOneTaxiOneTruckExample.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.examples.onetruck.OneTruckModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -56,7 +57,8 @@ public class RunOneTaxiOneTruckExample {
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new OneTaxiModule(TAXIS_FILE));
 		controler.addOverridingModule(new OneTruckModule(TRUCKS_FILE));
-		controler.addOverridingModule(new DvrpModule(TransportMode.taxi, TransportMode.truck));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.taxi, TransportMode.truck));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -51,7 +52,8 @@ public final class RunOneTruckExample {
 		// setup controler
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new OneTruckModule(TRUCKS_FILE));
-		controler.addOverridingModule(new DvrpModule(TransportMode.truck));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.truck));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
@@ -39,11 +39,11 @@ public abstract class AbstractDvrpModeQSimModule extends AbstractQSimModule {
 		this.mode = mode;
 	}
 
-	public final String getMode() {
+	protected final String getMode() {
 		return mode;
 	}
 
-	public final DvrpMode getDvrpMode() {
+	protected final DvrpMode getDvrpMode() {
 		return DvrpModes.mode(mode);
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/ConfigConsistencyCheckers.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/ConfigConsistencyCheckers.java
@@ -20,16 +20,34 @@
 
 package org.matsim.contrib.dvrp.run;
 
-import java.util.Collection;
-import java.util.stream.Stream;
+import java.util.HashSet;
+import java.util.function.Consumer;
+
+import org.matsim.core.config.ConfigGroup;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public interface MultiModal<M extends Modal> {
-	Collection<M> getModalElements();
+public class ConfigConsistencyCheckers {
+	public static <C extends ConfigGroup & Modal> void checkSingleOrMultiModeConsistency(C cfg,
+			MultiModal<C> multiModeCfg, Consumer<C> consistencyChecker) {
+		if (cfg != null) {
+			if (multiModeCfg != null) {
+				throw new RuntimeException("Either single or multi-mode " + cfg.getName() + " must be defined");
+			}
+			consistencyChecker.accept(cfg);
+		} else {
+			if (multiModeCfg == null) {
+				throw new RuntimeException("Either single or multi-mode " + cfg.getName() + " must be defined");
+			}
+			multiModeCfg.getModalElements().stream().forEach(consistencyChecker);
+			if (!areModesUnique(multiModeCfg)) {
+				throw new RuntimeException("Modes in multi-mode config are not unique");
+			}
+		}
+	}
 
-	default Stream<String> modes() {
-		return getModalElements().stream().map(Modal::getMode);
+	public static boolean areModesUnique(MultiModal<?> multiModal) {
+		return multiModal.modes().allMatch(new HashSet<>()::add);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -19,41 +19,17 @@
 
 package org.matsim.contrib.dvrp.run;
 
-import java.util.List;
-
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentQueryHelper;
 import org.matsim.contrib.dynagent.run.DynActivityEngineModule;
-import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
-import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
-import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 import org.matsim.vis.otfvis.OnTheFlyServer.NonPlanAgentQueryHelper;
 
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 public final class DvrpModule extends AbstractModule {
-	private final List<String> modes;
-
-	public DvrpModule(String... modes) {
-		this.modes = ImmutableList.copyOf(modes);
-	}
-
-	@Provides
-	@Singleton
-	public QSimComponentsConfig provideQSimComponentsConfig(Config config) {
-		QSimComponentsConfig components = new QSimComponentsConfig();
-		new StandardQSimComponentConfigurator(config).configure(components);
-		DynActivityEngineModule.configureComponents(components);
-		modes.forEach(m -> components.addComponent(DvrpModes.mode(m)));
-		return components;
-	}
-
 	@Override
 	public void install() {
 		// Visualisation of schedules for DVRP DynAgents

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpQSimComponents.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpQSimComponents.java
@@ -3,7 +3,7 @@
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -20,16 +20,23 @@
 
 package org.matsim.contrib.dvrp.run;
 
-import java.util.HashSet;
-import java.util.stream.Stream;
+import org.matsim.contrib.dynagent.run.DynActivityEngineModule;
+import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public interface HasMode {
-	String getMode();
+public class DvrpQSimComponents {
+	public static QSimComponentsConfigurator activateModes(String... modes) {
+		return components -> {
+			DynActivityEngineModule.configureComponents(components);
+			for (String m : modes) {
+				components.addComponent(DvrpModes.mode(m));
+			}
+		};
+	}
 
-	static boolean areModesUnique(Stream<? extends HasMode> elementsWithModes) {
-		return elementsWithModes.map(HasMode::getMode).allMatch(new HashSet<>()::add);
+	public static QSimComponentsConfigurator activateAllModes(MultiModal<?> multiModal) {
+		return activateModes(multiModal.modes().toArray(String[]::new));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/Modal.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/Modal.java
@@ -18,45 +18,11 @@
  * *********************************************************************** *
  */
 
-package org.matsim.contrib.drt.run;
-
-import java.util.Collection;
-
-import org.matsim.contrib.dvrp.run.MultiModal;
-import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
-import org.matsim.core.config.ReflectiveConfigGroup;
+package org.matsim.contrib.dvrp.run;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class MultiModeDrtConfigGroup extends ReflectiveConfigGroup implements MultiModal<DrtConfigGroup> {
-	public static final String GROUP_NAME = "multiModeDrt";
-
-	@SuppressWarnings("deprecation")
-	public static MultiModeDrtConfigGroup get(Config config) {
-		return (MultiModeDrtConfigGroup)config.getModule(GROUP_NAME);
-	}
-
-	public MultiModeDrtConfigGroup() {
-		super(GROUP_NAME);
-	}
-
-	@Override
-	public ConfigGroup createParameterSet(String type) {
-		if (type.equals(DrtConfigGroup.GROUP_NAME)) {
-			return new DrtConfigGroup();
-		}
-		throw new IllegalArgumentException(type);
-	}
-
-	@SuppressWarnings("unchecked")
-	public Collection<DrtConfigGroup> getDrtConfigGroups() {
-		return (Collection<DrtConfigGroup>)getParameterSets(DrtConfigGroup.GROUP_NAME);
-	}
-
-	@Override
-	public Collection<DrtConfigGroup> getModalElements() {
-		return getDrtConfigGroups();
-	}
+public interface Modal {
+	String getMode();
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkControlerModule;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.run.TaxiModule;
 import org.matsim.core.config.Config;
@@ -66,7 +67,8 @@ public class RunTaxiBenchmark {
 
 		Controler controler = new Controler(scenario);
 		controler.setModules(new DvrpBenchmarkControlerModule());
-		controler.addOverridingModule(new DvrpBenchmarkModule(mode));
+		controler.addOverridingModule(new DvrpBenchmarkModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
 
 		controler.addOverridingModule(new TaxiModule());
 		controler.addOverridingModule(new AbstractModule() {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiConfigGroup.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.taxi.run;
 
 import java.util.Collection;
 
+import org.matsim.contrib.dvrp.run.MultiModal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -29,7 +30,7 @@ import org.matsim.core.config.ReflectiveConfigGroup;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class MultiModeTaxiConfigGroup extends ReflectiveConfigGroup {
+public class MultiModeTaxiConfigGroup extends ReflectiveConfigGroup implements MultiModal<TaxiConfigGroup> {
 	public static final String GROUP_NAME = "multiModeTaxi";
 
 	@SuppressWarnings("deprecation")
@@ -52,5 +53,10 @@ public class MultiModeTaxiConfigGroup extends ReflectiveConfigGroup {
 	@SuppressWarnings("unchecked")
 	public Collection<TaxiConfigGroup> getTaxiConfigGroups() {
 		return (Collection<TaxiConfigGroup>)getParameterSets(TaxiConfigGroup.GROUP_NAME);
+	}
+
+	@Override
+	public Collection<TaxiConfigGroup> getModalElements() {
+		return getTaxiConfigGroups();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiConfigGroup.java
@@ -50,13 +50,9 @@ public class MultiModeTaxiConfigGroup extends ReflectiveConfigGroup implements M
 		throw new IllegalArgumentException(type);
 	}
 
-	@SuppressWarnings("unchecked")
-	public Collection<TaxiConfigGroup> getTaxiConfigGroups() {
-		return (Collection<TaxiConfigGroup>)getParameterSets(TaxiConfigGroup.GROUP_NAME);
-	}
-
 	@Override
+	@SuppressWarnings("unchecked")
 	public Collection<TaxiConfigGroup> getModalElements() {
-		return getTaxiConfigGroups();
+		return (Collection<TaxiConfigGroup>)getParameterSets(TaxiConfigGroup.GROUP_NAME);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/MultiModeTaxiModule.java
@@ -41,7 +41,7 @@ public class MultiModeTaxiModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		for (TaxiConfigGroup taxiCfg : multiModeTaxiCfg.getTaxiConfigGroups()) {
+		for (TaxiConfigGroup taxiCfg : multiModeTaxiCfg.getModalElements()) {
 			install(new TaxiModeModule(taxiCfg));
 		}
 		install(new DvrpModule());

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
@@ -19,8 +19,8 @@
 
 package org.matsim.contrib.taxi.run;
 
+import org.matsim.contrib.dvrp.run.ConfigConsistencyCheckers;
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
-import org.matsim.contrib.dvrp.run.MultiModal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 
@@ -29,22 +29,8 @@ public class TaxiConfigConsistencyChecker implements ConfigConsistencyChecker {
 	public void checkConsistency(Config config) {
 		new DvrpConfigConsistencyChecker().checkConsistency(config);
 
-		TaxiConfigGroup taxiCfg = TaxiConfigGroup.get(config);
-		MultiModeTaxiConfigGroup multiModeTaxiCfg = MultiModeTaxiConfigGroup.get(config);
-		if (taxiCfg != null) {
-			if (multiModeTaxiCfg != null) {
-				throw new RuntimeException("Either TaxiConfigGroup or MultiModeTaxiConfigGroup must be defined");
-			}
-			checkTaxiConfigConsistency(taxiCfg);
-		} else {
-			if (multiModeTaxiCfg == null) {
-				throw new RuntimeException("Either TaxiConfigGroup or MultiModeTaxiConfigGroup must be defined");
-			}
-			multiModeTaxiCfg.getTaxiConfigGroups().stream().forEach(this::checkTaxiConfigConsistency);
-			if (!MultiModal.areModesUnique(multiModeTaxiCfg)) {
-				throw new RuntimeException("Taxi modes are not unique");
-			}
-		}
+		ConfigConsistencyCheckers.checkSingleOrMultiModeConsistency(TaxiConfigGroup.get(config),
+				MultiModeTaxiConfigGroup.get(config), this::checkTaxiConfigConsistency);
 
 		if (config.qsim().getNumberOfThreads() != 1) {
 			throw new RuntimeException("Only a single-threaded QSim allowed");

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigConsistencyChecker.java
@@ -20,7 +20,7 @@
 package org.matsim.contrib.taxi.run;
 
 import org.matsim.contrib.dvrp.run.DvrpConfigConsistencyChecker;
-import org.matsim.contrib.dvrp.run.HasMode;
+import org.matsim.contrib.dvrp.run.MultiModal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.consistency.ConfigConsistencyChecker;
 
@@ -41,7 +41,7 @@ public class TaxiConfigConsistencyChecker implements ConfigConsistencyChecker {
 				throw new RuntimeException("Either TaxiConfigGroup or MultiModeTaxiConfigGroup must be defined");
 			}
 			multiModeTaxiCfg.getTaxiConfigGroups().stream().forEach(this::checkTaxiConfigConsistency);
-			if (!HasMode.areModesUnique(multiModeTaxiCfg.getTaxiConfigGroups().stream())) {
+			if (!MultiModal.areModesUnique(multiModeTaxiCfg)) {
 				throw new RuntimeException("Taxi modes are not unique");
 			}
 		}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -27,12 +27,12 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.PositiveOrZero;
 
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.contrib.dvrp.run.HasMode;
+import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
-public class TaxiConfigGroup extends ReflectiveConfigGroup implements HasMode {
+public class TaxiConfigGroup extends ReflectiveConfigGroup implements Modal {
 	public static final String GROUP_NAME = "taxi";
 
 	@SuppressWarnings("deprecation")

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiControlerCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiControlerCreator.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.taxi.run;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.Controler;
@@ -44,8 +45,9 @@ public class TaxiControlerCreator {
 
 	public static void addTaxiAsSingleDvrpModeToControler(Controler controler) {
 		addTaxiWithoutDvrpModuleToControler(controler);
-		controler.addOverridingModule(new DvrpModule(
-				TaxiConfigGroup.get(controler.getConfig()).getMode()));
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(
+				DvrpQSimComponents.activateModes(TaxiConfigGroup.get(controler.getConfig()).getMode()));
 	}
 
 	public static void addTaxiWithoutDvrpModuleToControler(Controler controler) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunMultiModeTaxiExample.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunMultiModeTaxiExample.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.taxi.run.examples;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
 import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
@@ -50,6 +51,8 @@ public class RunMultiModeTaxiExample {
 		Controler controler = new Controler(scenario);
 
 		controler.addOverridingModule(new MultiModeTaxiModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeTaxiConfigGroup.get(config)));
+
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.taxi.run.examples;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.TaxiConfigConsistencyChecker;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -49,8 +50,9 @@ public class RunTaxiExample {
 
 		// setup controler
 		Controler controler = new Controler(scenario);
-		controler.addOverridingModule(new DvrpModule(mode));
+		controler.addOverridingModule(new DvrpModule());
 		controler.addOverridingModule(new TaxiModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation


### PR DESCRIPTION
Moved to DvrpQSimComponents to enable easier "scripting"

Additionally, generalise handling of multi-mode drt/taxi configs...