### PR TITLE
clean up XxxEnergyConsumption

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtTaskFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtTaskFactoryImpl.java
@@ -23,9 +23,9 @@ import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.ev.data.Charger;
-import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
 import org.matsim.contrib.ev.dvrp.TaskEnergyConsumptions;
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
 
 /**
  * @author michalm
@@ -34,7 +34,7 @@ public class EDrtTaskFactoryImpl implements DrtTaskFactory {
 	@Override
 	public EDrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path) {
 		ElectricVehicle ev = ((EvDvrpVehicle)vehicle).getElectricVehicle();
-		double totalEnergy = TaskEnergyConsumptions.calcTotalEnergyConsumption(ev, path);
+		double totalEnergy = TaskEnergyConsumptions.calcTotalEnergyConsumption(ev, path, path.getDepartureTime());
 		return new EDrtDriveTask(path, totalEnergy);
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTracker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTracker.java
@@ -32,6 +32,8 @@ public interface OnlineDriveTaskTracker extends TaskTracker {
 
 	int getCurrentLinkIdx();
 
+	double getCurrentLinkEnterTime();
+
 	LinkTimePair getDiversionPoint();
 
 	void divertPath(VrpPathWithTravelData newSubPath);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTrackerImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/tracker/OnlineDriveTaskTrackerImpl.java
@@ -81,6 +81,11 @@ public class OnlineDriveTaskTrackerImpl implements OnlineDriveTaskTracker {
 	}
 
 	@Override
+	public double getCurrentLinkEnterTime() {
+		return linkEnterTime;
+	}
+
+	@Override
 	public void movedOverNode(Link nextLink) {
 		currentLinkIdx++;
 		linkEnterTime = timer.getTimeOfDay();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
@@ -45,7 +45,7 @@ public class AuxDischargingHandler implements MobsimAfterSimStepListener {
 		if ((e.getSimulationTime() + 1) % auxDischargeTimeStep == 0) {
 			for (ElectricVehicle ev : evFleet.getElectricVehicles().values()) {
 				double energy = ev.getAuxEnergyConsumption()
-						.calcEnergyConsumption(e.getSimulationTime() + 1, auxDischargeTimeStep);
+						.calcEnergyConsumption(e.getSimulationTime(), auxDischargeTimeStep);
 				ev.getBattery().discharge(energy);
 			}
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
@@ -19,12 +19,13 @@
 
 package org.matsim.contrib.ev.discharging;
 
-import com.google.inject.Inject;
 import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.core.mobsim.framework.events.MobsimAfterSimStepEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimAfterSimStepListener;
+
+import com.google.inject.Inject;
 
 /**
  * This AUX Discharge runs also when vehicles are not in use. This is handy for vehicles with idle engines, such as taxis (where heating is on while the vehicle is idle), but should not be used with ordinary passenger cars.
@@ -43,7 +44,8 @@ public class AuxDischargingHandler implements MobsimAfterSimStepListener {
 	public void notifyMobsimAfterSimStep(@SuppressWarnings("rawtypes") MobsimAfterSimStepEvent e) {
 		if ((e.getSimulationTime() + 1) % auxDischargeTimeStep == 0) {
 			for (ElectricVehicle ev : evFleet.getElectricVehicles().values()) {
-				double energy = ev.getAuxEnergyConsumption().calcEnergyConsumption(auxDischargeTimeStep, e.getSimulationTime() + 1);
+				double energy = ev.getAuxEnergyConsumption()
+						.calcEnergyConsumption(e.getSimulationTime() + 1, auxDischargeTimeStep);
 				ev.getBattery().discharge(energy);
 			}
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxEnergyConsumption.java
@@ -26,5 +26,5 @@ public interface AuxEnergyConsumption {
 		AuxEnergyConsumption create(ElectricVehicle electricVehicle);
 	}
 
-	double calcEnergyConsumption(double period, double timeOfDay);
+	double calcEnergyConsumption(double beginTime, double duration);
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -19,7 +19,9 @@
 
 package org.matsim.contrib.ev.discharging;
 
-import com.google.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.LinkLeaveEvent;
 import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
@@ -36,8 +38,7 @@ import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.vehicles.Vehicle;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.inject.Inject;
 
 /**
  * Because in QSim and JDEQSim vehicles enter and leave traffic at the end of links, we skip the first link when
@@ -113,7 +114,7 @@ public class DriveDischargingHandler
 			ElectricVehicle ev = evDrive.ev;
 			double energy = ev.getDriveEnergyConsumption().calcEnergyConsumption(link, tt, eventTime);
 			if (handleAuxDischarging) {
-				energy += ev.getAuxEnergyConsumption().calcEnergyConsumption(tt, eventTime);
+				energy += ev.getAuxEnergyConsumption().calcEnergyConsumption(eventTime, tt);
 			}
             //Energy consumption might be negative on links with negative slope
             if (energy < 0) {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -112,16 +112,16 @@ public class DriveDischargingHandler
 			Link link = network.getLinks().get(linkId);
 			double tt = eventTime - evDrive.movedOverNodeTime;
 			ElectricVehicle ev = evDrive.ev;
-			double energy = ev.getDriveEnergyConsumption().calcEnergyConsumption(link, tt, eventTime);
+			double energy = ev.getDriveEnergyConsumption().calcEnergyConsumption(link, tt, eventTime - tt);
 			if (handleAuxDischarging) {
 				energy += ev.getAuxEnergyConsumption().calcEnergyConsumption(eventTime - tt, tt);
 			}
-            //Energy consumption might be negative on links with negative slope
-            if (energy < 0) {
-                ev.getBattery().charge(Math.abs(energy));
-            } else {
-                ev.getBattery().discharge(energy);
-            }
+			//Energy consumption might be negative on links with negative slope
+			if (energy < 0) {
+				ev.getBattery().charge(Math.abs(energy));
+			} else {
+				ev.getBattery().discharge(energy);
+			}
 			double linkConsumption = energy + energyConsumptionPerLink.getOrDefault(linkId, 0.0);
 			energyConsumptionPerLink.put(linkId, linkConsumption);
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -114,7 +114,7 @@ public class DriveDischargingHandler
 			ElectricVehicle ev = evDrive.ev;
 			double energy = ev.getDriveEnergyConsumption().calcEnergyConsumption(link, tt, eventTime);
 			if (handleAuxDischarging) {
-				energy += ev.getAuxEnergyConsumption().calcEnergyConsumption(eventTime, tt);
+				energy += ev.getAuxEnergyConsumption().calcEnergyConsumption(eventTime - tt, tt);
 			}
             //Energy consumption might be negative on links with negative slope
             if (energy < 0) {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveEnergyConsumption.java
@@ -34,8 +34,8 @@ public interface DriveEnergyConsumption {
 	/**
 	 * @param link          Link where energy is consumed
 	 * @param travelTime    TravelTime spent on link
-	 * @param linkLeaveTime time of link Leave (may be undefined)
+	 * @param linkEnterTime time of entering link (may be undefined)
 	 * @return energy consumed by vehicle on link in J
 	 */
