### PR TITLE
Provide the ability to choose between the fraction and average-speed approaches

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
@@ -86,6 +86,9 @@ extends ReflectiveConfigGroup
 	public enum NonScenarioVehicles { ignore, abort }
 	private static final String NON_SCENARIO_VEHICLES = "nonScenarioVehicles";
 	private NonScenarioVehicles nonScenarioVehicles = NonScenarioVehicles.abort;
+
+	private static final String USE_FRACTIONAL_APPROACH = "isUsingFractionalApproach";
+	private boolean isUsingFractionalApproach = true;
 	
 	@Deprecated // should be phased out.  kai, oct'18
 	private static final String EMISSION_ROADTYPE_MAPPING_FILE_CMT = "REQUIRED if source of the HBEFA road type is set to "+HbefaRoadTypeSource.fromFile +". It maps from input road types to HBEFA 3.1 road type strings";
@@ -125,6 +128,8 @@ extends ReflectiveConfigGroup
 			+ NonScenarioVehicles.values()
 			+ " Should eventually be extended by 'getVehiclesFromMobsim'."
 	 ;
+
+	private static final String USE_FRACTIONAL_APPROACH_CMT = "if true, the original fractional method from Hülsmann et al (2011) will be used to calculate emission factors";
 
 
 	@Override
@@ -168,6 +173,8 @@ extends ReflectiveConfigGroup
 		map.put(HANDLE_HIGH_AVERAGE_SPEEDS, HANDLE_HIGH_AVERAGE_SPEEDS_CMT);
 		
 		map.put(NON_SCENARIO_VEHICLES, NON_SCENARIO_VEHICLES_CMT);
+
+        map.put(USE_FRACTIONAL_APPROACH, USE_FRACTIONAL_APPROACH_CMT);
 
 		return map;
 	}
@@ -379,4 +386,15 @@ extends ReflectiveConfigGroup
 	public void setNonScenarioVehicles(NonScenarioVehicles nonScenarioVehicles) {
 		this.nonScenarioVehicles = nonScenarioVehicles;
 	}
+
+    @StringGetter(USE_FRACTIONAL_APPROACH)
+    public boolean isUsingFractionalApproach() {
+        return isUsingFractionalApproach;
+    }
+
+    @StringSetter(USE_FRACTIONAL_APPROACH)
+    public void setUsingFractionalApproach(boolean useFractionalApproach) {
+        this.isUsingFractionalApproach = useFractionalApproach;
+    }
+
 }

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
@@ -87,8 +87,9 @@ extends ReflectiveConfigGroup
 	private static final String NON_SCENARIO_VEHICLES = "nonScenarioVehicles";
 	private NonScenarioVehicles nonScenarioVehicles = NonScenarioVehicles.abort;
 
-	private static final String USE_FRACTIONAL_APPROACH = "isUsingFractionalApproach";
-	private boolean isUsingFractionalApproach = true;
+	public enum EmissionsComputationMethod {StopAndGoFraction,AverageSpeed}
+	private static final String EMISSIONS_COMPUTATION_METHOD = "emissionsComputationMethod";
+	private EmissionsComputationMethod emissionsComputationMethod = EmissionsComputationMethod.StopAndGoFraction;
 	
 	@Deprecated // should be phased out.  kai, oct'18
 	private static final String EMISSION_ROADTYPE_MAPPING_FILE_CMT = "REQUIRED if source of the HBEFA road type is set to "+HbefaRoadTypeSource.fromFile +". It maps from input road types to HBEFA 3.1 road type strings";
@@ -129,7 +130,7 @@ extends ReflectiveConfigGroup
 			+ " Should eventually be extended by 'getVehiclesFromMobsim'."
 	 ;
 
-	private static final String USE_FRACTIONAL_APPROACH_CMT = "if true, the original fractional method from Hülsmann et al (2011) will be used to calculate emission factors";
+	private static final String EMISSIONS_COMPUTATION_METHOD_CMT = "if true, the original fractional method from Hülsmann et al (2011) will be used to calculate emission factors";
 
 
 	@Override
