### PR TITLE
Guicier EV

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtControlerCreator.java
@@ -23,6 +23,7 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtConfigs;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.dvrp.EvDvrpIntegrationModule;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
@@ -44,6 +45,8 @@ public class EDrtControlerCreator {
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new EDrtModule());
 		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new EvModule());
+		controler.addOverridingModule(new EvDvrpIntegrationModule());
 		controler.configureQSimComponents(EvDvrpIntegrationModule.activateModes(drtCfg.getMode()));
 
 		if (otfvis) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
@@ -24,6 +24,8 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.edrt.optimizer.EDrtVehicleDataEntryFactory.EDrtVehicleDataEntryFactoryProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.charging.ChargingLogic;
+import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.FixedSpeedChargingStrategy;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.dvrp.DvrpAuxConsumptionFactory;
@@ -53,18 +55,18 @@ public class RunEDrtScenario {
 		DrtConfigGroup drtCfg = DrtConfigGroup.get(config);
 		Controler controler = EDrtControlerCreator.createControler(config, otfvis);
 
+		controler.addOverridingModule(new EvDvrpIntegrationModule(drtCfg.getMode()));
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
-				install(createEvDvrpIntegrationModule(drtCfg.getMode()));
 				bind(EDrtVehicleDataEntryFactoryProvider.class).toInstance(
 						new EDrtVehicleDataEntryFactoryProvider(MIN_RELATIVE_SOC));
-			}
-		});
 
-		controler.addOverridingModule(new AbstractModule() {
-			@Override
-			public void install() {
+				bind(ChargingLogic.Factory.class).toInstance(
+						charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
+								new FixedSpeedChargingStrategy(charger.getPower() * CHARGING_SPEED_FACTOR,
+										MAX_RELATIVE_SOC)));
+
 				bind(AuxEnergyConsumption.Factory.class).toInstance(
 						new DvrpAuxConsumptionFactory(drtCfg.getMode(), () -> TEMPERATURE,
 								RunEDrtScenario::isTurnedOn));
@@ -72,12 +74,6 @@ public class RunEDrtScenario {
 		});
 
 		return controler;
-	}
-
-	public static EvDvrpIntegrationModule createEvDvrpIntegrationModule(String mode) {
-		return new EvDvrpIntegrationModule(mode).setChargingStrategyFactory(
-				charger -> new FixedSpeedChargingStrategy(charger.getPower() * CHARGING_SPEED_FACTOR,
-						MAX_RELATIVE_SOC));
 	}
 
 	private static boolean isTurnedOn(DvrpVehicleSpecification vehicle, double time) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
