### PR TITLE
fix: replace call addMobsimListenerBinding() with addModalQSimComponent()

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -64,7 +64,7 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
 			protected void configureQSim() {
-				addMobsimListenerBinding().toProvider(modalProvider(
+				addModalQSimComponentBinding().toProvider(modalProvider(
 						getter -> new DrtVehicleOccupancyProfileWriter(getter.getModal(Fleet.class),
 								getter.get(MatsimServices.class), drtCfg)));
 			}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -28,14 +28,12 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
@@ -96,9 +94,7 @@ public class RunDrtExampleIT {
 		controler.addOverridingQSimModule(new AbstractDvrpModeQSimModule(DrtConfigGroup.get(config).getMode()) {
 			@Override
 			protected void configureQSim() {
-				this.bind(PassengerRequestValidator.class)
-						.annotatedWith(DvrpModes.mode(TransportMode.drt))
-						.toInstance(personIdValidator);
+				bindModal(PassengerRequestValidator.class).toInstance(personIdValidator);
 			}
 		});
 		controler.run();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeModule.java
@@ -43,7 +43,7 @@ public abstract class AbstractDvrpModeModule extends AbstractModule {
 	}
 
 	protected <T> Key<T> modalKey(Class<T> type) {
-		return Key.get(type, DvrpModes.mode(mode));
+		return DvrpModes.key(type, mode);
 	}
 
 	protected <T> LinkedBindingBuilder<T> bindModal(Class<T> type) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
@@ -49,7 +49,7 @@ public abstract class AbstractDvrpModeQSimModule extends AbstractQSimModule {
 	}
 
 	protected final <T> Key<T> modalKey(Class<T> type) {
-		return Key.get(type, getDvrpMode());
+		return DvrpModes.key(type, mode);
 	}
 
 	protected final <T> LinkedBindingBuilder<T> bindModal(Class<T> type) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.dvrp.run;
 
 import java.util.function.Function;
 
+import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponent;
 
@@ -53,6 +54,30 @@ public abstract class AbstractDvrpModeQSimModule extends AbstractQSimModule {
 
 	protected final <T> LinkedBindingBuilder<T> bindModal(Class<T> type) {
 		return bind(modalKey(type));
+	}
+
+	/**
+	 * Adding this method to AbstractDvrpModeQSimModule prevents accidentally calling
+	 * AbstractModule.addMobsimListenerBinding() from the AbstractDvrpModeQSimModule.configureQSim() method.
+	 * (which has happened to me at least twice, michal.mac, feb'19)
+	 * <p>
+	 * Normally, if an AbstractQSimModule class is an inner class of an outer AbstractModule class,
+	 * addMobsimListenerBinding() will call AbstractModule.addMobsimListenerBinding(), which will have no effect (
+	 * too late for adding a listener with the controller scope).
+	 * <p>
+	 * However, quite likely, the programmer intention is to add a listener with the mobsim/QSim scope, as if
+	 * addQSimComponentBinding() or addModalQSimComponentBinding() were called.
+	 * <p>
+	 * Although less likely, other methods of AbstractModule could also be accidentally called. Therefore, one should
+	 * consider prefixing calls with "this" (e.g. this.addModalQSimComponentBinding()) when an AbstractQSimModule
+	 * is inside an AbstractModule.
+	 *
+	 * @throws RuntimeException
+	 */
+	@Deprecated
+	protected final LinkedBindingBuilder<MobsimListener> addMobsimListenerBinding() {
+		throw new UnsupportedOperationException(
+				"Very likely you wanted to call addQSimComponentBinding() or addModalQSimComponentBinding()");
 	}
 
 	protected final LinkedBindingBuilder<QSimComponent> addModalQSimComponentBinding() {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/ModalProviders.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/ModalProviders.java
@@ -75,7 +75,7 @@ public class ModalProviders {
 		}
 
 		public <T> T getModal(Class<T> type) {
-			return injector.getInstance(Key.get(type, DvrpModes.mode(mode)));
+			return injector.getInstance(DvrpModes.key(type, mode));
 		}
 
 		public <T> T getNamed(Class<T> type, String name) {
@@ -94,7 +94,7 @@ public class ModalProviders {
 		}
 
 		protected <I> I getModalInstance(Class<I> type) {
-			return injector.getInstance(Key.get(type, DvrpModes.mode(mode)));
+			return injector.getInstance(DvrpModes.key(type, mode));
 		}
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/DvrpAuxConsumptionFactory.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/DvrpAuxConsumptionFactory.java
@@ -32,7 +32,6 @@ import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.OhdeSlaskiAuxEnergyConsumption;
 
 import com.google.inject.Injector;
-import com.google.inject.Key;
 
 public class DvrpAuxConsumptionFactory implements AuxEnergyConsumption.Factory {
 	@Inject
@@ -51,7 +50,7 @@ public class DvrpAuxConsumptionFactory implements AuxEnergyConsumption.Factory {
 
 	@Override
 	public AuxEnergyConsumption create(ElectricVehicle electricVehicle) {
-		Fleet fleet = injector.getInstance(Key.get(Fleet.class, DvrpModes.mode(mode)));
+		Fleet fleet = injector.getInstance(DvrpModes.key(Fleet.class, mode));
 		DvrpVehicle vehicle = fleet.getVehicles().get(electricVehicle.getId());
 		return new OhdeSlaskiAuxEnergyConsumption(electricVehicle, temperatureProvider,
 				ev -> turnedOnPredicate.test(vehicle));


### PR DESCRIPTION
It is very easy to accidentally call `addMobsimListenerBinding()` instead of `addQSimComponentBinding()` in a QSim module nested inside a "standard" (controller) module.

I tried to prevent such cases in the future with: 99b4551 (for subclasses of `AbstractDvrpModeQSimModule`).

Maybe there is a cleaner approach that prevents adding controller-level bindings after the controller starts???