### PR TITLE
add DvrpMode-annotated network

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
@@ -23,12 +23,14 @@ package org.matsim.contrib.dvrp.examples.onetaxi;
 import java.net.URL;
 
 import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.DefaultPassengerRequestValidator;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
@@ -36,7 +38,9 @@ import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynRoutingModule;
 
+import com.google.inject.Key;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -52,7 +56,9 @@ public class OneTaxiModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));
+
 		install(new FleetModule(getMode(), fleetSpecificationUrl));
 		bindModal(PassengerRequestValidator.class).to(DefaultPassengerRequestValidator.class);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
@@ -32,7 +32,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerRequestAcceptedEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestScheduledEvent;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.schedule.DriveTaskImpl;
@@ -50,7 +49,6 @@ import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -68,9 +66,8 @@ final class OneTaxiOptimizer implements VrpOptimizer {
 	private static final double DROPOFF_DURATION = 60;
 
 	@Inject
-	public OneTaxiOptimizer(EventsManager eventsManager,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network, @DvrpMode(TransportMode.taxi) Fleet fleet,
-			MobsimTimer timer) {
+	public OneTaxiOptimizer(EventsManager eventsManager, @DvrpMode(TransportMode.taxi) Network network,
+			@DvrpMode(TransportMode.taxi) Fleet fleet, MobsimTimer timer) {
 		this.eventsManager = eventsManager;
 		this.timer = timer;
 		travelTime = new FreeSpeedTravelTime();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
@@ -24,8 +24,10 @@ import java.net.URL;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
@@ -36,6 +38,7 @@ import org.matsim.vehicles.VehicleCapacityImpl;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
+import com.google.inject.Key;
 import com.google.inject.name.Names;
 
 /**
@@ -52,6 +55,8 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
+		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+
 		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
 				.toInstance(createTruckType());
 		install(new FleetModule(getMode(), fleetSpecificationUrl));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
@@ -30,7 +30,6 @@ import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.schedule.DriveTaskImpl;
@@ -47,7 +46,6 @@ import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -64,8 +62,8 @@ final class OneTruckOptimizer implements VrpOptimizer {
 	private static final double DELIVERY_DURATION = 60;
 
 	@Inject
-	public OneTruckOptimizer(@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			@DvrpMode(TransportMode.truck) Fleet fleet, MobsimTimer timer) {
+	public OneTruckOptimizer(@DvrpMode(TransportMode.truck) Network network, @DvrpMode(TransportMode.truck) Fleet fleet,
+			MobsimTimer timer) {
 		this.timer = timer;
 		travelTime = new FreeSpeedTravelTime();
 		router = new DijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckRequestCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckRequestCreator.java
@@ -30,12 +30,9 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.core.mobsim.framework.events.MobsimAfterSimStepEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimAfterSimStepListener;
-
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -47,7 +44,7 @@ public final class OneTruckRequestCreator implements MobsimAfterSimStepListener 
 
 	@Inject
 	public OneTruckRequestCreator(@DvrpMode(TransportMode.truck) VrpOptimizer optimizer,
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING) Network network) {
+			@DvrpMode(TransportMode.truck) Network network) {
 		this.optimizer = optimizer;
 		requests.addAll(Arrays.asList(createRequest("parcel_0", "114", "349", 0, network),
 				createRequest("parcel_1", "144", "437", 300, network),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -23,14 +23,10 @@ package org.matsim.contrib.dvrp.fleet;
 import java.net.URL;
 
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
-
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -60,17 +56,9 @@ public class FleetModule extends AbstractDvrpModeModule {
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
 			protected void configureQSim() {
-				bindModal(Fleet.class).toProvider(new ModalProviders.AbstractProvider<Fleet>(getMode()) {
-					@Inject
-					@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-					private Network network;
-
-					@Override
-					public Fleet get() {
-						FleetSpecification fleetSpecification = getModalInstance(FleetSpecification.class);
-						return Fleets.createDefaultFleet(fleetSpecification, network.getLinks()::get);
-					}
-				}).asEagerSingleton();
+				bindModal(Fleet.class).toProvider(ModalProviders.createProvider(getMode(),
+						getter -> Fleets.createDefaultFleet(getter.getModal(FleetSpecification.class),
+								getter.getModal(Network.class).getLinks()::get))).asEagerSingleton();
 			}
 		});
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
@@ -4,14 +4,11 @@ import javax.inject.Inject;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
-import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.PreplanningEngine;
-
-import com.google.inject.name.Named;
 
 public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 	public PassengerEngineQSimModule(String mode) {
@@ -33,15 +30,12 @@ public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 			@Inject
 			private PassengerRequestEventToPassengerEngineForwarder passengerRequestEventForwarder;
 
-			@Inject
-			@Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
 			@Override
 			public PassengerEngine get() {
 				return new PassengerEngine(getMode(), eventsManager, mobsimTimer, preplanningEngine,
-						getModalInstance(PassengerRequestCreator.class), getModalInstance(VrpOptimizer.class), network,
-						getModalInstance(PassengerRequestValidator.class), passengerRequestEventForwarder);
+						getModalInstance(PassengerRequestCreator.class), getModalInstance(VrpOptimizer.class),
+						getModalInstance(Network.class), getModalInstance(PassengerRequestValidator.class),
+						passengerRequestEventForwarder);
 			}
 		});
 	}


### PR DESCRIPTION
- Add support for `DvrpMode`-annotated networks to dvrp `Fleet` and `PassengerEngine` (missing in the previous PR #581 ).
- Adapt generic dvrp examples (i.e. non-taxi and non-drt)