### PR TITLE
Vehicle handler

### DIFF
--- a/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/HybridNetworkFactory.java
+++ b/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/HybridNetworkFactory.java
@@ -33,6 +33,8 @@ import org.matsim.core.mobsim.qsim.interfaces.AgentCounter;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.DefaultVehicleHandler;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.vis.snapshotwriters.SnapshotLinkWidthCalculator;
 
 public final class HybridNetworkFactory implements QNetworkFactory {
@@ -76,8 +78,9 @@ public final class HybridNetworkFactory implements QNetworkFactory {
 	public QLinkI createNetsimLink(Link link, QNodeI queueNode) {
 		if (link.getAllowedModes().contains("2ext")) {
 			LinkSpeedCalculator linkSpeedCalculator = new DefaultLinkSpeedCalculator() ;
+			VehicleHandler vehicleHandler = new DefaultVehicleHandler();
 			// yyyyyy I don't think that this would have been set correctly before I refactored this.  kai, feb'18
-			return new QSimExternalTransitionLink(link, this.externalEngine, context, netsimEngine, queueNode, linkSpeedCalculator);
+			return new QSimExternalTransitionLink(link, this.externalEngine, context, netsimEngine, queueNode, linkSpeedCalculator, vehicleHandler);
 		}
 //		QLinkImpl ret = new QLinkImpl(link, network, queueNode, linkSpeedCalculator);
 		QLinkImpl.Builder linkBuilder = new QLinkImpl.Builder(context, netsimEngine );

--- a/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QSimExternalTransitionLink.java
+++ b/contribs/hybridsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QSimExternalTransitionLink.java
@@ -32,6 +32,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.lanes.Lane;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vis.snapshotwriters.VisData;
@@ -45,8 +46,8 @@ public class QSimExternalTransitionLink extends AbstractQLink {
 	private final QNodeI toQNode ;
 
 	QSimExternalTransitionLink(Link link, ExternalEngine e, NetsimEngineContext context, NetsimInternalInterface netsimEngine,
-							   QNodeI toQNode, LinkSpeedCalculator linkSpeedCalculator) {
-		super(link, toQNode, context, netsimEngine, linkSpeedCalculator);
+							   QNodeI toQNode, LinkSpeedCalculator linkSpeedCalculator, VehicleHandler vehicleHandler) {
+		super(link, toQNode, context, netsimEngine, linkSpeedCalculator, vehicleHandler);
 		this.e = e;
 		this.em = e.getEventsManager();
 		this.context = context ;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractQLink.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractQLink.java
@@ -51,6 +51,7 @@ import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
 import org.matsim.core.mobsim.qsim.pt.TransitDriverAgent;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.vehicles.Vehicle;
 
@@ -111,13 +112,15 @@ abstract class AbstractQLink implements QLinkI {
 
 	private final NetsimInternalInterface netsimEngine;
 	private final LinkSpeedCalculator linkSpeedCalculator;
+	private final VehicleHandler vehicleHandler;
 	
-	AbstractQLink(Link link, QNodeI toNode, NetsimEngineContext context, NetsimInternalInterface netsimEngine2, LinkSpeedCalculator linkSpeedCalculator) {
+	AbstractQLink(Link link, QNodeI toNode, NetsimEngineContext context, NetsimInternalInterface netsimEngine2, LinkSpeedCalculator linkSpeedCalculator, VehicleHandler vehicleHandler) {
 		this.link = link ;
 		this.toQNode = toNode ;
 		this.context = context;
 		this.netsimEngine = netsimEngine2;
 		this.linkSpeedCalculator = linkSpeedCalculator;
+		this.vehicleHandler = vehicleHandler;
 	}
 
 	@Override
@@ -140,8 +143,8 @@ abstract class AbstractQLink implements QLinkI {
 		// This is a bit involved since we do not want to ask the registry in every time step if the link is already active.
 	}
 	private static int wrnCnt = 0 ;
-	@Override
-	public final void addParkedVehicle(MobsimVehicle vehicle) {
+	
+	public final void addParkedVehicle(MobsimVehicle vehicle, boolean isInitial) {
 		QVehicle qveh = (QVehicle) vehicle; // cast ok: when it gets here, it needs to be a qvehicle to work.
 
 		if ( this.parkedVehicles.put(qveh.getId(), qveh) != null ) {
@@ -152,16 +155,30 @@ abstract class AbstractQLink implements QLinkI {
 			}
 		}
 		qveh.setCurrentLink(this.link);
+		
+		if (isInitial) {
+			vehicleHandler.handleInitialVehicleArrival(qveh, link);
+		}
 	}
 	
-	/* package */ final void letVehicleArrive(QVehicle qveh) {
-		addParkedVehicle(qveh);
-		double now = context.getSimTimer().getTimeOfDay();;
-		context.getEventsManager().processEvent(new VehicleLeavesTrafficEvent(now , qveh.getDriver().getId(), 
-				this.link.getId(), qveh.getId(), qveh.getDriver().getMode(), 1.0 ) ) ;
+	@Override 
+	public final void addParkedVehicle(MobsimVehicle vehicle) {
+		addParkedVehicle(vehicle, true);
+	}
+	
+	/* package */ final boolean letVehicleArrive(QVehicle qveh) {
+		if (vehicleHandler.handleVehicleArrival(qveh, this.getLink())) {
+			addParkedVehicle(qveh);
+			double now = context.getSimTimer().getTimeOfDay();;
+			context.getEventsManager().processEvent(new VehicleLeavesTrafficEvent(now , qveh.getDriver().getId(), 
+					this.link.getId(), qveh.getId(), qveh.getDriver().getMode(), 1.0 ) ) ;
+			
+			this.netsimEngine.letVehicleArrive(qveh);
+			makeVehicleAvailableToNextDriver(qveh);
+			return true;
+		}
 		
-		this.netsimEngine.letVehicleArrive(qveh);
-		makeVehicleAvailableToNextDriver(qveh);
+		return false;
 	}
 
 	@Override
@@ -179,6 +196,7 @@ abstract class AbstractQLink implements QLinkI {
 		this.waitingList.add(vehicle);
 		vehicle.setCurrentLink(this.getLink());
 		this.activateLink();
+		vehicleHandler.handleVehicleDeparture(vehicle, link);
 	}
 
 	@Override
@@ -513,8 +531,8 @@ abstract class AbstractQLink implements QLinkI {
 			AbstractQLink.this.addParkedVehicle(veh);
 		}
 		
-		public void letVehicleArrive(QVehicle veh) {
-			AbstractQLink.this.letVehicleArrive(veh);
+		public boolean letVehicleArrive(QVehicle veh) {
+			return AbstractQLink.this.letVehicleArrive(veh);
 		}
 		
 		public void makeVehicleAvailableToNextDriver(QVehicle veh) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractQLink.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractQLink.java
@@ -168,7 +168,7 @@ abstract class AbstractQLink implements QLinkI {
 	
 	/* package */ final boolean letVehicleArrive(QVehicle qveh) {
 		if (vehicleHandler.handleVehicleArrival(qveh, this.getLink())) {
-			addParkedVehicle(qveh);
+			addParkedVehicle(qveh, false);
 			double now = context.getSimTimer().getTimeOfDay();;
 			context.getEventsManager().processEvent(new VehicleLeavesTrafficEvent(now , qveh.getDriver().getId(), 
 					this.link.getId(), qveh.getId(), qveh.getDriver().getMode(), 1.0 ) ) ;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
@@ -31,6 +31,8 @@ import org.matsim.core.mobsim.qsim.interfaces.AgentCounter;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.DefaultVehicleHandler;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.core.mobsim.qsim.qnetsimengine.vehicleq.FIFOVehicleQ;
 import org.matsim.core.mobsim.qsim.qnetsimengine.vehicleq.VehicleQ;
 import org.matsim.vis.snapshotwriters.SnapshotLinkWidthCalculator;
@@ -51,6 +53,7 @@ public final class ConfigurableQNetworkFactory implements QNetworkFactory {
 	private NetsimInternalInterface netsimEngine ;
 	private LinkSpeedCalculator linkSpeedCalculator = new DefaultLinkSpeedCalculator() ;
 	private TurnAcceptanceLogic turnAcceptanceLogic = new DefaultTurnAcceptanceLogic() ;
+	private VehicleHandler vehicleHandler = new DefaultVehicleHandler();
 	private VehicleQ.Factory<QVehicle> vehicleQFactory = FIFOVehicleQ::new ;
 
 	public ConfigurableQNetworkFactory( EventsManager events, Scenario scenario ) {
@@ -81,6 +84,7 @@ public final class ConfigurableQNetworkFactory implements QNetworkFactory {
 			linkBuilder.setLaneFactory( laneFactory );
 		}
 		linkBuilder.setLinkSpeedCalculator( linkSpeedCalculator ) ;
+		linkBuilder.setVehicleHandler(vehicleHandler);
 
 		return linkBuilder.build(link, toQueueNode) ;
 	}
@@ -97,6 +101,9 @@ public final class ConfigurableQNetworkFactory implements QNetworkFactory {
 	}
 	public final void setTurnAcceptanceLogic( TurnAcceptanceLogic turnAcceptanceLogic ) {
 		this.turnAcceptanceLogic = turnAcceptanceLogic;
+	}
+	public final void setVehicleHandler(VehicleHandler vehicleHandler) {
+		this.vehicleHandler = vehicleHandler;
 	}
 	public final void setVehicleQFactory( VehicleQ.Factory<QVehicle> factory ) {
 		this.vehicleQFactory = factory ;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkImpl.java
@@ -34,6 +34,8 @@ import org.matsim.core.mobsim.qsim.interfaces.SignalizeableItem;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.DefaultVehicleHandler;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.lanes.VisLaneModelBuilder;
@@ -59,6 +61,7 @@ public final class QLinkImpl extends AbstractQLink implements SignalizeableItem 
 		private final NetsimEngineContext context;
 		private LaneFactory laneFactory;
 		private LinkSpeedCalculator linkSpeedCalculator = new DefaultLinkSpeedCalculator() ;
+		private VehicleHandler vehicleHandler = new DefaultVehicleHandler();
 		
 		Builder(NetsimEngineContext context, NetsimInternalInterface netsimEngine2) {
 			this.context = context ;
@@ -71,11 +74,16 @@ public final class QLinkImpl extends AbstractQLink implements SignalizeableItem 
 		public void setLinkSpeedCalculator(LinkSpeedCalculator linkSpeedCalculator) {
 			this.linkSpeedCalculator = linkSpeedCalculator;
 		}
+		
+		public void setVehicleHandler(VehicleHandler vehicleHandler) {
+			this.vehicleHandler = vehicleHandler;
+		}
+		
 		QLinkImpl build( Link link, QNodeI toNode ) {
 			if ( laneFactory == null ) {
 				laneFactory = new QueueWithBuffer.Builder( context ) ;
 			}
-			return new QLinkImpl( link, toNode, laneFactory, context, netsimEngine, linkSpeedCalculator) ;
+			return new QLinkImpl( link, toNode, laneFactory, context, netsimEngine, linkSpeedCalculator, vehicleHandler) ;
 		}
 	}
 
@@ -97,8 +105,8 @@ public final class QLinkImpl extends AbstractQLink implements SignalizeableItem 
 	private NetsimEngineContext context;
 	
 	private QLinkImpl(final Link link2, final QNodeI toNode, final LaneFactory roadFactory, NetsimEngineContext context,
-					  NetsimInternalInterface netsimEngine, LinkSpeedCalculator linkSpeedCalculator) {
-		super(link2, toNode, context, netsimEngine, linkSpeedCalculator) ;
+					  NetsimInternalInterface netsimEngine, LinkSpeedCalculator linkSpeedCalculator, VehicleHandler vehicleHandler) {
+		super(link2, toNode, context, netsimEngine, linkSpeedCalculator, vehicleHandler) ;
 		this.context = context ;
 		// The next line must must by contract stay within the constructor,
 		// so that the caller can use references to the created roads to wire them together,

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkLanesImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QLinkLanesImpl.java
@@ -28,6 +28,8 @@ import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.DefaultVehicleHandler;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
 import org.matsim.core.mobsim.qsim.qnetsimengine.vehicleq.FIFOVehicleQ;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
@@ -119,6 +121,7 @@ public final class QLinkLanesImpl extends AbstractQLink {
 		private final NetsimEngineContext context;
 		private final NetsimInternalInterface netsimEngine;
 		private LinkSpeedCalculator linkSpeedCalculator = new DefaultLinkSpeedCalculator() ;
+		private VehicleHandler vehicleHandler = new DefaultVehicleHandler();
 
 		public Builder(NetsimEngineContext context, NetsimInternalInterface netsimEngine ) {
 			this.context = context;
@@ -130,7 +133,7 @@ public final class QLinkLanesImpl extends AbstractQLink {
 		}
 
 		AbstractQLink build(Link link, QNodeI toNodeQ, List<ModelLane> lanes ) {
-			return new QLinkLanesImpl(link, toNodeQ, lanes, context, netsimEngine, linkSpeedCalculator ) ;
+			return new QLinkLanesImpl(link, toNodeQ, lanes, context, netsimEngine, linkSpeedCalculator, vehicleHandler ) ;
 		}
 
 	}
@@ -170,8 +173,8 @@ public final class QLinkLanesImpl extends AbstractQLink {
 	 * @param linkSpeedCalculator
 	 */
 	private QLinkLanesImpl(final Link link, final QNodeI toNodeQ, List<ModelLane> lanes, NetsimEngineContext context,
-				   NetsimInternalInterface netsimEngine, LinkSpeedCalculator linkSpeedCalculator) {
-		super(link, toNodeQ, context, netsimEngine, linkSpeedCalculator);
+				   NetsimInternalInterface netsimEngine, LinkSpeedCalculator linkSpeedCalculator, VehicleHandler vehicleHandler) {
+		super(link, toNodeQ, context, netsimEngine, linkSpeedCalculator, vehicleHandler);
 		this.context = context ;
 		this.toQueueNode = toNodeQ;
 		this.laneQueues = new LinkedHashMap<>();

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -493,12 +493,13 @@ final class QueueWithBuffer implements QLaneI, SignalizeableItem {
 
 			// Check if veh has reached destination:
 			if ( driver.isWantingToArriveOnCurrentLink() ) {
-				qLink.letVehicleArrive( veh );
-
-				// remove _after_ processing the arrival to keep link active:
-				removeVehicleFromQueue( veh ) ;
-
-				continue;
+				if (qLink.letVehicleArrive( veh )) {
+					// remove _after_ processing the arrival to keep link active:
+					removeVehicleFromQueue( veh ) ;
+					continue;
+				} else { // The current vehicle is not allowed to arrive, so it will block the link
+					return;
+				}
 			}
 
 			/* is there still any flow capacity left? */

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/DefaultVehicleHandler.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/DefaultVehicleHandler.java
@@ -1,0 +1,21 @@
+package org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
+
+public class DefaultVehicleHandler implements VehicleHandler {
+	@Override
+	public void handleVehicleDeparture(QVehicle vehicle, Link link) {
+
+	}
+
+	@Override
+	public boolean handleVehicleArrival(QVehicle vehicle, Link link) {
+		return true;
+	}
+
+	@Override
+	public void handleInitialVehicleArrival(QVehicle vehicle, Link link) {
+
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/DefaultVehicleHandler.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/DefaultVehicleHandler.java
@@ -3,6 +3,12 @@ package org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 
+/**
+ * Default implementation of a {{@link #VehicleHandler()}. It always allows
+ * vehicles to arrive at a link.
+ * 
+ * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
+ */
 public class DefaultVehicleHandler implements VehicleHandler {
 	@Override
 	public void handleVehicleDeparture(QVehicle vehicle, Link link) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/VehicleHandler.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/VehicleHandler.java
@@ -1,0 +1,12 @@
+package org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
+
+public interface VehicleHandler {
+	void handleVehicleDeparture(QVehicle vehicle, Link link);
+
+	boolean handleVehicleArrival(QVehicle vehicle, Link link);
+
+	void handleInitialVehicleArrival(QVehicle vehicle, Link link);
+}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/VehicleHandler.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/vehicle_handler/VehicleHandler.java
@@ -3,10 +3,30 @@ package org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 
+/**
+ * This interface provides functionality to decide what happens if a vehicle
+ * interacts with a link in the network simulation.
+ * 
+ * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
+ */
 public interface VehicleHandler {
+	/**
+	 * Called when a vehicle departs in the network simulation.
+	 */
 	void handleVehicleDeparture(QVehicle vehicle, Link link);
 
+	/**
+	 * Called when a vehicle wants to arrive at a certain link the network
+	 * simulation.
+	 * 
+	 * @return Return value defines whether vehicle is currently allowed to arrive
+	 *         at the link. If not, the link will block until the next query or
+	 *         until the agent changes its plan dynamically.
+	 */
 	boolean handleVehicleArrival(QVehicle vehicle, Link link);
 
+	/**
+	 * Called when a vehicle is initially placed on a certain link.
+	 */
 	void handleInitialVehicleArrival(QVehicle vehicle, Link link);
 }

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/VehicleHandlerTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/VehicleHandlerTest.java
@@ -1,0 +1,196 @@
+package org.matsim.core.mobsim.qsim.qnetsimengine;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
+import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ActivityParams;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.misc.Time;
+
+import com.google.inject.Provides;
+
+public class VehicleHandlerTest {
+	@Test
+	public void testVehicleHandler() {
+		// This is a test where there is a link with a certain parking capacity. As soon as
+		// it is reached the link is blocking, until a vehicle is leaving the link again. In 
+		// this case there are three agents which do a longer stop on the capacitated link,
+		// but they all have the same route and plan. This means that if the capacity is 
+		// above 3, all agents will perform their plans without any distraction. If the
+		// capacity is set to 2, the third agent needs to wait until the first of the 
+		// previous ones is leaving, and so on ...
+		
+		Assert.assertEquals(20203.0, runTestScenario(4), 1e-3);
+		Assert.assertEquals(20203.0, runTestScenario(3), 1e-3);
+		Assert.assertEquals(23003.0, runTestScenario(2), 1e-3);
+		Assert.assertEquals(33003.0, runTestScenario(1), 1e-3);
+	}
+
+	public double runTestScenario(long capacity) {
+		Scenario scenario = createScenario();
+		Controler controler = new Controler(scenario);
+
+		LatestArrivalHandler arrivalHandler = new LatestArrivalHandler();
+		BlockingVehicleHandler vehicleHandler = new BlockingVehicleHandler(capacity);
+
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				addEventHandlerBinding().toInstance(arrivalHandler);
+			}
+		});
+
+		controler.addOverridingQSimModule(new AbstractQSimModule() {
+			@Override
+			protected void configureQSim() {
+			}
+
+			@Provides
+			QNetworkFactory provideQNetworkFactory(EventsManager eventsManager, Scenario scenario) {
+				ConfigurableQNetworkFactory factory = new ConfigurableQNetworkFactory(eventsManager, scenario);
+				factory.setVehicleHandler(vehicleHandler);
+				return factory;
+			}
+		});
+
+		controler.run();
+		return arrivalHandler.latestArrivalTime;
+	}
+
+	private class BlockingVehicleHandler implements VehicleHandler {
+		private final Id<Link> linkId = Id.createLinkId("CD");
+		private final long capacity;
+
+		long count = 0;
+
+		public BlockingVehicleHandler(long capacity) {
+			this.capacity = capacity;
+		}
+
+		@Override
+		public void handleVehicleDeparture(QVehicle vehicle, Link link) {
+			if (link.getId().equals(linkId)) {
+				count--;
+			}
+		}
+
+		@Override
+		public boolean handleVehicleArrival(QVehicle vehicle, Link link) {
+			if (link.getId().equals(linkId)) {
+				if (count >= capacity) {
+					return false;
+				}
+
+				count++;
+			}
+
+			return true;
+		}
+
+		@Override
+		public void handleInitialVehicleArrival(QVehicle vehicle, Link link) {
+
+		}
+	}
+
+	private class LatestArrivalHandler implements PersonArrivalEventHandler {
+		double latestArrivalTime = Time.getUndefinedTime();
+
+		@Override
+		public void handleEvent(PersonArrivalEvent event) {
+			if (event.getLinkId().equals(Id.createLinkId("DE"))) {
+				latestArrivalTime = event.getTime();
+			}
+		}
+	}
+
+	private Scenario createScenario() {
+		Config config = ConfigUtils.createConfig();
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setLastIteration(0);
+
+		ActivityParams genericParams = new ActivityParams("generic");
+		genericParams.setTypicalDuration(1.0);
+
+		config.planCalcScore().addActivityParams(genericParams);
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+
+		Network network = scenario.getNetwork();
+		NetworkFactory networkFactory = network.getFactory();
+
+		Node nodeA = networkFactory.createNode(Id.createNodeId("A"), new Coord(0.0, 0.0));
+		Node nodeB = networkFactory.createNode(Id.createNodeId("B"), new Coord(1000.0, 2000.0));
+		Node nodeC = networkFactory.createNode(Id.createNodeId("C"), new Coord(1000.0, 3000.0));
+		Node nodeD = networkFactory.createNode(Id.createNodeId("D"), new Coord(1000.0, 4000.0));
+		Node nodeE = networkFactory.createNode(Id.createNodeId("E"), new Coord(1000.0, 5000.0));
+
+		Link linkAB = networkFactory.createLink(Id.createLinkId("AB"), nodeA, nodeB);
+		Link linkBC = networkFactory.createLink(Id.createLinkId("BC"), nodeB, nodeC);
+		Link linkCD = networkFactory.createLink(Id.createLinkId("CD"), nodeC, nodeD);
+		Link linkDE = networkFactory.createLink(Id.createLinkId("DE"), nodeD, nodeE);
+
+		Arrays.asList(nodeA, nodeB, nodeC, nodeD, nodeE).forEach(network::addNode);
+		Arrays.asList(linkAB, linkBC, linkCD, linkDE).forEach(network::addLink);
+
+		Population population = scenario.getPopulation();
+		PopulationFactory populationFactory = population.getFactory();
+
+		Person person1 = populationFactory.createPerson(Id.createPersonId("person1"));
+		Person person2 = populationFactory.createPerson(Id.createPersonId("person2"));
+		Person person3 = populationFactory.createPerson(Id.createPersonId("person3"));
+
+		for (Person person : Arrays.asList(person1, person2, person3)) {
+			population.addPerson(person);
+
+			Plan plan = populationFactory.createPlan();
+			person.addPlan(plan);
+
+			Activity activity;
+			Leg leg;
+
+			activity = populationFactory.createActivityFromLinkId("generic", linkAB.getId());
+			activity.setEndTime(0.0);
+			plan.addActivity(activity);
+
+			leg = populationFactory.createLeg("car");
+			plan.addLeg(leg);
+
+			activity = populationFactory.createActivityFromLinkId("generic", linkCD.getId());
+			activity.setMaximumDuration(10000.0);
+			plan.addActivity(activity);
+
+			leg = populationFactory.createLeg("car");
+			plan.addLeg(leg);
+
+			activity = populationFactory.createActivityFromLinkId("generic", linkDE.getId());
+			plan.addActivity(activity);
+		}
+
+		return scenario;
+	}
+}


### PR DESCRIPTION
This PR adds a new (optional in the sense of `LinkSpeedCalculator`) component to the Netsim. Basically, it represents a condition that decides whether a vehicle is actually allowed to arrive at a link if it `isWantingToArrive`. In the default case, the handler will always return `true`, which replicates the current behaviour that there is no restriction on where and when vehicles can arrive on a link:

```java
public interface VehicleHandler {
   void handleVehicleDeparture(QVehicle vehicle, Link link);
   boolean handleVehicleArrival(QVehicle vehicle, Link link);
   void handleInitialVehicleArrival(QVehicle vehicle, Link link);
}
```

With this handler it is now possible to define additional dynamics: One can count the number of vehicles that have already entered the link and block once a certain capacity limit is reached. The interface is quite versatile, in a current project we, for instance, have defined two different capacities for "pickup and dropoff" and for "parking" for DVRP vehicles. 

The important point is that there is backspill when a dropoff point is already crowded, for example. While it was possible before to count vehicles and maybe artificially add delays in the dispatching of vehicles, this is new now.

Later on, I can add examples for DVRP.