### PR TITLE
Remove forced log level in EditTrips constructor

### DIFF
--- a/matsim/src/main/java/org/matsim/withinday/utils/EditTrips.java
+++ b/matsim/src/main/java/org/matsim/withinday/utils/EditTrips.java
@@ -66,7 +66,6 @@ public final class EditTrips {
 	private EventsManager eventsManager;
 
 	public EditTrips( QSim qsim, TripRouter tripRouter, Scenario scenario ) {
-		log.setLevel( Level.DEBUG);
 		this.tripRouter = tripRouter;
 		this.scenario = scenario;
 		this.pf = scenario.getPopulation().getFactory() ;


### PR DESCRIPTION
The constructor in `EditTrips` currently forces a particular log level for the class: 
https://github.com/matsim-org/matsim/blob/e5eecb76184401c35ed021a2a8be8fafea97403e/matsim/src/main/java/org/matsim/withinday/utils/EditTrips.java#L68-L69

This configuration should instead be done in the `log4j.xml`, for instance using something like:
```
<logger name="org.matsim.withinday.utils.EditTrips">
	<level value="info"/>
</logger>
```

Forcing the log level in the constructor means any configuration coming from `log4j.xml` will always be overwritten and cannot be overridden at runtime. Presumably this is not what is intended.