### PR TITLE
separate OnlineTrackerListener from VrpOptimizater

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
@@ -140,12 +140,4 @@ public class DefaultDrtOptimizer implements DrtOptimizer {
 			}
 		}
 	}
-
-	@Override
-	public void vehicleEnteredNextLink(Vehicle vehicle, Link nextLink) {
-		// scheduler.updateTimeline(vehicle);
-
-		// TODO we may here possibly decide whether or not to reoptimize
-		// if (delays/speedups encountered) {requiresReoptimization = true;}
-	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtOptimizer.java
@@ -19,11 +19,11 @@
 
 package org.matsim.contrib.drt.optimizer;
 
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeSimStepListener;
 
 /**
  * @author michalm
  */
-public interface DrtOptimizer extends VrpOptimizerWithOnlineTracking, MobsimBeforeSimStepListener {
+public interface DrtOptimizer extends VrpOptimizer, MobsimBeforeSimStepListener {
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -68,8 +68,8 @@ public final class DrtControlerCreator {
 	 * @param otfvis
 	 * @return
 	 */
-	public static Controler createControler(Config config, boolean otfvis) {
-		return createControler(config, otfvis, cfg -> {
+	public static Controler createControlerWithSingleModeDrt(Config config, boolean otfvis) {
+		return createControlerWithSingleModeDrt(config, otfvis, cfg -> {
 			Scenario scenario = createScenarioWithDrtRouteFactory(cfg);
 			ScenarioUtils.loadScenario(scenario);
 			return scenario;
@@ -84,7 +84,8 @@ public final class DrtControlerCreator {
 	 * @param scenarioLoader
 	 * @return
 	 */
-	public static Controler createControler(Config config, boolean otfvis, Function<Config, Scenario> scenarioLoader) {
+	public static Controler createControlerWithSingleModeDrt(Config config, boolean otfvis,
+			Function<Config, Scenario> scenarioLoader) {
 		DrtConfigs.adjustDrtConfig(DrtConfigGroup.get(config), config.planCalcScore());
 
 		config.addConfigConsistencyChecker(new DrtConfigConsistencyChecker());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
@@ -160,8 +160,7 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).
 				toProvider(modalProvider(getter -> new DrtActionCreator(getter.getModal(PassengerEngine.class),
-						getter.getModal(DrtOptimizer.class), getter.get(MobsimTimer.class),
-						getter.get(DvrpConfigGroup.class)))).
+						getter.get(MobsimTimer.class), getter.get(DvrpConfigGroup.class)))).
 				asEagerSingleton();
 
 		bindModal(PassengerRequestCreator.class).toProvider(new Provider<DrtRequestCreator>() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
@@ -31,7 +31,7 @@ public class RunDrtScenario {
 	public static void run(String configFile, boolean otfvis) {
 		Config config = ConfigUtils.loadConfig(configFile, new DrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
-		DrtControlerCreator.createControler(config, otfvis).run();
+		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
 	}
 
 	public static void main(String[] args) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunDrtExample.java
@@ -42,7 +42,7 @@ public class RunDrtExample {
 	private static final String MIELEC_CONFIG_FILE = "mielec_2014_02/mielec_drt_config.xml";
 
 	public static void run(Config config, boolean otfvis) {
-		DrtControlerCreator.createControler(config, otfvis).run();
+		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
 	}
 
 	public static void main(String[] args) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunOneSharedTaxiExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunOneSharedTaxiExample.java
@@ -37,7 +37,7 @@ public class RunOneSharedTaxiExample {
 				new OTFVisConfigGroup());
 		config.controler().setLastIteration(lastIteration);
 		config.controler().setWriteEventsInterval(lastIteration);
-		DrtControlerCreator.createControler(config, otfvis).run();
+		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
 	}
 
 	public static void main(String[] args) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
@@ -19,7 +19,6 @@
 
 package org.matsim.contrib.drt.vrpagent;
 
-import org.matsim.contrib.drt.optimizer.DrtOptimizer;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTask;
@@ -27,6 +26,7 @@ import org.matsim.contrib.dvrp.data.Vehicle;
 import org.matsim.contrib.dvrp.passenger.BusStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
@@ -43,9 +43,9 @@ public class DrtActionCreator implements VrpAgentLogic.DynActionCreator {
 	private final PassengerEngine passengerEngine;
 	private final VrpLegFactory legFactory;
 
-	public DrtActionCreator(PassengerEngine passengerEngine, DrtOptimizer optimizer, MobsimTimer timer,
-			DvrpConfigGroup dvrpCfg) {
-		this(passengerEngine, v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v, optimizer, timer));
+	public DrtActionCreator(PassengerEngine passengerEngine, MobsimTimer timer, DvrpConfigGroup dvrpCfg) {
+		this(passengerEngine, v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v,
+				OnlineTrackerListener.NO_LISTENER, timer));
 	}
 
 	public DrtActionCreator(PassengerEngine passengerEngine, VrpLegFactory legFactory) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -89,7 +89,7 @@ public class RunDrtExampleIT {
 
 		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
-		Controler controler = DrtControlerCreator.createControler(config, false);
+		Controler controler = DrtControlerCreator.createControlerWithSingleModeDrt(config, false);
 
 		PersonIdValidator personIdValidator = new PersonIdValidator();
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTrackerImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTrackerImpl.java
@@ -21,7 +21,6 @@ package org.matsim.contrib.dvrp.tracker;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.data.Vehicle;
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
 import org.matsim.contrib.dvrp.path.DivertedVrpPath;
 import org.matsim.contrib.dvrp.path.VrpPath;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
@@ -38,7 +37,7 @@ public class OnlineDriveTaskTrackerImpl implements OnlineDriveTaskTracker {
 	private final DriveTask driveTask;
 	private final VrpLeg vrpDynLeg;
 
-	private final VrpOptimizerWithOnlineTracking optimizer;
+	private final OnlineTrackerListener onlineTrackerListener;
 	private final MobsimTimer timer;
 
 	private VrpPath path;
@@ -46,12 +45,12 @@ public class OnlineDriveTaskTrackerImpl implements OnlineDriveTaskTracker {
 	private double linkEnterTime;
 	private double[] remainingTTs;// excluding the current link
 
-	public OnlineDriveTaskTrackerImpl(Vehicle vehicle, VrpLeg vrpDynLeg, VrpOptimizerWithOnlineTracking optimizer,
+	public OnlineDriveTaskTrackerImpl(Vehicle vehicle, VrpLeg vrpDynLeg, OnlineTrackerListener onlineTrackerListener,
 			MobsimTimer timer) {
 		this.vehicle = vehicle;
 		this.driveTask = (DriveTask)vehicle.getSchedule().getCurrentTask();
 		this.vrpDynLeg = vrpDynLeg;
-		this.optimizer = optimizer;
+		this.onlineTrackerListener = onlineTrackerListener;
 		this.timer = timer;
 
 		initForPath(driveTask.getPath());
@@ -84,7 +83,7 @@ public class OnlineDriveTaskTrackerImpl implements OnlineDriveTaskTracker {
 	public void movedOverNode(Link nextLink) {
 		currentLinkIdx++;
 		linkEnterTime = timer.getTimeOfDay();
-		optimizer.vehicleEnteredNextLink(vehicle, nextLink);
+		onlineTrackerListener.vehicleEnteredNextLink(vehicle, nextLink);
 	}
 
 	/**

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineTrackerListener.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineTrackerListener.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,20 +15,26 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
-package org.matsim.contrib.dvrp.optimizer;
+package org.matsim.contrib.dvrp.tracker;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.data.Vehicle;
 
 /**
- * @author michalm
- * @author (of documentation) nagel
+ * @author Michal Maciejewski (michalm)
  */
-public interface VrpOptimizerWithOnlineTracking extends VrpOptimizer {
+public interface OnlineTrackerListener {
+	OnlineTrackerListener NO_LISTENER = (vehicle, link) -> {
+	};
+
 	/**
-	 * Notifies the optimizer that the next link was entered.
+	 * Notifies that the next link was entered.
+	 *
+	 * @param vehicle
+	 * @param nextLink
 	 */
 	void vehicleEnteredNextLink(Vehicle vehicle, Link nextLink);
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/TaskTrackers.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/TaskTrackers.java
@@ -20,7 +20,6 @@
 package org.matsim.contrib.dvrp.tracker;
 
 import org.matsim.contrib.dvrp.data.Vehicle;
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -36,16 +35,10 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
  * <li>An offline tracker knows/uses only the corresponding task and the schedule (i.e. plan)</li>
  * <li>An online tracker knows/uses also the corresponding {@link DynAction} (i.e. execution)</li>
  * </ul>
- * 
+ *
  * @author michalm
  */
 public class TaskTrackers {
-	public static void initOnlineDriveTaskTracking(Vehicle vehicle, VrpLeg vrpDynLeg,
-			VrpOptimizerWithOnlineTracking optimizer, MobsimTimer timer) {
-		initOnlineDriveTaskTracking(vehicle, vrpDynLeg,
-				new OnlineDriveTaskTrackerImpl(vehicle, vrpDynLeg, optimizer, timer));
-	}
-
 	public static void initOnlineDriveTaskTracking(Vehicle vehicle, VrpLeg vrpDynLeg,
 			OnlineDriveTaskTracker onlineTracker) {
 		DriveTask driveTask = (DriveTask)vehicle.getSchedule().getCurrentTask();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLegFactory.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpLegFactory.java
@@ -19,8 +19,9 @@
 package org.matsim.contrib.dvrp.vrpagent;
 
 import org.matsim.contrib.dvrp.data.Vehicle;
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
+import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTrackerImpl;
+import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.tracker.TaskTrackers;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
@@ -41,11 +42,12 @@ public interface VrpLegFactory {
 		return leg;
 	}
 
-	static VrpLeg createWithOnlineTracker(String mode, Vehicle vehicle, VrpOptimizerWithOnlineTracking optimizer,
+	static VrpLeg createWithOnlineTracker(String mode, Vehicle vehicle, OnlineTrackerListener onlineTrackerListener,
 			MobsimTimer timer) {
 		DriveTask driveTask = (DriveTask)vehicle.getSchedule().getCurrentTask();
 		VrpLeg leg = new VrpLeg(mode, driveTask.getPath());
-		TaskTrackers.initOnlineDriveTaskTracking(vehicle, leg, optimizer, timer);
+		TaskTrackers.initOnlineDriveTaskTracking(vehicle, leg,
+				new OnlineDriveTaskTrackerImpl(vehicle, leg, onlineTrackerListener, timer));
 		return leg;
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.TreeSet;
 
 import org.apache.log4j.Logger;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.data.Fleet;
 import org.matsim.contrib.dvrp.data.Request;
 import org.matsim.contrib.dvrp.data.Vehicle;
@@ -129,15 +128,6 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 
 	protected boolean doReoptimizeAfterNextTask(TaxiTask newCurrentTask) {
 		return !destinationKnown && newCurrentTask.getTaxiTaskType() == TaxiTaskType.OCCUPIED_DRIVE;
-	}
-
-	@Override
-	public void vehicleEnteredNextLink(Vehicle vehicle, Link nextLink) {
-		// TODO do we really need this??? timeline is updated always before reoptimisation
-		scheduler.updateTimeline(vehicle);// TODO comment this out...
-
-		// TODO we may here possibly decide whether or not to reoptimize
-		// if (delays/speedups encountered) {requiresReoptimization = true;}
 	}
 
 	protected void setRequiresReoptimization(boolean requiresReoptimization) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerParams.java
@@ -36,7 +36,7 @@ public class DefaultTaxiOptimizerParams {
 	public DefaultTaxiOptimizerParams(Configuration optimizerConfig, boolean doUnscheduleAwaitingRequests,
 			boolean doUpdateTimelines) {
 		this.doUnscheduleAwaitingRequests = doUnscheduleAwaitingRequests;
-		this.doUpdateTimelines = doUnscheduleAwaitingRequests;
+		this.doUpdateTimelines = doUpdateTimelines;
 
 		reoptimizationTimeStep = optimizerConfig.getInt(REOPTIMIZATION_TIME_STEP, 1);
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizer.java
@@ -20,11 +20,10 @@
 package org.matsim.contrib.taxi.optimizer;
 
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
-import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeSimStepListener;
 
 /**
  * @author michalm
  */
-public interface TaxiOptimizer extends VrpOptimizer, OnlineTrackerListener, MobsimBeforeSimStepListener {
+public interface TaxiOptimizer extends VrpOptimizer, MobsimBeforeSimStepListener {
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizer.java
@@ -19,11 +19,12 @@
 
 package org.matsim.contrib.taxi.optimizer;
 
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizerWithOnlineTracking;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeSimStepListener;
 
 /**
  * @author michalm
  */
-public interface TaxiOptimizer extends VrpOptimizerWithOnlineTracking, MobsimBeforeSimStepListener {
+public interface TaxiOptimizer extends VrpOptimizer, OnlineTrackerListener, MobsimBeforeSimStepListener {
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -123,8 +123,7 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					@Override
 					public TaxiActionCreator get() {
 						PassengerEngine passengerEngine = getModalInstance(PassengerEngine.class);
-						TaxiOptimizer optimizer = getModalInstance(TaxiOptimizer.class);
-						return new TaxiActionCreator(passengerEngine, taxiCfg, optimizer, timer, dvrpCfg);
+						return new TaxiActionCreator(passengerEngine, taxiCfg, timer, dvrpCfg);
 					}
 				}).asEagerSingleton();
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
@@ -24,12 +24,12 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.SinglePassengerDropoffActivity;
 import org.matsim.contrib.dvrp.passenger.SinglePassengerPickupActivity;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.vrpagent.VrpActivity;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.contrib.dynagent.DynAction;
 import org.matsim.contrib.dynagent.DynAgent;
-import org.matsim.contrib.taxi.optimizer.TaxiOptimizer;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
@@ -49,10 +49,10 @@ public class TaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 	private final VrpLegFactory legFactory;
 	private final double pickupDuration;
 
-	public TaxiActionCreator(PassengerEngine passengerEngine, TaxiConfigGroup taxiCfg, TaxiOptimizer optimizer,
-			MobsimTimer timer, DvrpConfigGroup dvrpCfg) {
+	public TaxiActionCreator(PassengerEngine passengerEngine, TaxiConfigGroup taxiCfg,
+			OnlineTrackerListener onlineTrackerListener, MobsimTimer timer, DvrpConfigGroup dvrpCfg) {
 		this(passengerEngine, taxiCfg.isOnlineVehicleTracker() ?
-						v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v, optimizer, timer) :
+						v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v, onlineTrackerListener, timer) :
 						v -> VrpLegFactory.createWithOfflineTracker(dvrpCfg.getMobsimMode(), v, timer),
 				taxiCfg.getPickupDuration());
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
@@ -49,10 +49,11 @@ public class TaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 	private final VrpLegFactory legFactory;
 	private final double pickupDuration;
 
-	public TaxiActionCreator(PassengerEngine passengerEngine, TaxiConfigGroup taxiCfg,
-			OnlineTrackerListener onlineTrackerListener, MobsimTimer timer, DvrpConfigGroup dvrpCfg) {
+	public TaxiActionCreator(PassengerEngine passengerEngine, TaxiConfigGroup taxiCfg, MobsimTimer timer,
+			DvrpConfigGroup dvrpCfg) {
 		this(passengerEngine, taxiCfg.isOnlineVehicleTracker() ?
-						v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v, onlineTrackerListener, timer) :
+						v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.getMobsimMode(), v,
+								OnlineTrackerListener.NO_LISTENER, timer) :
 						v -> VrpLegFactory.createWithOfflineTracker(dvrpCfg.getMobsimMode(), v, timer),
 				taxiCfg.getPickupDuration());
 	}


### PR DESCRIPTION
- separate at the level of interfaces
- no need for active listening in most cases - currently schedules get updated before each optimisation