### PR TITLE
make Route extend Attributable

### DIFF
--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/population/DriverRoute.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/population/DriverRoute.java
@@ -32,8 +32,8 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.routes.NetworkRoute;
-import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author thibautd
@@ -41,6 +41,7 @@ import org.matsim.core.population.routes.RouteUtils;
 public class DriverRoute implements Route , NetworkRoute {
 	private final NetworkRoute netRoute;
 	private final Set<Id<Person>> passengers = new TreeSet<Id<Person>>();
+	private final Attributes attributes = new Attributes();
 
 	public DriverRoute(final Id<Link> startLink , final Id<Link> endLink) {
 		netRoute = RouteUtils.createLinkNetworkRouteImpl(startLink, endLink);
@@ -205,7 +206,12 @@ public class DriverRoute implements Route , NetworkRoute {
 	public String getRouteType() {
 		return "driver";
 	}
-	
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
+	}
+
 	@Override
 	public String toString() {
 		return "[DriverRoute: delegate="+netRoute+"; passengers="+passengers+"]";

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/population/PassengerRoute.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/population/PassengerRoute.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.utils.misc.Time;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * A route for passenger trips.
@@ -35,6 +36,7 @@ public class PassengerRoute implements Route {
 	private Id<Link> startLink = null;
 	private Id<Link> endLink = null;
 	private Id<Person> driver = null;
+	private final Attributes attributes = new Attributes();
 
 	private PassengerRoute() {}
 
@@ -108,6 +110,11 @@ public class PassengerRoute implements Route {
 	@Override
 	public String getRouteType() {
 		return "passenger";
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
 	}
 
 	@Override

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/sharedvehicles/replanning/VehicleOnlyNetworkRoute.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/sharedvehicles/replanning/VehicleOnlyNetworkRoute.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * to put vehicle Id in legs without route.
@@ -132,6 +133,11 @@ class VehicleOnlyNetworkRoute implements NetworkRoute {
 
 	@Override
 	public VehicleOnlyNetworkRoute clone() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Attributes getAttributes() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/population/Route.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/population/Route.java
@@ -23,13 +23,13 @@ package org.matsim.api.core.v01.population;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.api.internal.MatsimPopulationObject;
-import org.matsim.core.scenario.Lockable;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * @author nagel
  *
  */
-public interface Route extends MatsimPopulationObject {
+public interface Route extends MatsimPopulationObject, Attributable {
 
 	public double getDistance();
 

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/pt/AbstractTransitDriverAgent.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/pt/AbstractTransitDriverAgent.java
@@ -19,6 +19,9 @@
 
 package org.matsim.core.mobsim.qsim.pt;
 
+import java.util.List;
+import java.util.ListIterator;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -42,10 +45,8 @@ import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
-
-import java.util.List;
-import java.util.ListIterator;
 
 public abstract class AbstractTransitDriverAgent implements TransitDriverAgent, PlanAgent {
 
@@ -429,6 +430,11 @@ public abstract class AbstractTransitDriverAgent implements TransitDriverAgent, 
 		@Override
 		public void setTravelTime(final double travelTime) {
 			throw new UnsupportedOperationException("read only route.");
+		}
+
+		@Override
+		public Attributes getAttributes() {
+			return this.delegate.getAttributes();
 		}
 
 		@Override

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
@@ -19,13 +19,21 @@
 
 package org.matsim.core.population.io;
 
-import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Stack;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.population.*;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.api.internal.MatsimReader;
 import org.matsim.core.population.PersonUtils;
 import org.matsim.core.population.PopulationUtils;
@@ -45,9 +53,7 @@ import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegat
 import org.matsim.vehicles.Vehicle;
 import org.xml.sax.Attributes;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Stack;
+import com.google.inject.Inject;
 
 /**
  * A reader for plans files of MATSim according to <code>population_v6.dtd</code>.
@@ -162,6 +168,9 @@ import java.util.Stack;
 						break;
 					case LEG:
 						currAttributes = currleg.getAttributes();
+						break;
+					case ROUTE:
+						currAttributes = currRoute.getAttributes();
 						break;
 					default:
 						throw new RuntimeException( context.peek() );

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV6.java
@@ -20,10 +20,20 @@
 
 package org.matsim.core.population.io;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.population.*;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.PersonUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -32,10 +42,6 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 import org.matsim.vehicles.Vehicle;
-
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * @author thibautd
@@ -95,7 +101,7 @@ import java.util.Map;
 					// route
 					Route route = leg.getRoute();
 					if (route != null) {
-						PopulationWriterHandlerImplV6.startRoute(route, out);
+						this.startRoute(route, out);
 						PopulationWriterHandlerImplV6.endRoute(out);
 					}
 					PopulationWriterHandlerImplV6.endLeg(out);
@@ -234,7 +240,7 @@ import java.util.Map;
 		out.write("\t\t\t</leg>\n");
 	}
 
-	private static void startRoute(final Route route, final BufferedWriter out) throws IOException {
+	private void startRoute(final Route route, final BufferedWriter out) throws IOException {
 		out.write("\t\t\t\t<route ");
 		out.write("type=\"");
 		out.write(route.getRouteType());
@@ -266,6 +272,8 @@ import java.util.Map;
 		if (rd != null) {
 			out.write(rd);
 		}
+
+		this.attributesWriter.writeAttributes("\t\t\t\t\t", out, route.getAttributes());
 	}
 
 	private static void endRoute(final BufferedWriter out) throws IOException {

--- a/matsim/src/main/java/org/matsim/core/population/routes/AbstractRoute.java
+++ b/matsim/src/main/java/org/matsim/core/population/routes/AbstractRoute.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.utils.misc.Time;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * Default, abstract implementation of the {@link Route}-interface.
@@ -43,6 +44,8 @@ public abstract class AbstractRoute implements Route, Cloneable {
 
 	private Id<Link> startLinkId = null;
 	private Id<Link> endLinkId = null;
+
+	private final Attributes attributes = new Attributes();
 
 	public AbstractRoute(final Id<Link> startLinkId, final Id<Link> endLinkId) {
 		this.startLinkId = startLinkId;
@@ -90,7 +93,12 @@ public abstract class AbstractRoute implements Route, Cloneable {
 	public final Id<Link> getEndLinkId() {
 		return this.endLinkId;
 	}
-	
+
+	@Override
+	public Attributes getAttributes() {
+		return this.attributes;
+	}
+
 	public final void setLocked() {
 		locked = true ;
 	}

--- a/matsim/src/main/resources/dtd/population_v6.dtd
+++ b/matsim/src/main/resources/dtd/population_v6.dtd
@@ -39,7 +39,7 @@
           dep_time       CDATA                                                 #IMPLIED
           trav_time      CDATA                                                 #IMPLIED>
 
-<!ELEMENT route          (#PCDATA)>
+		<!ELEMENT route          (#PCDATA|attributes)*>
 <!ATTLIST route
           type           CDATA #IMPLIED
           start_link	 CDATA #IMPLIED


### PR DESCRIPTION
Instead of using `DrtRoute` (and adding soon `TaxiRoute`, etc.), we (@kainagel and I) decided to use the route types from the matsim core after making them more flexible. Besides fewer classes, this also means no need to supply customised route factories before scenario loading.