### PR TITLE
network filter manager did not recreate link attributes

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/filter/NetworkFilterManager.java
+++ b/matsim/src/main/java/org/matsim/core/network/filter/NetworkFilterManager.java
@@ -21,6 +21,7 @@ package org.matsim.core.network.filter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
@@ -98,6 +99,9 @@ public final class NetworkFilterManager {
 		ll.setFreespeed(l.getFreespeed());
 		ll.setLength(l.getLength());
 		ll.setNumberOfLanes(l.getNumberOfLanes());
+		for(Entry<String, Object> entry : l.getAttributes().getAsMap().entrySet()) {
+			ll.getAttributes().putAttribute(entry.getKey(), entry.getValue());
+		}
 		net.addLink(ll);
 	}
 	
@@ -106,9 +110,8 @@ public final class NetworkFilterManager {
 	 * @return
 	 */
 	public Network applyFilters() {
-		log.info("applying filters to network...");
-		int nodeCount = 0;
-		int linkCount = 0;
+		log.info("applying filters to network with " + network.getNodes().size() + " nodes and "
+				+ network.getLinks().size() + " links...");
 		Network net = NetworkUtils.createNetwork();
 		if (!this.nodeFilters.isEmpty()) {
 			for (Node n : this.network.getNodes().values()) {
@@ -121,7 +124,6 @@ public final class NetworkFilterManager {
 				}
 				if (add) {
 					this.addNode(net, n);
-					nodeCount++;
 				}
 			}
 		}
@@ -136,12 +138,10 @@ public final class NetworkFilterManager {
 				}
 				if (add) {
 					this.addLink(net, l);
-					linkCount++;
 				}
 			}
 		}
-		log.info("filtered " + nodeCount + " of " + network.getNodes().size() + " nodes...");
-		log.info("filtered " + linkCount + " of " + network.getLinks().size() + " links.");
+		log.info("filtered network contains " + net.getNodes().size() + " nodes and " + net.getLinks().size() + " links.");
 		return net;
 	}
 

--- a/matsim/src/test/java/org/matsim/core/network/filter/NetworkFilterManagerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/filter/NetworkFilterManagerTest.java
@@ -1,0 +1,105 @@
+package org.matsim.core.network.filter;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author mstraub Austrian Institute of Technology
+ */
+public class NetworkFilterManagerTest {
+
+	private static Network filterNetwork;
+	
+	private static final double DELTA = 0.00001;
+	
+	private static final double CAPACITY = 12.34;
+	private static final double FREESPEED = 13.888;
+	private static final double LENGTH = 777;
+	private static final int NR_OF_LANES = 2;
+	private static final String ATTRIBUTE_KEY = "key";
+	private static final String ATTRIBUTE_VALUE = "value";
+	private static final String ATTRIBUTE_KEY2 = "key2";
+	private static final int ATTRIBUTE_VALUE2 = 2;
+	
+	@BeforeClass
+	public static void prepareTestAllowedModes() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node a = network.getFactory().createNode(Id.create("a", Node.class), new Coord(0, 0));
+		Node b = network.getFactory().createNode(Id.create("b", Node.class), new Coord(0, LENGTH));
+		Node c = network.getFactory().createNode(Id.create("c", Node.class), new Coord(LENGTH, LENGTH));
+		Link ab = network.getFactory().createLink(Id.create("ab", Link.class), a, b);
+		Link ac = network.getFactory().createLink(Id.create("ac", Link.class), a, c);
+		
+		enrichLink(ab);
+		enrichLink(ac);
+
+		network.addNode(a);
+		network.addNode(b);
+		network.addNode(c);
+		network.addLink(ab);
+		network.addLink(ac);
+
+		filterNetwork = network;
+	}
+	
+	private static void enrichLink(Link link) {
+		link.setAllowedModes(ImmutableSet.of("car"));
+		link.setCapacity(CAPACITY);
+		link.setFreespeed(FREESPEED);
+		link.setLength(LENGTH);
+		link.setNumberOfLanes(NR_OF_LANES);
+		link.getAttributes().putAttribute(ATTRIBUTE_KEY, ATTRIBUTE_VALUE);
+		link.getAttributes().putAttribute(ATTRIBUTE_KEY2, ATTRIBUTE_VALUE2);
+	}
+
+	@Test
+	public void filterTest() {
+		NetworkFilterManager networkFilterManager = new NetworkFilterManager(filterNetwork);
+		networkFilterManager.addNodeFilter(new NetworkNodeFilter() {
+			@Override
+			public boolean judgeNode(Node n) {
+				if (n.getId().toString().equals("a"))
+					return true;
+				return false;
+			}
+		});
+		networkFilterManager.addLinkFilter(new NetworkLinkFilter() {
+			@Override
+			public boolean judgeLink(Link l) {
+				if (l.getId().toString().equals("ac"))
+					return false;
+				return true;
+			}
+		});
+		
+		Network filteredNetwork = networkFilterManager.applyFilters();
+		
+		Assert.assertEquals(2, filteredNetwork.getNodes().size());
+		Assert.assertTrue("must be added by nodefilter", filteredNetwork.getNodes().containsKey(Id.createNodeId("a")));
+		Assert.assertTrue("must be added for ab link", filteredNetwork.getNodes().containsKey(Id.createNodeId("b")));
+		
+		Assert.assertEquals(1, filteredNetwork.getLinks().size());
+		
+		Link ab = filteredNetwork.getLinks().get(Id.createLinkId("ab"));
+		Assert.assertEquals(CAPACITY, ab.getCapacity(), DELTA);
+		Assert.assertEquals(FREESPEED, ab.getFreespeed(), DELTA);
+		Assert.assertEquals(LENGTH, ab.getLength(), DELTA);
+		Assert.assertEquals(NR_OF_LANES, ab.getNumberOfLanes(), DELTA);
+		Assert.assertEquals(ATTRIBUTE_VALUE, ab.getAttributes().getAttribute(ATTRIBUTE_KEY));
+		Assert.assertEquals(ATTRIBUTE_VALUE2, ab.getAttributes().getAttribute(ATTRIBUTE_KEY2));
+	}
+
+}


### PR DESCRIPTION
This is a cleaned up PR #518 (without the commit relating to EV)