-	double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime);
+	double calcEnergyConsumption(Link link, double travelTime, double linkEnterTime);
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveEnergyConsumption.java
@@ -32,15 +32,10 @@ public interface DriveEnergyConsumption {
 	}
 
 	/**
-	 * @param link       Link where energy is consumed
-	 * @param travelTime TravelTime spent on link
-	 * @param timeOfDay  time of link Leave (may be undefined)
+	 * @param link          Link where energy is consumed
+	 * @param travelTime    TravelTime spent on link
+	 * @param linkLeaveTime time of link Leave (may be undefined)
 	 * @return energy consumed by vehicle on link in J
 	 */
-	double calcEnergyConsumption(Link link, double travelTime, double timeOfDay);
-
-
-	;
-
-
+	double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime);
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/EnergyConsumptions.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/EnergyConsumptions.java
@@ -27,7 +27,7 @@ public class EnergyConsumptions {
 		ev.getBattery().discharge(rate * link.getLength());
 	}
 
-	public static void consumeFixedAuxEnergy(ElectricVehicle ev, double auxPower, double period) {
-		ev.getBattery().discharge(auxPower * period);
+	public static void consumeFixedAuxEnergy(ElectricVehicle ev, double auxPower, double duration) {
+		ev.getBattery().discharge(auxPower * duration);
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/LTHDriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/LTHDriveEnergyConsumption.java
@@ -90,7 +90,7 @@ public class LTHDriveEnergyConsumption implements DriveEnergyConsumption {
 	}
 
 	@Override
-	public double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime) {
+	public double calcEnergyConsumption(Link link, double travelTime, double linkEnterTime) {
 		double length = link.getLength();
 		double speed = length / travelTime;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/LTHDriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/LTHDriveEnergyConsumption.java
@@ -21,7 +21,6 @@ package org.matsim.contrib.ev.discharging;/*
  * created by jbischoff, 23.08.2018
  */
 
-import com.google.common.primitives.Doubles;
 import org.apache.commons.math3.analysis.interpolation.PiecewiseBicubicSplineInterpolatingFunction;
 import org.apache.commons.math3.analysis.interpolation.PiecewiseBicubicSplineInterpolator;
 import org.apache.log4j.Logger;
@@ -31,6 +30,8 @@ import org.matsim.contrib.ev.EvUnits;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.vehicles.VehicleType;
+
+import com.google.common.primitives.Doubles;
 
 public class LTHDriveEnergyConsumption implements DriveEnergyConsumption {
 
@@ -89,7 +90,7 @@ public class LTHDriveEnergyConsumption implements DriveEnergyConsumption {
 	}
 
 	@Override
-	public double calcEnergyConsumption(Link link, double travelTime, double timeOfDay) {
+	public double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime) {
 		double length = link.getLength();
 		double speed = length / travelTime;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiAuxEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiAuxEnergyConsumption.java
@@ -19,10 +19,10 @@
 
 package org.matsim.contrib.ev.discharging;
 
-import org.matsim.contrib.ev.fleet.ElectricVehicle;
-
 import java.util.function.BiPredicate;
 import java.util.function.DoubleSupplier;
+
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
 
 public class OhdeSlaskiAuxEnergyConsumption implements AuxEnergyConsumption {
 	private static final double a = 1.3;// [W]
@@ -59,7 +59,7 @@ public class OhdeSlaskiAuxEnergyConsumption implements AuxEnergyConsumption {
 	}
 
 	@Override
-	public double calcEnergyConsumption(double period, double timeOfDay) {
-		return isTurnedOn.test(ev, timeOfDay) ? calcPower(temperatureProvider.getAsDouble()) * period : 0;
+	public double calcEnergyConsumption(double beginTime, double duration) {
+		return isTurnedOn.test(ev, beginTime) ? calcPower(temperatureProvider.getAsDouble()) * duration : 0;
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
@@ -65,7 +65,7 @@ public class OhdeSlaskiDriveEnergyConsumption implements DriveEnergyConsumption 
 	}
 
 	@Override
-	public double calcEnergyConsumption(Link link, double travelTime, double timeOfDay) {
+	public double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime) {
 		if (travelTime == 0) {
 			return 0;
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
@@ -65,7 +65,7 @@ public class OhdeSlaskiDriveEnergyConsumption implements DriveEnergyConsumption 
 	}
 
 	@Override
-	public double calcEnergyConsumption(Link link, double travelTime, double linkLeaveTime) {
+	public double calcEnergyConsumption(Link link, double travelTime, double linkEnterTime) {
 		if (travelTime == 0) {
 			return 0;
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/TaskEnergyConsumptions.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/TaskEnergyConsumptions.java
@@ -44,7 +44,7 @@ public class TaskEnergyConsumptions {
 	}
 
 	public static double calcAuxEnergy(ElectricVehicle ev, double beginTime, double endTime) {
-		return ev.getAuxEnergyConsumption().calcEnergyConsumption(endTime - beginTime, beginTime);
+		return ev.getAuxEnergyConsumption().calcEnergyConsumption(beginTime, endTime - beginTime);
 	}
 
 	public static double calcDriveEnergy(ElectricVehicle ev, VrpPath path) {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/TaskEnergyConsumptions.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/TaskEnergyConsumptions.java
@@ -24,19 +24,20 @@ import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
-import org.matsim.core.utils.misc.Time;
 
 /**
  * @author michalm
  */
 public class TaskEnergyConsumptions {
 	public static double calcTotalEnergyConsumption(ElectricVehicle ev, Task task) {
-		double driveEnergy = task instanceof DriveTask ? calcDriveEnergy(ev, ((DriveTask)task).getPath()) : 0;
+		double driveEnergy = task instanceof DriveTask ?
+				calcDriveEnergy(ev, ((DriveTask)task).getPath(), task.getBeginTime()) :
+				0;
 		return calcAuxEnergy(ev, task) + driveEnergy;
 	}
 
-	public static double calcTotalEnergyConsumption(ElectricVehicle ev, VrpPathWithTravelData path) {
-		return calcAuxEnergy(ev, path.getDepartureTime(), path.getArrivalTime()) + calcDriveEnergy(ev, path);
+	public static double calcTotalEnergyConsumption(ElectricVehicle ev, VrpPathWithTravelData path, double beginTime) {
+		return calcAuxEnergy(ev, path.getDepartureTime(), path.getArrivalTime()) + calcDriveEnergy(ev, path, beginTime);
 	}
 
 	public static double calcAuxEnergy(ElectricVehicle ev, Task task) {
@@ -47,15 +48,17 @@ public class TaskEnergyConsumptions {
 		return ev.getAuxEnergyConsumption().calcEnergyConsumption(beginTime, endTime - beginTime);
 	}
 
-	public static double calcDriveEnergy(ElectricVehicle ev, VrpPath path) {
-		return calcRemainingDriveEnergy(ev, path, 1);// skip first link
+	public static double calcDriveEnergy(ElectricVehicle ev, VrpPath path, double beginTime) {
+		return calcRemainingDriveEnergy(ev, path, 1, beginTime + 1);// skip first link
 	}
 
-	public static double calcRemainingDriveEnergy(ElectricVehicle ev, VrpPath path, int currentLinkIdx) {
+	public static double calcRemainingDriveEnergy(ElectricVehicle ev, VrpPath path, int currentLinkIdx,
+			double currentLinkEnterTime) {
 		DriveEnergyConsumption consumption = ev.getDriveEnergyConsumption();
 		double energy = 0;
 		for (int i = Math.max(currentLinkIdx, 1); i < path.getLinkCount(); i++) {// skip first link
-			energy += consumption.calcEnergyConsumption(path.getLink(i), path.getLinkTravelTime(i), Time.getUndefinedTime());
+			energy += consumption.calcEnergyConsumption(path.getLink(i), path.getLinkTravelTime(i),
+					currentLinkEnterTime);
 		}
 		return energy;
 	}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/tracker/OnlineEDriveTaskTracker.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/tracker/OnlineEDriveTaskTracker.java
@@ -23,9 +23,9 @@ import org.matsim.contrib.dvrp.path.VrpPath;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
-import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
 import org.matsim.contrib.ev.dvrp.TaskEnergyConsumptions;
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -66,6 +66,11 @@ public class OnlineEDriveTaskTracker implements OnlineDriveTaskTracker, ETaskTra
 	@Override
 	public int getCurrentLinkIdx() {
 		return driveTracker.getCurrentLinkIdx();
+	}
+
+	@Override
+	public double getCurrentLinkEnterTime() {
+		return driveTracker.getCurrentLinkEnterTime();
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/tracker/OnlineEDriveTaskTracker.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/tracker/OnlineEDriveTaskTracker.java
@@ -46,10 +46,9 @@ public class OnlineEDriveTaskTracker implements OnlineDriveTaskTracker, ETaskTra
 	public double predictSocAtEnd() {
 		ElectricVehicle ev = vehicle.getElectricVehicle();
 		double currentSoc = ev.getBattery().getSoc();
-		double driveEnergy = TaskEnergyConsumptions.calcRemainingDriveEnergy(ev, driveTracker.getPath(),
-				driveTracker.getCurrentLinkIdx());
-		double auxEnergy = TaskEnergyConsumptions.calcAuxEnergy(ev, timer.getTimeOfDay(),
-				driveTracker.predictEndTime());
+		double driveEnergy = TaskEnergyConsumptions.calcRemainingDriveEnergy(ev, getPath(), getCurrentLinkIdx(),
+				getCurrentLinkEnterTime());
+		double auxEnergy = TaskEnergyConsumptions.calcAuxEnergy(ev, timer.getTimeOfDay(), predictEndTime());
 		return currentSoc - driveEnergy - auxEnergy;
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetReader.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetReader.java
@@ -60,7 +60,7 @@ public class ElectricFleetReader extends MatsimXmlParser {
 				.batteryCapacity(EvUnits.kWh_to_J(Double.parseDouble(atts.getValue("battery_capacity"))))
 				.initialSoc(EvUnits.kWh_to_J(Double.parseDouble(atts.getValue("initial_soc"))))
 				.vehicleType(Optional.ofNullable(atts.getValue("vehicleType"))
-						.orElse(ElectricVehicleImpl.DEFAULT_VEHICLE_TYPE))
+						.orElse(ElectricVehicleSpecification.DEFAULT_VEHICLE_TYPE))
 				.chargerTypes(ImmutableList.copyOf(Optional.ofNullable(atts.getValue("chargerTypes"))
 						.orElse(ChargerImpl.DEFAULT_CHARGER_TYPE)
 						.split(",")))

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
@@ -27,55 +27,52 @@ import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 import com.google.common.collect.ImmutableList;
 
 public class ElectricVehicleImpl implements ElectricVehicle {
-    private final ElectricVehicleSpecification vehicleSpecification;
-    private final Battery battery;
+	public static ElectricVehicle create(ElectricVehicleSpecification vehicleSpecification,
+			DriveEnergyConsumption.Factory driveFactory, AuxEnergyConsumption.Factory auxFactory) {
+		ElectricVehicleImpl ev = new ElectricVehicleImpl(vehicleSpecification);
+		ev.driveEnergyConsumption = driveFactory == null ? null : driveFactory.create(ev);
+		ev.auxEnergyConsumption = auxFactory == null ? null : auxFactory.create(ev);
+		return ev;
+	}
 
-    private DriveEnergyConsumption driveEnergyConsumption;
-    private AuxEnergyConsumption auxEnergyConsumption;
+	private final ElectricVehicleSpecification vehicleSpecification;
+	private final Battery battery;
 
+	private DriveEnergyConsumption driveEnergyConsumption;
+	private AuxEnergyConsumption auxEnergyConsumption;
 
-    public static ElectricVehicle create(ElectricVehicleSpecification vehicleSpecification, DriveEnergyConsumption.Factory driveFactory, AuxEnergyConsumption.Factory auxFactory) {
-        ElectricVehicleImpl ev = new ElectricVehicleImpl(vehicleSpecification);
-        ev.driveEnergyConsumption = driveFactory == null ? null : driveFactory.create(ev);
-        ev.auxEnergyConsumption = auxFactory == null ? null : auxFactory.create(ev);
+	private ElectricVehicleImpl(ElectricVehicleSpecification vehicleSpecification) {
+		this.vehicleSpecification = vehicleSpecification;
+		battery = new BatteryImpl(vehicleSpecification.getBatteryCapacity(), vehicleSpecification.getInitialSoc());
+	}
 
-        return ev;
-    }
+	@Override
+	public Id<ElectricVehicle> getId() {
+		return vehicleSpecification.getId();
+	}
 
+	@Override
+	public Battery getBattery() {
+		return battery;
+	}
 
-    private ElectricVehicleImpl(ElectricVehicleSpecification vehicleSpecification) {
-        this.vehicleSpecification = vehicleSpecification;
-        battery = new BatteryImpl(vehicleSpecification.getBatteryCapacity(), vehicleSpecification.getInitialSoc());
+	@Override
+	public String getVehicleType() {
+		return vehicleSpecification.getVehicleType();
+	}
 
-    }
+	@Override
+	public ImmutableList<String> getChargerTypes() {
+		return vehicleSpecification.getChargerTypes();
+	}
 
-    @Override
-    public Id<ElectricVehicle> getId() {
-        return vehicleSpecification.getId();
-    }
+	@Override
+	public DriveEnergyConsumption getDriveEnergyConsumption() {
+		return driveEnergyConsumption;
+	}
 
-    @Override
-    public Battery getBattery() {
-        return battery;
-    }
-
-    @Override
-    public String getVehicleType() {
-        return vehicleSpecification.getVehicleType();
-    }
-
-    @Override
-    public ImmutableList<String> getChargerTypes() {
-        return vehicleSpecification.getChargerTypes();
-    }
-
-    @Override
-    public DriveEnergyConsumption getDriveEnergyConsumption() {
-        return driveEnergyConsumption;
-    }
-
-    @Override
-    public AuxEnergyConsumption getAuxEnergyConsumption() {
-        return auxEnergyConsumption;
-    }
+	@Override
+	public AuxEnergyConsumption getAuxEnergyConsumption() {
+		return auxEnergyConsumption;
+	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
@@ -20,14 +20,13 @@
 
 package org.matsim.contrib.ev.fleet;
 
-import com.google.common.collect.ImmutableList;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 
-public class ElectricVehicleImpl implements ElectricVehicle {
-    public static final String DEFAULT_VEHICLE_TYPE = "defaultVehicleType";
+import com.google.common.collect.ImmutableList;
 
+public class ElectricVehicleImpl implements ElectricVehicle {
     private final ElectricVehicleSpecification vehicleSpecification;
     private final Battery battery;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
  * @author Michal Maciejewski (michalm)
  */
 public interface ElectricVehicleSpecification {
+	String DEFAULT_VEHICLE_TYPE = "defaultVehicleType";
+
 	Id<ElectricVehicle> getId();
 
 	String getVehicleType();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EVNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EVNetworkRoutingModule.java
@@ -18,6 +18,12 @@
  * *********************************************************************** */
 package org.matsim.contrib.ev.routing;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
@@ -49,8 +55,6 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.Facility;
-
-import java.util.*;
 
 /**
  * This network Routing module adds stages for re-charging into the Route.
@@ -203,7 +207,7 @@ public final class EVNetworkRoutingModule implements RoutingModule {
             double travelT = travelTime.getLinkTravelTime(l, basicLeg.getDepartureTime(), null, null);
             double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, Time.getUndefinedTime());
             if (auxEnergyConsumption != null) {
-                consumption += auxEnergyConsumption.calcEnergyConsumption(travelT, basicLeg.getDepartureTime());
+				consumption += auxEnergyConsumption.calcEnergyConsumption(basicLeg.getDepartureTime(), travelT);
             }
             consumptions.put(l, consumption);
         }


### PR DESCRIPTION
Main changes:
- add `OnlineDriveTaskTracker.getCurrentLinkEnterTime()`
- change `linkLeaveTime` to `linkEnterTime` in the `DriveEnergyConsumption.calcEnergyConsumption()` arguments to keep this interface consistent with the `TravelTime` and `TravelDisutility` interfaces (where the departure time is used)
- change `AuxEnergyConsumption.calcEnergyConsumption(double period, double timeOfDay)` args to `(double beginTime, double duration)`. `timeOfDay` does not suggest whether it is the begin or end, and so was used inconsistently over the workspace