### PR TITLE
Make conversion to zero-length path optional

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
@@ -53,10 +53,15 @@ public class VrpPaths {
 			TravelTime travelTime) {
 		return createPath(fromLink, toLink, departureTime, pathData.path, travelTime);
 	}
-
+	
 	public static VrpPathWithTravelData createPath(Link fromLink, Link toLink, double departureTime, Path path,
 			TravelTime travelTime) {
-		if (fromLink == toLink) {
+		return createPath(fromLink, toLink, departureTime, path, travelTime, true);
+	}
+
+	public static VrpPathWithTravelData createPath(Link fromLink, Link toLink, double departureTime, Path path,
+			TravelTime travelTime, boolean considerZeroLengthPath) {
+		if (considerZeroLengthPath && fromLink == toLink) {
 			return createZeroLengthPath(fromLink, departureTime);
 		}
 


### PR DESCRIPTION
In my current use case I actually send vehicles to a parking spot after they drop off a passenger, but the links have separate capacities for parking and dropoff spots. So if the current link is selected as the parking spot, I actually want the vehicles to drive a loop and enter the link again, now with the "parking intention" rather "dropoff intention". Took me some time to figure out that vehicles were not moving at all in that case :)