### PR TITLE
add DvrpMode-annotated network to taxi and drt

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -23,8 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.inject.Inject;
-
 import org.apache.log4j.Logger;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -32,11 +30,7 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.core.utils.geometry.geotools.MGC;
-
-import com.google.inject.Provider;
-import com.google.inject.name.Named;
 
 /**
  * @author jbischoff
@@ -101,22 +95,5 @@ public class DrtZonalSystem {
 		}
 		Coord c = MGC.point2Coord(zone.getCentroid());
 		return c;
-	}
-
-	public static class DrtZonalSystemProvider implements Provider<DrtZonalSystem> {
-		@Inject
-		@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-		private Network network;
-
-		private final double cellSize;
-
-		public DrtZonalSystemProvider(double cellSize) {
-			this.cellSize = cellSize;
-		}
-
-		@Override
-		public DrtZonalSystem get() {
-			return new DrtZonalSystem(network, cellSize);
-		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelPathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelPathDataProvider.java
@@ -29,13 +29,12 @@ import javax.inject.Named;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
 import org.matsim.contrib.drt.optimizer.insertion.DetourLinksProvider.DetourLinksSet;
+import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
@@ -63,9 +62,8 @@ public class ParallelPathDataProvider implements PrecalculablePathDataProvider, 
 	private Map<Id<Link>, PathData> pathsToDropoffMap;
 	private Map<Id<Link>, PathData> pathsFromDropoffMap;
 
-	public ParallelPathDataProvider(@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			DrtConfigGroup drtCfg) {
+	public ParallelPathDataProvider(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, DrtConfigGroup drtCfg) {
 		toPickupPathSearch = OneToManyPathSearch.createBackwardSearch(network, travelTime, travelDisutility);
 		fromPickupPathSearch = OneToManyPathSearch.createForwardSearch(network, travelTime, travelDisutility);
 		toDropoffPathSearch = OneToManyPathSearch.createBackwardSearch(network, travelTime, travelDisutility);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/StopBasedPathDataProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/StopBasedPathDataProvider.java
@@ -32,7 +32,6 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.ManyToManyPathData;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.TimeDiscretizer;
 import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
@@ -56,14 +55,13 @@ public class StopBasedPathDataProvider implements PrecalculablePathDataProvider 
 	private Map<Id<Link>, PathData> pathsToDropoffMap;
 	private Map<Id<Link>, PathData> pathsFromDropoffMap;
 
-	public StopBasedPathDataProvider(@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			TransitSchedule schedule, TravelTimeCalculatorConfigGroup ttcConfig, DrtConfigGroup drtCfg) {
+	public StopBasedPathDataProvider(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, TransitSchedule schedule, TravelTimeCalculatorConfigGroup ttcConfig,
+			DrtConfigGroup drtCfg) {
 		stopDuration = drtCfg.getStopDuration();
 
 		List<Link> stopLinks = schedule.getFacilities()
-				.values()
-				.stream().map(tsf -> network.getLinks().get(tsf.getLinkId()))
+				.values().stream().map(tsf -> network.getLinks().get(tsf.getLinkId()))
 				.distinct()// more than one stop can be located on a link
 				.collect(ImmutableList.toImmutableList());
 		manyToManyPathData = new ManyToManyPathData(network, travelTime, travelDisutility, stopLinks,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
@@ -32,13 +32,10 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy.Relocation;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.util.distance.DistanceUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
-
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -47,8 +44,7 @@ public class AggregatedMinCostRelocationCalculator implements MinCostRelocationC
 	private final DrtZonalSystem zonalSystem;
 	private final Network network;
 
-	public AggregatedMinCostRelocationCalculator(DrtZonalSystem zonalSystem,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network) {
+	public AggregatedMinCostRelocationCalculator(DrtZonalSystem zonalSystem, Network network) {
 		this.zonalSystem = zonalSystem;
 		this.network = network;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -27,7 +27,6 @@ import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.Fleet;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.core.api.experimental.events.EventsManager;
@@ -46,7 +45,8 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 	@Override
 	public void install() {
 		MinCostFlowRebalancingParams params = drtCfg.getMinCostFlowRebalancing().get();
-		bindModal(DrtZonalSystem.class).toProvider(new DrtZonalSystem.DrtZonalSystemProvider(params.getCellSize()));
+		bindModal(DrtZonalSystem.class).toProvider(
+				modalProvider(getter -> new DrtZonalSystem(getter.getModal(Network.class), params.getCellSize())));
 
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
@@ -62,8 +62,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 
 				bindModal(MinCostRelocationCalculator.class).toProvider(modalProvider(
 						getter -> new AggregatedMinCostRelocationCalculator(getter.getModal(DrtZonalSystem.class),
-								getter.getNamed(Network.class, DvrpRoutingNetworkProvider.DVRP_ROUTING))))
-						.asEagerSingleton();
+								getter.getModal(Network.class)))).asEagerSingleton();
 			}
 		});
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.util.ExecutorServiceWithResource;
 import org.matsim.core.config.Config;
@@ -53,8 +52,7 @@ public class DefaultDrtRouteUpdater implements ShutdownListener, DrtRouteUpdater
 	private final Population population;
 	private final ExecutorServiceWithResource<LeastCostPathCalculator> executorService;
 
-	public DefaultDrtRouteUpdater(DrtConfigGroup drtCfg,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
+	public DefaultDrtRouteUpdater(DrtConfigGroup drtCfg, Network network,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
 			TravelDisutilityFactory travelDisutilityFactory, Population population, Config config) {
 		this.drtCfg = drtCfg;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -33,7 +33,6 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.router.EmptyStageActivityTypes;
@@ -62,7 +61,7 @@ public class DrtRoutingModule implements RoutingModule {
 	private final RoutingModule walkRouter;
 	private final DrtStageActivityType drtStageActivityType;
 
-	public DrtRoutingModule(DrtConfigGroup drtCfg, @Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
+	public DrtRoutingModule(DrtConfigGroup drtCfg, Network network,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
 			TravelDisutilityFactory travelDisutilityFactory, PopulationFactory populationFactory,
 			@Named(TransportMode.walk) RoutingModule walkRouter) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -54,7 +54,9 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 import com.google.inject.Inject;
+import com.google.inject.Key;
 import com.google.inject.name.Named;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -71,6 +73,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new FleetModule(getMode(), drtCfg.getVehiclesFileUrl(getConfig().getContext()),
@@ -110,10 +113,6 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DrtRouteUpdater.class).toProvider(new ModalProviders.AbstractProvider<DrtRouteUpdater>(getMode()) {
 			@Inject
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
-			@Inject
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 			private TravelTime travelTime;
 
@@ -125,6 +124,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 			@Override
 			public DefaultDrtRouteUpdater get() {
+				Network network = getModalInstance(Network.class);
 				return new DefaultDrtRouteUpdater(drtCfg, network, travelTime,
 						getModalInstance(TravelDisutilityFactory.class), population, config);
 			}
@@ -135,10 +135,6 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 	private static class DrtRoutingModuleProvider extends ModalProviders.AbstractProvider<DrtRoutingModule> {
 		private final DrtConfigGroup drtCfg;
-
-		@Inject
-		@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-		private Network network;
 
 		@Inject
 		@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
@@ -158,6 +154,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		@Override
 		public DrtRoutingModule get() {
+			Network network = getModalInstance(Network.class);
 			return new DrtRoutingModule(drtCfg, network, travelTime, getModalInstance(TravelDisutilityFactory.class),
 					populationFactory, walkRouter);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
@@ -48,7 +48,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -112,9 +111,6 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(EmptyVehicleRelocator.class).toProvider(
 				new ModalProviders.AbstractProvider<EmptyVehicleRelocator>(drtCfg.getMode()) {
-					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
 
 					@Inject
 					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
@@ -125,6 +121,7 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 					@Override
 					public EmptyVehicleRelocator get() {
+						Network network = getModalInstance(Network.class);
 						DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
@@ -154,15 +151,12 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		addModalComponent(ParallelPathDataProvider.class,
 				new ModalProviders.AbstractProvider<ParallelPathDataProvider>(getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 					private TravelTime travelTime;
 
 					@Override
 					public ParallelPathDataProvider get() {
+						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
 						return new ParallelPathDataProvider(network, travelTime, travelDisutility, drtCfg);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
@@ -26,7 +26,6 @@ import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -46,9 +45,8 @@ public class EmptyVehicleRelocator {
 	private final DrtTaskFactory taskFactory;
 	private final LeastCostPathCalculator router;
 
-	public EmptyVehicleRelocator(@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			MobsimTimer timer, DrtTaskFactory taskFactory) {
+	public EmptyVehicleRelocator(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, MobsimTimer timer, DrtTaskFactory taskFactory) {
 		this.travelTime = travelTime;
 		this.timer = timer;
 		this.taskFactory = taskFactory;

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeModule.java
@@ -55,7 +55,9 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 import com.google.inject.Inject;
+import com.google.inject.Key;
 import com.google.inject.name.Named;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -72,6 +74,7 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new EvDvrpFleetModule(getMode(), drtCfg.getVehiclesFile()));
@@ -110,10 +113,6 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DrtRouteUpdater.class).toProvider(new ModalProviders.AbstractProvider<DrtRouteUpdater>(getMode()) {
 			@Inject
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
-			@Inject
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 			private TravelTime travelTime;
 
@@ -125,6 +124,7 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 
 			@Override
 			public DefaultDrtRouteUpdater get() {
+				Network network = getModalInstance(Network.class);
 				return new DefaultDrtRouteUpdater(drtCfg, network, travelTime,
 						getModalInstance(TravelDisutilityFactory.class), population, config);
 			}
@@ -135,10 +135,6 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 
 	private static class DrtRoutingModuleProvider extends ModalProviders.AbstractProvider<DrtRoutingModule> {
 		private final DrtConfigGroup drtCfg;
-
-		@Inject
-		@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-		private Network network;
 
 		@Inject
 		@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
@@ -158,6 +154,7 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 
 		@Override
 		public DrtRoutingModule get() {
+			Network network = getModalInstance(Network.class);
 			return new DrtRoutingModule(drtCfg, network, travelTime, getModalInstance(TravelDisutilityFactory.class),
 					populationFactory, walkRouter);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
@@ -45,7 +45,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -103,10 +102,6 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(EmptyVehicleChargingScheduler.class).toProvider(
 				new ModalProviders.AbstractProvider<EmptyVehicleChargingScheduler>(drtCfg.getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					private MobsimTimer timer;
 
 					@Inject
@@ -114,6 +109,7 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 					@Override
 					public EmptyVehicleChargingScheduler get() {
+						Network network = getModalInstance(Network.class);
 						DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 						return new EmptyVehicleChargingScheduler(network, timer, taskFactory, chargingInfrastructure);
 					}
@@ -140,10 +136,6 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(EmptyVehicleRelocator.class).toProvider(
 				new ModalProviders.AbstractProvider<EmptyVehicleRelocator>(drtCfg.getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 					private TravelTime travelTime;
 
@@ -152,6 +144,7 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 					@Override
 					public EmptyVehicleRelocator get() {
+						Network network = getModalInstance(Network.class);
 						DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
@@ -181,15 +174,12 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		addModalComponent(ParallelPathDataProvider.class,
 				new ModalProviders.AbstractProvider<ParallelPathDataProvider>(getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 					private TravelTime travelTime;
 
 					@Override
 					public ParallelPathDataProvider get() {
+						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
 						return new ParallelPathDataProvider(network, travelTime, travelDisutility, drtCfg);

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/scheduler/EmptyVehicleChargingScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/scheduler/EmptyVehicleChargingScheduler.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.edrt.schedule.EDrtTaskFactoryImpl;
 import org.matsim.contrib.ev.charging.ChargingStrategy;
@@ -39,8 +38,6 @@ import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructure;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
-import com.google.inject.name.Named;
-
 /**
  * @author michalm
  */
