### PR TITLE
minor change in the command line functionality

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/CommandLine.java
+++ b/matsim/src/main/java/org/matsim/core/config/CommandLine.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ScoringParameterSet;
 
 /**
  * <p>
@@ -94,6 +95,7 @@ import org.apache.log4j.Logger;
  * <ul>
  * <li><code>--config:global.numberOfThreads 48</code></li>
  * <li><code>--config:strategy.strategysettings[strategyName=ReRoute].weight 0.0</code></li>
+ * <li><code>--config:planCalcScore.scoringParameters[subpopulation=null].modeParams[mode=car].constant -3.5</code></li>
  * </ul>
  * 
  * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
@@ -389,8 +391,8 @@ public class CommandLine {
 		List<String> flatArguments = new LinkedList<>();
 
 		for (String argument : args) {
-			int index = argument.indexOf("=");
-			int bracketIndex = argument.indexOf("]");
+			int index = argument.lastIndexOf("=");
+			int bracketIndex = argument.lastIndexOf("]");
 
 			if (bracketIndex > index) {
 				index = argument.indexOf("=", bracketIndex);
@@ -574,6 +576,13 @@ public class CommandLine {
 										processParameter(option, newPath, parameterSet, newRemainder);
 										return;
 									}
+									
+									// allow for the case subpopulation = 'null' in the scoring parameters
+									if (parameterSetType.equals(ScoringParameterSet.SET_TYPE) && selectionParameter.equals("subpopulation") && selectionValue.equals("null")) {
+										processParameter(option, newPath, parameterSet, newRemainder);
+										return;
+									}
+									
 								}
 							}
 


### PR DESCRIPTION
allow for more than one hierarchy level in the parameter sets, allow for
the (quite common) case subpopulation=null in the scoring parameters