@@ -29,7 +29,6 @@ import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.FixedSpeedChargingStrategy;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.dvrp.DvrpAuxConsumptionFactory;
-import org.matsim.contrib.ev.dvrp.EvDvrpIntegrationModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -55,7 +54,6 @@ public class RunEDrtScenario {
 		DrtConfigGroup drtCfg = DrtConfigGroup.get(config);
 		Controler controler = EDrtControlerCreator.createControler(config, otfvis);
 
-		controler.addOverridingModule(new EvDvrpIntegrationModule(drtCfg.getMode()));
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/RunEDrtScenario.java
@@ -25,6 +25,8 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.edrt.optimizer.EDrtVehicleDataEntryFactory.EDrtVehicleDataEntryFactoryProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.charging.FixedSpeedChargingStrategy;
+import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
+import org.matsim.contrib.ev.dvrp.DvrpAuxConsumptionFactory;
 import org.matsim.contrib.ev.dvrp.EvDvrpIntegrationModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -60,14 +62,22 @@ public class RunEDrtScenario {
 			}
 		});
 
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				bind(AuxEnergyConsumption.Factory.class).toInstance(
+						new DvrpAuxConsumptionFactory(drtCfg.getMode(), () -> TEMPERATURE,
+								RunEDrtScenario::isTurnedOn));
+			}
+		});
+
 		return controler;
 	}
 
 	public static EvDvrpIntegrationModule createEvDvrpIntegrationModule(String mode) {
 		return new EvDvrpIntegrationModule(mode).setChargingStrategyFactory(
-				charger -> new FixedSpeedChargingStrategy(charger.getPower() * CHARGING_SPEED_FACTOR, MAX_RELATIVE_SOC))
-				.setTemperatureProvider(() -> TEMPERATURE)
-				.setTurnedOnPredicate(RunEDrtScenario::isTurnedOn);
+				charger -> new FixedSpeedChargingStrategy(charger.getPower() * CHARGING_SPEED_FACTOR,
+						MAX_RELATIVE_SOC));
 	}
 
 	private static boolean isTurnedOn(DvrpVehicleSpecification vehicle, double time) {

--- a/contribs/drt/src/main/resources/mielec_2014_02/mielec_edrt_config.xml
+++ b/contribs/drt/src/main/resources/mielec_2014_02/mielec_edrt_config.xml
@@ -25,7 +25,7 @@
 	<module name="ev">
 		<param name="chargeTimeStep" value="5" />
 		<param name="auxDischargeTimeStep" value="10" />
-		<param name="auxDischargingSimulation" value="seperateAuxDischargingHandler" />
+		<param name="auxDischargingSimulation" value="separateAuxDischargingHandler"/>
 
 		<param name="chargersFile" value="chargers-1-plugs-1.xml" />
 		<param name="vehiclesFile" value="evehicles-10.xml" />

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -56,9 +56,9 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	@Positive
 	private int auxDischargeTimeStep = 60; // 1 min ==> 0.25% SOC (3 kW AUX power)
 
-	public static enum AuxDischargingSimulation {
+	public enum AuxDischargingSimulation {
 		// AuxDischargingHandler handles AUX consumption (every {@code auxDischargeTimeStep} seconds)
-		seperateAuxDischargingHandler,
+		separateAuxDischargingHandler,
 		// DriveDischargingHandler handles AUX consumption during drives
 		// an external handler needs to be used to simulate AUX consumption when a vehicle is parked
 		insideDriveDischargingHandler,

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -52,7 +52,7 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	@Positive
 	private int chargeTimeStep = 5; // 5 s ==> 0.35% SOC (fast charging, 50 kW)
 
-	// only used if SeperateAuxDischargingHandler is used, otherwise ignored
+	// only used if SeparateAuxDischargingHandler is used, otherwise ignored
 	@Positive
 	private int auxDischargeTimeStep = 60; // 1 min ==> 0.25% SOC (3 kW AUX power)
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingModule.java
@@ -33,21 +33,16 @@ import com.google.inject.name.Names;
  * @author Michal Maciejewski (michalm)
  */
 public class ChargingModule extends AbstractModule {
-	private static ChargingLogic.Factory DEFAULT_CHARGING_LOGIC_FACTORY = charger -> new ChargingWithQueueingLogic(
-			charger, new FixedSpeedChargingStrategy(charger.getPower()));
-
 	private final EvConfigGroup evCfg;
 	private final Key<Network> networkKey;
-	private final ChargingLogic.Factory chargingLogicFactory;
 
 	public ChargingModule(EvConfigGroup evCfg) {
-		this(evCfg, Key.get(Network.class), DEFAULT_CHARGING_LOGIC_FACTORY);
+		this(evCfg, Key.get(Network.class));
 	}
 
-	public ChargingModule(EvConfigGroup evCfg, Key<Network> networkKey, ChargingLogic.Factory chargingLogicFactory) {
+	public ChargingModule(EvConfigGroup evCfg, Key<Network> networkKey) {
 		this.evCfg = evCfg;
 		this.networkKey = networkKey;
-		this.chargingLogicFactory = chargingLogicFactory;
 	}
 
 	@Override
@@ -58,7 +53,8 @@ public class ChargingModule extends AbstractModule {
 		bind(ChargingInfrastructure.class).toProvider(
 				new ChargingInfrastructureProvider(evCfg.getChargersFileUrl(getConfig().getContext())))
 				.asEagerSingleton();
-		bind(ChargingLogic.Factory.class).toInstance(chargingLogicFactory);
+		bind(ChargingLogic.Factory.class).toInstance(charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
+				new FixedSpeedChargingStrategy(charger.getPower())));
 
 		bind(ChargingHandler.class).asEagerSingleton();
 		addMobsimListenerBinding().to(ChargingHandler.class);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingModule.java
@@ -53,8 +53,8 @@ public class ChargingModule extends AbstractModule {
 		bind(ChargingInfrastructure.class).toProvider(
 				new ChargingInfrastructureProvider(evCfg.getChargersFileUrl(getConfig().getContext())))
 				.asEagerSingleton();
-		bind(ChargingLogic.Factory.class).toInstance(charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
-				new FixedSpeedChargingStrategy(charger.getPower())));
+		bind(ChargingLogic.Factory.class).toInstance(
+				charger -> new ChargingWithQueueingLogic(charger, new FixedSpeedChargingStrategy(charger.getPower())));
 
 		bind(ChargingHandler.class).asEagerSingleton();
 		addMobsimListenerBinding().to(ChargingHandler.class);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -37,11 +37,11 @@ public class DischargingModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		boolean isSeperateAuxDischargingHandler = evCfg.getAuxDischargingSimulation()
+		boolean isSeparateAuxDischargingHandler = evCfg.getAuxDischargingSimulation()
 				== EvConfigGroup.AuxDischargingSimulation.separateAuxDischargingHandler;
 
 		bind(DriveEnergyConsumption.Factory.class).toInstance(ev -> new OhdeSlaskiDriveEnergyConsumption());
-		if (isSeperateAuxDischargingHandler) {
+		if (isSeparateAuxDischargingHandler) {
 			// TODO fixed temperature 15 oC
 			// FIXME start using TemperatureService
 			// FIXME "isTurnedOn" returns true ==> should not be used when for "separateAuxDischargingHandler"
@@ -53,7 +53,7 @@ public class DischargingModule extends AbstractModule {
 			@Override
 			protected void configureQSim() {
 				bind(DriveDischargingHandler.class).asEagerSingleton();
-				if (isSeperateAuxDischargingHandler) {
+				if (isSeparateAuxDischargingHandler) {
 					bind(AuxDischargingHandler.class).asEagerSingleton();
 					addQSimComponentBinding(EvModule.EV_COMPONENT).to(AuxDischargingHandler.class);
 				}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -31,26 +31,8 @@ import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 public class DischargingModule extends AbstractModule {
 	private final EvConfigGroup evCfg;
 
-	private static DriveEnergyConsumption.Factory DEFAULT_DRIVE_CONSUMPTION_FACTORY //
-			= ev -> new OhdeSlaskiDriveEnergyConsumption();
-
-	// TODO fixed temperature 15 oC
-	// FIXME reintroduce TemperatureProvider
-	private static AuxEnergyConsumption.Factory DEFAULT_AUX_CONSUMPTION_FACTORY //
-			= ev -> new OhdeSlaskiAuxEnergyConsumption(ev, () -> 15, (v, t) -> true);
-
-	private final DriveEnergyConsumption.Factory driveConsumptionFactory;
-	private final AuxEnergyConsumption.Factory auxConsumptionFactory;
-
 	public DischargingModule(EvConfigGroup evCfg) {
-		this(evCfg, DEFAULT_DRIVE_CONSUMPTION_FACTORY, DEFAULT_AUX_CONSUMPTION_FACTORY);
-	}
-
-	public DischargingModule(EvConfigGroup evCfg, DriveEnergyConsumption.Factory driveConsumptionFactory,
-			AuxEnergyConsumption.Factory auxConsumptionFactory) {
 		this.evCfg = evCfg;
-		this.driveConsumptionFactory = driveConsumptionFactory;
-		this.auxConsumptionFactory = auxConsumptionFactory;
 	}
 
 	@Override
@@ -59,9 +41,12 @@ public class DischargingModule extends AbstractModule {
 		boolean isSeperateAuxDischargingHandler = evCfg.getAuxDischargingSimulation()
 				== EvConfigGroup.AuxDischargingSimulation.seperateAuxDischargingHandler;
 
-		bind(DriveEnergyConsumption.Factory.class).toInstance(driveConsumptionFactory);
+		bind(DriveEnergyConsumption.Factory.class).toInstance(ev -> new OhdeSlaskiDriveEnergyConsumption());
 		if (isSeperateAuxDischargingHandler) {
-			bind(AuxEnergyConsumption.Factory.class).toInstance(auxConsumptionFactory);
+			// TODO fixed temperature 15 oC
+			// FIXME start using TemperatureService
+			bind(AuxEnergyConsumption.Factory.class).toInstance(
+					ev -> new OhdeSlaskiAuxEnergyConsumption(ev, () -> 15, (v, t) -> true));
 		}
 
 		installQSimModule(new AbstractQSimModule() {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -37,14 +37,14 @@ public class DischargingModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		//XXX "isTurnedOn" returns true ==> should not be used when for "seperateAuxDischargingHandler"
 		boolean isSeperateAuxDischargingHandler = evCfg.getAuxDischargingSimulation()
-				== EvConfigGroup.AuxDischargingSimulation.seperateAuxDischargingHandler;
+				== EvConfigGroup.AuxDischargingSimulation.separateAuxDischargingHandler;
 
 		bind(DriveEnergyConsumption.Factory.class).toInstance(ev -> new OhdeSlaskiDriveEnergyConsumption());
 		if (isSeperateAuxDischargingHandler) {
 			// TODO fixed temperature 15 oC
 			// FIXME start using TemperatureService
+			// FIXME "isTurnedOn" returns true ==> should not be used when for "separateAuxDischargingHandler"
 			bind(AuxEnergyConsumption.Factory.class).toInstance(
 					ev -> new OhdeSlaskiAuxEnergyConsumption(ev, () -> 15, (v, t) -> true));
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiAuxEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiAuxEnergyConsumption.java
@@ -48,7 +48,9 @@ public class OhdeSlaskiAuxEnergyConsumption implements AuxEnergyConsumption {
 	}
 
 	private final ElectricVehicle ev;
+	//TODO temperature should be accessible via TemperatureService
 	private final DoubleSupplier temperatureProvider;
+	//TODO this predicate should be used as a wrapper around AuxEnergyConsumption
 	private final BiPredicate<ElectricVehicle, Double> isTurnedOn;
 
 	public OhdeSlaskiAuxEnergyConsumption(ElectricVehicle ev, DoubleSupplier temperatureProvider,

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
@@ -18,27 +18,20 @@
 
 package org.matsim.contrib.ev.dvrp;
 
-import java.util.function.BiPredicate;
-import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dynagent.run.DynActivityEngineModule;
 import org.matsim.contrib.ev.EvConfigGroup;
-import org.matsim.contrib.ev.EvConfigGroup.AuxDischargingSimulation;
 import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.charging.ChargingModule;
 import org.matsim.contrib.ev.charging.ChargingStrategy;
 import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
-import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DischargingModule;
-import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
-import org.matsim.contrib.ev.discharging.OhdeSlaskiDriveEnergyConsumption;
 import org.matsim.contrib.ev.fleet.ElectricFleetModule;
 import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.stats.EvStatsModule;
@@ -64,11 +57,6 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 	}
 
 	private Function<Charger, ChargingStrategy> chargingStrategyFactory;
-	private DoubleSupplier temperatureProvider;
-	private BiPredicate<DvrpVehicleSpecification, Double> turnedOnPredicate;
-
-	private AuxEnergyConsumption.Factory auxDischargingFactory;
-	private DriveEnergyConsumption.Factory driveDischargingFactory;
 
 	public EvDvrpIntegrationModule(String mode) {
 		super(mode);
@@ -77,19 +65,6 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		EvConfigGroup evCfg = EvConfigGroup.get(getConfig());
-
-		if (EvConfigGroup.get(getConfig()).getAuxDischargingSimulation()
-				== AuxDischargingSimulation.insideDriveDischargingHandler) {
-			if (turnedOnPredicate != null) {
-				throw new RuntimeException("turnedOnPredicate must not be set"
-						+ " if auxDischargingSimulation == 'insideDriveDischargingHandler'");
-			}
-		} else {
-			if (turnedOnPredicate == null) {
-				throw new RuntimeException("turnedOnPredicate must be set"
-						+ " if auxDischargingSimulation != 'insideDriveDischargingHandler'");
-			}
-		}
 
 		bind(MobsimScopeEventHandling.class).asEagerSingleton();
 		addControlerListenerBinding().to(MobsimScopeEventHandling.class);
@@ -100,38 +75,13 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 				charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
 						chargingStrategyFactory.apply(charger))));
 
-		install(new DischargingModule(evCfg, (driveDischargingFactory != null) ?
-				driveDischargingFactory :
-				d -> new OhdeSlaskiDriveEnergyConsumption(), (auxDischargingFactory != null) ? auxDischargingFactory :
-				new DvrpAuxConsumptionFactory(getMode(), temperatureProvider, turnedOnPredicate)));
-
+		install(new DischargingModule(evCfg));
 		install(new EvStatsModule(evCfg));
 	}
 
 	public EvDvrpIntegrationModule setChargingStrategyFactory(
 			Function<Charger, ChargingStrategy> chargingStrategyFactory) {
 		this.chargingStrategyFactory = chargingStrategyFactory;
-		return this;
-	}
-
-	public EvDvrpIntegrationModule setAuxDischargingFactory(AuxEnergyConsumption.Factory auxDischargingFactory) {
-		this.auxDischargingFactory = auxDischargingFactory;
-		return this;
-	}
-
-	public EvDvrpIntegrationModule setDriveDischargingFactory(DriveEnergyConsumption.Factory driveDischargingFactory) {
-		this.driveDischargingFactory = driveDischargingFactory;
-		return this;
-	}
-
-	public EvDvrpIntegrationModule setTemperatureProvider(DoubleSupplier temperatureProvider) {
-		this.temperatureProvider = temperatureProvider;
-		return this;
-	}
-
-	public EvDvrpIntegrationModule setTurnedOnPredicate(
-			BiPredicate<DvrpVehicleSpecification, Double> turnedOnPredicate) {
-		this.turnedOnPredicate = turnedOnPredicate;
 		return this;
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
@@ -18,8 +18,6 @@
 
 package org.matsim.contrib.ev.dvrp;
 
-import java.util.function.Function;
-
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
@@ -29,10 +27,8 @@ import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.charging.ChargingModule;
-import org.matsim.contrib.ev.charging.ChargingStrategy;
 import org.matsim.contrib.ev.discharging.DischargingModule;
 import org.matsim.contrib.ev.fleet.ElectricFleetModule;
-import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.stats.EvStatsModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
 
@@ -55,8 +51,6 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 		};
 	}
 
-	private Function<Charger, ChargingStrategy> chargingStrategyFactory;
-
 	public EvDvrpIntegrationModule(String mode) {
 		super(mode);
 	}
@@ -75,11 +69,5 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 
 		install(new DischargingModule(evCfg));
 		install(new EvStatsModule(evCfg));
-	}
-
-	public EvDvrpIntegrationModule setChargingStrategyFactory(
-			Function<Charger, ChargingStrategy> chargingStrategyFactory) {
-		this.chargingStrategyFactory = chargingStrategyFactory;
-		return this;
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
@@ -20,27 +20,22 @@ package org.matsim.contrib.ev.dvrp;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
-import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dynagent.run.DynActivityEngineModule;
-import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.EvModule;
-import org.matsim.contrib.ev.MobsimScopeEventHandling;
-import org.matsim.contrib.ev.charging.ChargingModule;
-import org.matsim.contrib.ev.discharging.DischargingModule;
-import org.matsim.contrib.ev.fleet.ElectricFleetModule;
-import org.matsim.contrib.ev.stats.EvStatsModule;
+import org.matsim.contrib.ev.infrastructure.ChargingInfrastructureProvider;
+import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
 
 import com.google.inject.Key;
 import com.google.inject.name.Names;
 
 /**
- * Use this module instead of the default EvModule
+ * Use this module in addition to EvModule
  *
  * @author michalm
  */
-public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
+public class EvDvrpIntegrationModule extends AbstractModule {
 	public static QSimComponentsConfigurator activateModes(String... modes) {
 		return components -> {
 			DynActivityEngineModule.configureComponents(components);
@@ -51,23 +46,10 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 		};
 	}
 
-	public EvDvrpIntegrationModule(String mode) {
-		super(mode);
-	}
-
 	@Override
 	public void install() {
-		EvConfigGroup evCfg = EvConfigGroup.get(getConfig());
-
-		bind(MobsimScopeEventHandling.class).asEagerSingleton();
-		addControlerListenerBinding().to(MobsimScopeEventHandling.class);
-
-		install(new ElectricFleetModule(evCfg));
-
-		install(new ChargingModule(evCfg,
-				Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING))));
-
-		install(new DischargingModule(evCfg));
-		install(new EvStatsModule(evCfg));
+		bind(Network.class).annotatedWith(Names.named(ChargingInfrastructureProvider.CHARGERS))
+				.to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)))
+				.asEagerSingleton();
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpIntegrationModule.java
@@ -30,7 +30,6 @@ import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.charging.ChargingModule;
 import org.matsim.contrib.ev.charging.ChargingStrategy;
-import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.discharging.DischargingModule;
 import org.matsim.contrib.ev.fleet.ElectricFleetModule;
 import org.matsim.contrib.ev.infrastructure.Charger;
@@ -71,9 +70,8 @@ public class EvDvrpIntegrationModule extends AbstractDvrpModeModule {
 
 		install(new ElectricFleetModule(evCfg));
 
-		install(new ChargingModule(evCfg, Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)),
-				charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
-						chargingStrategyFactory.apply(charger))));
+		install(new ChargingModule(evCfg,
+				Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING))));
 
 		install(new DischargingModule(evCfg));
 		install(new EvStatsModule(evCfg));

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/temperature/TemperatureService.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/temperature/TemperatureService.java
@@ -5,7 +5,7 @@ import org.matsim.api.core.v01.network.Link;
 
 public interface TemperatureService {
 
-    double getCurrentTemperature(Id<Link> linkId);
+	double getCurrentTemperature(Id<Link> linkId);
 
-    double getCurrentTemperature();
+	double getCurrentTemperature();
 }

--- a/contribs/ev/src/main/resources/config.xml
+++ b/contribs/ev/src/main/resources/config.xml
@@ -3,7 +3,7 @@
 <config>
     <module name="ev">
         <param name="auxDischargeTimeStep" value="10"/>
-        <!-- Possible values: seperateAuxDischargingHandler, insideDriveDischargingHandler, none -->
+		<!-- Possible values: separateAuxDischargingHandler, insideDriveDischargingHandler, none -->
         <param name="auxDischargingSimulation" value="none"/>
         <param name="chargeTimeStep" value="5"/>
         <param name="chargersFile" value="chargers.xml"/>

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
@@ -23,16 +23,24 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkConfigConsistencyChecker;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkControlerModule;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkModule;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
 import org.matsim.contrib.etaxi.optimizer.ETaxiOptimizerProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.charging.ChargingLogic;
+import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
+import org.matsim.contrib.ev.charging.VariableSpeedCharging;
+import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
+import org.matsim.contrib.ev.dvrp.DvrpAuxConsumptionFactory;
+import org.matsim.contrib.ev.dvrp.EvDvrpIntegrationModule;
 import org.matsim.contrib.taxi.benchmark.RunTaxiBenchmark;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
@@ -48,6 +56,10 @@ import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
  * each link over time. The default approach is to specify free-flow speeds in each time interval (usually 15 minutes).
  */
 public class RunETaxiBenchmark {
+	private static final double CHARGING_SPEED_FACTOR = 1.; // full speed
+	private static final double MAX_RELATIVE_SOC = 0.8;// up to 80% SOC
+	private static final double TEMPERATURE = 20;// oC
+
 	public static void run(String configFile, int runs) {
 		Config config = ConfigUtils.loadConfig(configFile,
 				new TaxiConfigGroup(ETaxiOptimizerProvider::createParameterSet), new DvrpConfigGroup(),
@@ -72,7 +84,20 @@ public class RunETaxiBenchmark {
 
 		controler.addOverridingModule(new ETaxiModule());
 
-		controler.addOverridingModule(RunETaxiScenario.createEvDvrpIntegrationModule(taxiCfg.getMode()));
+		controler.addOverridingModule(new EvDvrpIntegrationModule(taxiCfg.getMode()));
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				bind(ChargingLogic.Factory.class).toInstance(
+						charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
+								VariableSpeedCharging.createStrategyForNissanLeaf(
+										charger.getPower() * CHARGING_SPEED_FACTOR, MAX_RELATIVE_SOC)));
+
+				bind(AuxEnergyConsumption.Factory.class).toInstance(
+						new DvrpAuxConsumptionFactory(taxiCfg.getMode(), () -> TEMPERATURE,
+								RunETaxiBenchmark::isTurnedOn));
+			}
+		});
 
 		controler.addOverridingModule(QSimScopeObjectListenerModule.builder(ETaxiBenchmarkStats.class)
 				.mode(taxiCfg.getMode())
@@ -81,6 +106,11 @@ public class RunETaxiBenchmark {
 				.build());
 
 		return controler;
+	}
+
+	private static boolean isTurnedOn(DvrpVehicleSpecification vehicle, double time) {
+		//FIXME should use actual vehicle to check if schedule is STARTED
+		return vehicle.getServiceBeginTime() <= time && time <= vehicle.getServiceEndTime();
 	}
 
 	public static void main(String[] args) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
@@ -30,6 +30,7 @@ import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
 import org.matsim.contrib.etaxi.optimizer.ETaxiOptimizerProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.charging.ChargingLogic;
 import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.VariableSpeedCharging;
@@ -79,12 +80,12 @@ public class RunETaxiBenchmark {
 
 		Controler controler = new Controler(scenario);
 		controler.setModules(new DvrpBenchmarkControlerModule());
+		controler.addOverridingModule(new ETaxiModule());
 		controler.addOverridingModule(new DvrpBenchmarkModule());
+		controler.addOverridingModule(new EvModule());
+		controler.addOverridingModule(new EvDvrpIntegrationModule());
 		controler.configureQSimComponents(DvrpQSimComponents.activateModes(taxiCfg.getMode()));
 
-		controler.addOverridingModule(new ETaxiModule());
-
-		controler.addOverridingModule(new EvDvrpIntegrationModule(taxiCfg.getMode()));
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
@@ -25,6 +25,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.etaxi.optimizer.ETaxiOptimizerProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.charging.ChargingLogic;
 import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.VariableSpeedCharging;
@@ -63,9 +64,10 @@ public class RunETaxiScenario {
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new ETaxiModule());
 		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new EvModule());
+		controler.addOverridingModule(new EvDvrpIntegrationModule());
 		controler.configureQSimComponents(EvDvrpIntegrationModule.activateModes(taxiCfg.getMode()));
 
-		controler.addOverridingModule(new EvDvrpIntegrationModule(taxiCfg.getMode()));
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
@@ -25,6 +25,8 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.etaxi.optimizer.ETaxiOptimizerProvider;
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.charging.ChargingLogic;
+import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.VariableSpeedCharging;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.dvrp.DvrpAuxConsumptionFactory;
@@ -63,10 +65,15 @@ public class RunETaxiScenario {
 		controler.addOverridingModule(new DvrpModule());
 		controler.configureQSimComponents(EvDvrpIntegrationModule.activateModes(taxiCfg.getMode()));
 
-		controler.addOverridingModule(createEvDvrpIntegrationModule(taxiCfg.getMode()));
+		controler.addOverridingModule(new EvDvrpIntegrationModule(taxiCfg.getMode()));
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
+				bind(ChargingLogic.Factory.class).toInstance(
+						charger -> new ChargingWithQueueingAndAssignmentLogic(charger,
+								VariableSpeedCharging.createStrategyForNissanLeaf(
+										charger.getPower() * CHARGING_SPEED_FACTOR, MAX_RELATIVE_SOC)));
+
 				bind(AuxEnergyConsumption.Factory.class).toInstance(
 						new DvrpAuxConsumptionFactory(taxiCfg.getMode(), () -> TEMPERATURE,
 								RunETaxiScenario::isTurnedOn));
@@ -78,12 +85,6 @@ public class RunETaxiScenario {
 		}
 
 		return controler;
-	}
-
-	public static EvDvrpIntegrationModule createEvDvrpIntegrationModule(String mode) {
-		return new EvDvrpIntegrationModule(mode).setChargingStrategyFactory(
-				charger -> VariableSpeedCharging.createStrategyForNissanLeaf(charger.getPower() * CHARGING_SPEED_FACTOR,
-						MAX_RELATIVE_SOC));
 	}
 
 	private static boolean isTurnedOn(DvrpVehicleSpecification vehicle, double time) {

--- a/contribs/taxi/src/main/resources/mielec_2014_02/mielec_etaxi_config.xml
+++ b/contribs/taxi/src/main/resources/mielec_2014_02/mielec_etaxi_config.xml
@@ -28,7 +28,7 @@
 	<module name="ev">
 		<param name="chargeTimeStep" value="5"/>
 		<param name="auxDischargeTimeStep" value="10"/>
-		<param name="auxDischargingSimulation" value="seperateAuxDischargingHandler"/>
+		<param name="auxDischargingSimulation" value="separateAuxDischargingHandler"/>
 
 		<param name="chargersFile" value="chargers-2-plugs-2.xml"/>
 		<param name="vehiclesFile" value="etaxis-25.xml"/>

--- a/contribs/taxi/src/main/resources/mielec_2014_02/mielec_etaxi_config_assignment.xml
+++ b/contribs/taxi/src/main/resources/mielec_2014_02/mielec_etaxi_config_assignment.xml
@@ -55,7 +55,7 @@
 	<module name="ev">
 		<param name="chargeTimeStep" value="5"/>
 		<param name="auxDischargeTimeStep" value="10"/>
-		<param name="auxDischargingSimulation" value="seperateAuxDischargingHandler"/>
+		<param name="auxDischargingSimulation" value="separateAuxDischargingHandler"/>
 
 		<param name="chargersFile" value="chargers-2-plugs-2.xml"/>
 		<param name="vehiclesFile" value="etaxis-25.xml"/>


### PR DESCRIPTION
Mainly: size down `EvDvrpIntegrationModule`:
- remove all factory setters (use binding overriding instead)
- use `EvDvrpIntegrationModule` in addition to (not instead of) EvModule
