### PR TITLE
Kn let pt use access walk telep params

### DIFF
--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/utils/ProcessNoiseImmissions.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/utils/ProcessNoiseImmissions.java
@@ -33,11 +33,7 @@ import org.apache.log4j.Logger;
 import org.locationtech.jts.geom.Envelope;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
-import org.matsim.contrib.analysis.vsp.qgis.GraduatedSymbolRenderer;
-import org.matsim.contrib.analysis.vsp.qgis.QGisConstants;
-import org.matsim.contrib.analysis.vsp.qgis.QGisWriter;
-import org.matsim.contrib.analysis.vsp.qgis.RendererFactory;
-import org.matsim.contrib.analysis.vsp.qgis.VectorLayer;
+import org.matsim.contrib.analysis.vsp.qgis.*;
 import org.matsim.contrib.noise.data.ReceiverPoint;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
 import org.matsim.core.utils.io.IOUtils;
@@ -254,7 +250,7 @@ public class ProcessNoiseImmissions {
 		noiseLayer.setXField("x");
 		noiseLayer.setYField("y");
 
-        GraduatedSymbolRenderer renderer = RendererFactory.createNoiseRenderer(noiseLayer, this.receiverPointGap);
+        GraduatedSymbolRenderer renderer = RendererFactory.createNoiseRenderer(noiseLayer, this.receiverPointGap );
 		renderer.setRenderingAttribute("Lden");
 		
 		writer.addLayer(noiseLayer);

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
@@ -298,18 +298,34 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		}
 	}
 
+	public void clearModeRoutingParams() {
+		clearParameterSetsForType( ModeRoutingParams.SET_TYPE ) ;
+	}
+
 	@Override
 	public void addParameterSet(final ConfigGroup set) {
-		if ( set.getName().equals( ModeRoutingParams.SET_TYPE ) && !this.acceptModeParamsWithoutClearing ) {
-			clearParameterSetsForType( set.getName() );
-			this.acceptModeParamsWithoutClearing = true;
-			
-		}
-		ModeRoutingParams pars = (ModeRoutingParams) set ;
-		// for the time being pushing the "global" factor into the local ones if they are not initialized by
-		// themselves.  Necessary for some tests; maybe we should eventually disable them.  kai, feb'15
-		if ( pars.getBeelineDistanceFactor()== null ) {
-			pars.setBeelineDistanceFactor( this.beelineDistanceFactor );
+		if ( set.getName().equals( ModeRoutingParams.SET_TYPE ) ){
+			if( !this.acceptModeParamsWithoutClearing ){
+				//			clearParameterSetsForType( set.getName() );
+				log.warn( "It used to be the case that manually setting one mode routing here would first clear all the default values.  I have now removed " +
+						    "this clearing, i.e. default values will remain.  If they are in the way, removeModeRoutingParams(...) can be used to " +
+						    "individually remove them.  kai, apr'19" );
+				this.acceptModeParamsWithoutClearing = true;
+			}
+			ModeRoutingParams pars = (ModeRoutingParams) set;
+
+			ModeRoutingParams result = this.getModeRoutingParams().get( pars.getMode() );
+			if ( result != null ) {
+				log.info("Replacing mode routing params for mode=" + pars.getMode() + "." ) ;
+				// above warning can be converted to info in about 2 years.  kai, apr'19
+				this.removeModeRoutingParams( pars.getMode() );
+			}
+
+			// for the time being pushing the "global" factor into the local ones if they are not initialized by
+			// themselves.  Necessary for some tests; maybe we should eventually disable them.  kai, feb'15
+			if( pars.getBeelineDistanceFactor() == null ){
+				pars.setBeelineDistanceFactor( this.beelineDistanceFactor );
+			}
 		}
 		super.addParameterSet( set );
 	}
@@ -470,7 +486,7 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		return map ;
 	}
 	
-	@Deprecated // use mode-specific factors.  kai, apr'15
+//	@Deprecated // use mode-specific factors.  kai, apr'15
 	public void setTeleportedModeFreespeedFactor(String mode, double freespeedFactor) {
 		testForLocked() ;
 		// re-create, to trigger erasing of defaults (normally forbidden, see acceptModeParamsWithoutClearing)
@@ -479,7 +495,7 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		addParameterSet( pars );
 	}
 
-	@Deprecated // use mode-specific factors.  kai, apr'15
+//	@Deprecated // use mode-specific factors.  kai, apr'15
 	public void setTeleportedModeSpeed(String mode, double speed) {
 		testForLocked() ;
 		// re-create, to trigger erasing of defaults (normally forbidden, see acceptModeParamsWithoutClearing)

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -27,7 +27,10 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.config.groups.VspExperimentalConfigGroup;
+import org.matsim.core.gbl.Gbl;
 import org.matsim.pt.config.TransitRouterConfigGroup;
+
+import java.util.Map;
 
 /**
  * Design decisions:<ul>
@@ -114,8 +117,15 @@ public class TransitRouterConfig implements MatsimParameters {
 		}
 		
 		// walk:
-		this.beelineDistanceFactor = pcrConfig.getModeRoutingParams().get( TransportMode.access_walk ).getBeelineDistanceFactor();
-		this.beelineWalkSpeed = pcrConfig.getTeleportedModeSpeeds().get(TransportMode.access_walk) / beelineDistanceFactor ;
+		{
+			for( Map.Entry<String, PlansCalcRouteConfigGroup.ModeRoutingParams> entry : pcrConfig.getModeRoutingParams().entrySet() ){
+				Logger.getLogger( this.getClass() ).warn("mode=" + entry.getKey() + "; params=" + entry.getValue()) ;
+			}
+			final PlansCalcRouteConfigGroup.ModeRoutingParams params = pcrConfig.getModeRoutingParams().get( TransportMode.access_walk );
+			Gbl.assertNotNull( params );
+			this.beelineDistanceFactor = params.getBeelineDistanceFactor();
+			this.beelineWalkSpeed = pcrConfig.getTeleportedModeSpeeds().get( TransportMode.access_walk ) / beelineDistanceFactor;
+		}
 		// yyyyyy the two above need to be moved away from walk since otherwise one is not able to move walk routing to network routing!!!!!! Now trying access_walk ...  kai,
 		// apr'19
 		

--- a/matsim/src/test/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroupTest.java
@@ -63,6 +63,7 @@ public class PlansCalcRouteConfigGroupTest {
 	@Test
 	public void testDefaultsAreCleared() {
 		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup();
+		group.clearModeRoutingParams();
 		group.setTeleportedModeSpeed( "skateboard" , 20 / 3.6 );
 		group.setTeleportedModeSpeed( "longboard" , 20 / 3.6 );
 		Assert.assertEquals(

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
@@ -53,7 +53,8 @@ public class TransitRouterConfigTest {
 		
 		planScoring.setUtilityOfLineSwitch(-2.34);
 		
-		planRouting.setTeleportedModeSpeed(TransportMode.walk, 1.37);
+		planRouting.setTeleportedModeSpeed(TransportMode.access_walk, 1.37);
+		// (this will clear all defaults!)
 		planRouting.setBeelineDistanceFactor(1.2);
 		
 		transitRouting.setAdditionalTransferTime(128.0);


### PR DESCRIPTION
Implementation of `TransitRouterConfig` was such that it needed teleported walk routing activated.  Changed that (by using the access_walk params instead).

In the process, I removed the automagical clearing of default routing params.  I found that more awkward than helpful.  Now one can actively remove them one by one, or clear them all, or add to them.