@@ -174,7 +175,7 @@ extends ReflectiveConfigGroup
 		
 		map.put(NON_SCENARIO_VEHICLES, NON_SCENARIO_VEHICLES_CMT);
 
-        map.put(USE_FRACTIONAL_APPROACH, USE_FRACTIONAL_APPROACH_CMT);
+        map.put(EMISSIONS_COMPUTATION_METHOD, EMISSIONS_COMPUTATION_METHOD_CMT);
 
 		return map;
 	}
@@ -387,14 +388,14 @@ extends ReflectiveConfigGroup
 		this.nonScenarioVehicles = nonScenarioVehicles;
 	}
 
-    @StringGetter(USE_FRACTIONAL_APPROACH)
-    public boolean isUsingFractionalApproach() {
-        return isUsingFractionalApproach;
+    @StringGetter(EMISSIONS_COMPUTATION_METHOD)
+    public EmissionsComputationMethod getEmissionsComputationMethod() {
+        return emissionsComputationMethod;
     }
 
-    @StringSetter(USE_FRACTIONAL_APPROACH)
-    public void setUsingFractionalApproach(boolean useFractionalApproach) {
-        this.isUsingFractionalApproach = useFractionalApproach;
+    @StringSetter(EMISSIONS_COMPUTATION_METHOD)
+    public void setEmissionsComputationMethod(EmissionsComputationMethod emissionsComputationMethod) {
+        this.emissionsComputationMethod = emissionsComputationMethod;
     }
 
 }

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModule.java
@@ -518,6 +518,7 @@ public class TestWarmEmissionAnalysisModule {
 		
 		// = ff speed
 		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, linkLength/petrolSpeedFf*3.6);
+		Assert.assertEquals(0, weam.getFractionOccurences());
 		Assert.assertEquals(linkLength/1000, weam.getFreeFlowKmCounter(), MatsimTestUtils.EPSILON);
 		Assert.assertEquals(1, weam.getFreeFlowOccurences());
 		Assert.assertEquals(linkLength/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
@@ -537,6 +538,88 @@ public class TestWarmEmissionAnalysisModule {
 		weam.reset();
 		
 		
+	}
+
+	@Test
+	public void testCounters1fractional(){
+		setUp();
+		weam.getEcg().setUsingFractionalApproach(true);
+		weam.reset();
+
+		/*
+		 * using the same case as above - case 1 and check the counters for all possible combinations of avg, stop go and free flow speed
+		 */
+
+		Id<Vehicle> vehicleId = Id.create("vehicle 1", Vehicle.class);
+		String roadType = "0";
+		double linkLength = 2*1000.; //in meter
+		Id<VehicleType> vehicleTypeId = Id.create(passengercar+ ";"+petrolTechnology+";"+petrolSizeClass+";"+petrolConcept, VehicleType.class);
+		VehiclesFactory vehFac = VehicleUtils.getFactory();
+		Vehicle vehicle = vehFac.createVehicle(vehicleId, vehFac.createVehicleType(vehicleTypeId));
+
+		Link mockLink = createMockLink("link 1", linkLength, petrolSpeedFf / 3.6);
+
+
+		// <stop&go speed
+		Double travelTime = linkLength/petrolSpeedSg*1.2;
+		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, travelTime*3.6);
+		Assert.assertEquals(0, weam.getFractionOccurences(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0., weam.getFreeFlowKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getFreeFlowOccurences());
+		Assert.assertEquals(linkLength/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(linkLength/1000, weam.getStopGoKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(1, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+		weam.reset();
+
+		// = s&g speed
+		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, linkLength/petrolSpeedSg*3.6);
+		Assert.assertEquals(0, weam.getFractionOccurences());
+		Assert.assertEquals(0., weam.getFreeFlowKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getFreeFlowOccurences());
+		Assert.assertEquals(linkLength/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(linkLength/1000, weam.getStopGoKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(1, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+		weam.reset();
+
+		// > s&g speed, <ff speed
+		// speed in km/h
+		travelTime = .5 * linkLength/petrolSpeedFf *3.6 + .5* (linkLength/petrolSpeedSg)*3.6; //540 seconds
+		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, travelTime);
+		Assert.assertEquals(1, weam.getFractionOccurences());
+		Assert.assertEquals(1., weam.getFreeFlowKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getFreeFlowOccurences());
+		Assert.assertEquals(linkLength/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(1., weam.getStopGoKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+		Assert.assertEquals(weam.getKmCounter(), (weam.getStopGoKmCounter()+weam.getFreeFlowKmCounter()), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(travelTime, 3600*weam.getFreeFlowKmCounter()/petrolSpeedFf+3600*weam.getStopGoKmCounter()/petrolSpeedSg, MatsimTestUtils.EPSILON);
+		weam.reset();
+
+		// = ff speed
+		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, linkLength/petrolSpeedFf*3.6);
+		Assert.assertEquals(0, weam.getFractionOccurences());
+		Assert.assertEquals(linkLength/1000, weam.getFreeFlowKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(1, weam.getFreeFlowOccurences());
+		Assert.assertEquals(linkLength/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0., weam.getStopGoKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+		weam.reset();
+
+		//> ff speed
+		boolean exceptionThrown = false;
+		try{
+			warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicle, mockLink, 0.4*linkLength/petrolSpeedFf*3.6);
+		}catch(RuntimeException re){
+			exceptionThrown = true;
+		}
+		Assert.assertTrue("An average speed higher than the free flow speed should throw a runtime exception", exceptionThrown);
+		weam.reset();
+
+
 	}
 
 	@Test
@@ -681,6 +764,42 @@ public class TestWarmEmissionAnalysisModule {
 		
 		warmEmissions =weam.checkVehicleInfoAndCalculateWarmEmissions(inconffVehicle, inconLink, 2*inconff/(petrolSpeedFf+petrolSpeedSg)*3.6);
 	}
+
+	@Test
+	public void testCounters6(){
+		setUp();
+		weam.getEcg().setUsingFractionalApproach(true);
+		weam.reset();
+
+		// case 1 - data in both tables -> use detailed
+		// free flow velocity inconsistent -> different value in table
+		Id<Vehicle> inconffVehicleId = Id.create("vehicle 7", Vehicle.class);
+		double inconff = 30. * 1000;
+		double inconffavgSpeed = petrolSpeedFf*2.2;
+		Id<VehicleType> inconffVehicleTypeId = Id.create(passengercar + ";"+petrolTechnology+";"+petrolSizeClass+";"+petrolConcept, VehicleType.class);
+		VehiclesFactory vehFac = VehicleUtils.getFactory();
+		Vehicle inconffVehicle = vehFac.createVehicle(inconffVehicleId, vehFac.createVehicleType(inconffVehicleTypeId));
+		Link inconLink = createMockLink("link incon", inconff, inconffavgSpeed / 3.6);
+
+		// average speed equals free flow speed from table
+		warmEmissions =weam.checkVehicleInfoAndCalculateWarmEmissions(inconffVehicle,inconLink, inconff/petrolSpeedFf*3.6);
+		Assert.assertEquals(1, weam.getFractionOccurences());
+		Assert.assertEquals(0, weam.getFreeFlowOccurences());
+		Assert.assertEquals(inconff/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+		weam.reset();
+
+		// average speed equals wrong free flow speed
+		warmEmissions =weam.checkVehicleInfoAndCalculateWarmEmissions(inconffVehicle, inconLink, inconff/inconffavgSpeed*3.6);
+		Assert.assertEquals(0, weam.getFractionOccurences());
+		Assert.assertEquals(1, weam.getFreeFlowOccurences());
+		Assert.assertEquals(inconff/1000, weam.getKmCounter(), MatsimTestUtils.EPSILON);
+		Assert.assertEquals(0, weam.getStopGoOccurences());
+		Assert.assertEquals(1, weam.getWarmEmissionEventCounter());
+
+		warmEmissions =weam.checkVehicleInfoAndCalculateWarmEmissions(inconffVehicle, inconLink, 2*inconff/(petrolSpeedFf+petrolSpeedSg)*3.6);
+	}
 	
 	@Test
 	public void testCounters7(){
@@ -779,6 +898,7 @@ public class TestWarmEmissionAnalysisModule {
 
 		EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
+		ecg.setUsingFractionalApproach(false);
 
 		WarmEmissionAnalysisModuleParameter weamParameter
 				= new WarmEmissionAnalysisModuleParameter(avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);
@@ -805,7 +925,23 @@ public class TestWarmEmissionAnalysisModule {
 				(numberOfWarmEmissions*avgPcFactorFf*rescaleF) + " but were " + HandlerToTestEmissionAnalysisModules.getSum();
 		
 		Assert.assertEquals(message, rescaleF*numberOfWarmEmissions*avgPcFactorFf, HandlerToTestEmissionAnalysisModules.getSum(), MatsimTestUtils.EPSILON);
-		
+
+		///test the fractional approach with rescaling as well
+		ecg.setUsingFractionalApproach(true);
+		HandlerToTestEmissionAnalysisModules.reset();
+
+		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicleForAvgTable, dieselLink, linkLength /dieselFreeVelocity*3.6);
+		weam.throwWarmEmissionEvent(10, idForAvgTable, vehicleIdForAvgTable, warmEmissions);
+
+		numberOfWarmEmissions = numberOfWarmPollutants;
+
+		message = "The expected rescaled emissions with the fractional method for this event are (calculated emissions * rescalefactor) = "
+				+ (numberOfWarmEmissions*avgPcFactorFf) + " * " + rescaleF + " = " +
+				(numberOfWarmEmissions*avgPcFactorFf*rescaleF) + " but were " + HandlerToTestEmissionAnalysisModules.getSum();
+
+		Assert.assertEquals(message, rescaleF*numberOfWarmEmissions*avgPcFactorFf, HandlerToTestEmissionAnalysisModules.getSum(), MatsimTestUtils.EPSILON);
+
+
 	}
 	
 	private void setUp() {
@@ -820,11 +956,11 @@ public class TestWarmEmissionAnalysisModule {
 		EventsManager emissionEventManager = new HandlerToTestEmissionAnalysisModules();
         EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
+		ecg.setUsingFractionalApproach(false);
 
 		WarmEmissionAnalysisModuleParameter warmEmissionParameterObject = new WarmEmissionAnalysisModuleParameter(
 				avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);
 		weam = new WarmEmissionAnalysisModule(warmEmissionParameterObject, emissionEventManager, null);
-
 	}
 
 	private Link createMockLink(String linkId, double linkLength, double ffspeed) {

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModule.java
@@ -40,6 +40,7 @@ import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.VehiclesFactory;
 
+import static org.matsim.contrib.emissions.utils.EmissionsConfigGroup.EmissionsComputationMethod.*;
 
 /**
  * @author julia
@@ -543,7 +544,7 @@ public class TestWarmEmissionAnalysisModule {
 	@Test
 	public void testCounters1fractional(){
 		setUp();
-		weam.getEcg().setUsingFractionalApproach(true);
+		weam.getEcg().setEmissionsComputationMethod(StopAndGoFraction);
 		weam.reset();
 
 		/*
@@ -768,8 +769,8 @@ public class TestWarmEmissionAnalysisModule {
 	@Test
 	public void testCounters6(){
 		setUp();
-		weam.getEcg().setUsingFractionalApproach(true);
-		weam.reset();
+		weam.getEcg().setEmissionsComputationMethod(StopAndGoFraction);
+        weam.reset();
 
 		// case 1 - data in both tables -> use detailed
 		// free flow velocity inconsistent -> different value in table
@@ -898,7 +899,7 @@ public class TestWarmEmissionAnalysisModule {
 
 		EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
-		ecg.setUsingFractionalApproach(false);
+        ecg.setEmissionsComputationMethod(AverageSpeed);
 
 		WarmEmissionAnalysisModuleParameter weamParameter
 				= new WarmEmissionAnalysisModuleParameter(avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);
@@ -927,7 +928,7 @@ public class TestWarmEmissionAnalysisModule {
 		Assert.assertEquals(message, rescaleF*numberOfWarmEmissions*avgPcFactorFf, HandlerToTestEmissionAnalysisModules.getSum(), MatsimTestUtils.EPSILON);
 
 		///test the fractional approach with rescaling as well
-		ecg.setUsingFractionalApproach(true);
+        weam.getEcg().setEmissionsComputationMethod(StopAndGoFraction);
 		HandlerToTestEmissionAnalysisModules.reset();
 
 		warmEmissions = weam.checkVehicleInfoAndCalculateWarmEmissions(vehicleForAvgTable, dieselLink, linkLength /dieselFreeVelocity*3.6);
@@ -956,7 +957,7 @@ public class TestWarmEmissionAnalysisModule {
 		EventsManager emissionEventManager = new HandlerToTestEmissionAnalysisModules();
         EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
-		ecg.setUsingFractionalApproach(false);
+        ecg.setEmissionsComputationMethod(AverageSpeed);
 
 		WarmEmissionAnalysisModuleParameter warmEmissionParameterObject = new WarmEmissionAnalysisModuleParameter(
 				avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModuleTrafficSituations.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModuleTrafficSituations.java
@@ -42,6 +42,7 @@ import org.matsim.vehicles.VehiclesFactory;
 import java.util.*;
 
 import static org.matsim.contrib.emissions.types.HbefaTrafficSituation.*;
+import static org.matsim.contrib.emissions.utils.EmissionsConfigGroup.EmissionsComputationMethod.*;
 
 
 /**
@@ -107,7 +108,7 @@ public class TestWarmEmissionAnalysisModuleTrafficSituations {
 		EventsManager emissionEventManager = new HandlerToTestEmissionAnalysisModules();
         EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
-		ecg.setUsingFractionalApproach(false);
+		ecg.setEmissionsComputationMethod(AverageSpeed);
 
 		WarmEmissionAnalysisModuleParameter warmEmissionParameterObject = new WarmEmissionAnalysisModuleParameter(
 				avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModuleTrafficSituations.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionAnalysisModuleTrafficSituations.java
@@ -107,6 +107,7 @@ public class TestWarmEmissionAnalysisModuleTrafficSituations {
 		EventsManager emissionEventManager = new HandlerToTestEmissionAnalysisModules();
         EmissionsConfigGroup ecg = new EmissionsConfigGroup();
 		ecg.setUsingVehicleTypeIdAsVehicleDescription(true);
+		ecg.setUsingFractionalApproach(false);
 
 		WarmEmissionAnalysisModuleParameter warmEmissionParameterObject = new WarmEmissionAnalysisModuleParameter(
 				avgHbefaWarmTable, detailedHbefaWarmTable, hbefaRoadTrafficSpeeds, pollutants, ecg);


### PR DESCRIPTION
The default is the fraction method validated in Hülsmann et al. (2011).

This pull request would return the previous method which took a fraction of freeflow and stop&go to reflect queuing time on links. An approach using all 4 traffic states is still available, but must be enabled in the emissions config with `isUsingFractionalApproach`

The functionality that was restored is (removed in commit [5c80fd ](https://github.com/matsim-org/matsim/commit/5c80fdf9849e995a1adeee9a62d0720e991287fa):
```
double distanceStopGo_km = (linkLength_km * stopGoSpeedFromTable_kmh * (freeFlowSpeed_kmh - averageSpeed_kmh)) / (averageSpeed_kmh * (freeFlowSpeed_kmh - stopGoSpeedFromTable_kmh));
double distanceFreeFlow_km = linkLength_km - distanceStopGo_km;
generatedEmissions = (distanceFreeFlow_km * efFreeFlow_gpkm) + (distanceStopGo_km * efStopGo_gpkm);
```