@@ -49,8 +46,8 @@ public class EmptyVehicleChargingScheduler {
 	private final EDrtTaskFactoryImpl taskFactory;
 	private final Map<Id<Link>, Charger> linkToChargerMap;
 
-	public EmptyVehicleChargingScheduler(@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			MobsimTimer timer, DrtTaskFactory taskFactory, ChargingInfrastructure chargingInfrastructure) {
+	public EmptyVehicleChargingScheduler(Network network, MobsimTimer timer, DrtTaskFactory taskFactory,
+			ChargingInfrastructure chargingInfrastructure) {
 		this.timer = timer;
 		this.taskFactory = (EDrtTaskFactoryImpl)taskFactory;
 		linkToChargerMap = chargingInfrastructure.getChargers().values().stream()

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpFleetModule.java
@@ -27,7 +27,6 @@ import org.matsim.contrib.dvrp.fleet.FleetReader;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecificationImpl;
 import org.matsim.contrib.dvrp.fleet.Fleets;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -35,7 +34,6 @@ import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.core.config.ConfigGroup;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -63,13 +61,10 @@ public class EvDvrpFleetModule extends AbstractDvrpModeModule {
 					@Inject
 					private ElectricFleet evFleet;
 
-					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
 					@Override
 					public Fleet get() {
 						FleetSpecification fleetSpecification = getModalInstance(FleetSpecification.class);
+						Network network = getModalInstance(Network.class);
 						return Fleets.createCustomFleet(fleetSpecification, s -> EvDvrpVehicle.create(
 								new DvrpVehicleImpl(s, network.getLinks().get(s.getStartLinkId())), evFleet));
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -27,7 +27,6 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
@@ -49,8 +48,7 @@ import com.google.inject.name.Named;
 
 public class ETaxiScheduler extends TaxiScheduler {
 
-	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, MobsimTimer timer,
+	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility) {
 		super(taxiCfg, fleet, network, timer, travelTime, travelDisutility);
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
@@ -21,7 +21,6 @@ package org.matsim.contrib.etaxi.optimizer;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.etaxi.ETaxiScheduler;
 import org.matsim.contrib.etaxi.optimizer.assignment.AssignmentETaxiOptimizer;
@@ -51,10 +50,10 @@ public class ETaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final ETaxiScheduler eScheduler;
 	private final ChargingInfrastructure chargingInfrastructure;
 
-	public ETaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, MobsimTimer timer,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			ETaxiScheduler eScheduler, ChargingInfrastructure chargingInfrastructure) {
+	public ETaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet, Network network,
+			MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, ETaxiScheduler eScheduler,
+			ChargingInfrastructure chargingInfrastructure) {
 		this.eventsManager = eventsManager;
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeModule.java
@@ -20,7 +20,9 @@
 
 package org.matsim.contrib.etaxi.run;
 
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
@@ -32,6 +34,9 @@ import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -48,6 +53,7 @@ public final class ETaxiModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
@@ -27,7 +27,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -71,10 +70,6 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 
 		addModalComponent(TaxiOptimizer.class, new ModalProviders.AbstractProvider<TaxiOptimizer>(taxiCfg.getMode()) {
 			@Inject
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
-			@Inject
 			private MobsimTimer timer;
 
 			@Inject
@@ -90,6 +85,7 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 			@Override
 			public TaxiOptimizer get() {
 				Fleet fleet = getModalInstance(Fleet.class);
+				Network network = getModalInstance(Network.class);
 				ETaxiScheduler eTaxiScheduler = getModalInstance(ETaxiScheduler.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
@@ -101,10 +97,6 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(ETaxiScheduler.class).toProvider(
 				new ModalProviders.AbstractProvider<ETaxiScheduler>(taxiCfg.getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					private MobsimTimer timer;
 
 					@Inject
@@ -114,6 +106,7 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					@Override
 					public ETaxiScheduler get() {
 						Fleet fleet = getModalInstance(Fleet.class);
+						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
 						return new ETaxiScheduler(taxiCfg, fleet, network, timer, travelTime, travelDisutility);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
@@ -23,7 +23,6 @@ import java.net.URL;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizer;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizerParams;
@@ -55,9 +54,8 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final URL context;
 
 	public DefaultTaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, MobsimTimer timer,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			TaxiScheduler scheduler, URL context) {
+			Network network, MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, TaxiScheduler scheduler, URL context) {
 		this.eventsManager = eventsManager;
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
@@ -20,8 +20,10 @@
 
 package org.matsim.contrib.taxi.run;
 
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
@@ -31,6 +33,9 @@ import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -47,6 +52,7 @@ public final class TaxiModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -28,7 +28,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -71,10 +70,6 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 
 		addModalComponent(TaxiOptimizer.class, new ModalProviders.AbstractProvider<TaxiOptimizer>(taxiCfg.getMode()) {
 			@Inject
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
-			@Inject
 			private MobsimTimer timer;
 
 			@Inject
@@ -87,6 +82,7 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 			@Override
 			public TaxiOptimizer get() {
 				Fleet fleet = getModalInstance(Fleet.class);
+				Network network = getModalInstance(Network.class);
 				TaxiScheduler taxiScheduler = getModalInstance(TaxiScheduler.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
@@ -98,10 +94,6 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(TaxiScheduler.class).toProvider(
 				new ModalProviders.AbstractProvider<TaxiScheduler>(taxiCfg.getMode()) {
 					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Inject
 					private MobsimTimer timer;
 
 					@Inject
@@ -111,6 +103,7 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					@Override
 					public TaxiScheduler get() {
 						Fleet fleet = getModalInstance(Fleet.class);
+						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
 						return new TaxiScheduler(taxiCfg, fleet, network, timer, travelTime, travelDisutility);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -29,7 +29,6 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelDataImpl;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
@@ -67,8 +66,7 @@ public class TaxiScheduler implements TaxiScheduleInquiry {
 	private final TravelTime travelTime;
 	private final LeastCostPathCalculator router;
 
-	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, MobsimTimer timer,
+	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;

--- a/examples/scenarios/dvrp-grid/one_etaxi_benchmark_config.xml
+++ b/examples/scenarios/dvrp-grid/one_etaxi_benchmark_config.xml
@@ -50,7 +50,7 @@
 	</module>
 
 	<module name="controler">
-		<param name="outputDirectory" value="test/output/one_taxi_benchmark"/>
+		<param name="outputDirectory" value="test/output/one_etaxi_benchmark"/>
 		<param name="overwriteFiles" value="deleteDirectoryIfExists"/>
 		<param name="writeEventsInterval" value="0"/>
 		<param name="writePlansInterval" value="0"/>


### PR DESCRIPTION
- Each dvrp mode has its own DvrpMode-annotated network.

- By default, `@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network` is used by dvrp modes:
```
bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
```

Because now the DvrpMode-annotated network is used in code instead, it gives an option to programmatically override the above binding, for instance, to restrict operations of some dvrp modes to a sub-network of the DVRP_ROUTING network.

This is not (yet?) supported via config.