### PR TITLE
Dvrp mode subnetworks via config

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -56,6 +56,14 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	static final String MODE_EXP = "Mode which will be handled by PassengerEngine and VrpOptimizer "
 			+ "(passengers'/customers' perspective)";
 
+	public static final String USE_MODE_FILTERED_SUBNETWORK = "useModeFilteredSubnetwork";
+	static final String USE_MODE_FILTERED_SUBNETWORK_EXP =
+			"Limit the operation of vehicles to links (of the 'dvrp_routing'"
+					+ " network) with 'allowedModes' containing this 'mode'."
+					+ " For backward compatibility, the value is set to false by default"
+					+ " -- this means that the vehicles are allowed to operate on all links of the 'dvrp_routing' network."
+					+ " The 'dvrp_routing' is defined by DvrpConfigGroup.networkModes)";
+
 	public static final String STOP_DURATION = "stopDuration";
 	static final String STOP_DURATION_EXP = "Bus stop duration. Must be positive.";
 
@@ -126,6 +134,8 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 	@NotBlank
 	private String mode = TransportMode.drt; // travel mode (passengers'/customers' perspective)
+
+	private boolean useModeFilteredSubnetwork = false;
 
 	@Positive
 	private double stopDuration = Double.NaN;// seconds
@@ -227,6 +237,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
 		map.put(MODE, MODE_EXP);
+		map.put(USE_MODE_FILTERED_SUBNETWORK, USE_MODE_FILTERED_SUBNETWORK_EXP);
 		map.put(STOP_DURATION, STOP_DURATION_EXP);
 		map.put(MAX_WAIT_TIME, MAX_WAIT_TIME_EXP);
 		map.put(MAX_TRAVEL_TIME_ALPHA, MAX_TRAV_ALPHA_EXP);
@@ -261,6 +272,22 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	@StringSetter(MODE)
 	public void setMode(String mode) {
 		this.mode = mode;
+	}
+
+	/**
+	 * @return {@value #USE_MODE_FILTERED_SUBNETWORK_EXP}
+	 */
+	@StringGetter(USE_MODE_FILTERED_SUBNETWORK)
+	public boolean isUseModeFilteredSubnetwork() {
+		return useModeFilteredSubnetwork;
+	}
+
+	/**
+	 * @param useModeFilteredSubnetwork {@value #USE_MODE_FILTERED_SUBNETWORK_EXP}
+	 */
+	@StringSetter(USE_MODE_FILTERED_SUBNETWORK)
+	public void setUseModeFilteredSubnetwork(boolean useModeFilteredSubnetwork) {
+		this.useModeFilteredSubnetwork = useModeFilteredSubnetwork;
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -410,9 +410,8 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	 * @param operationalScheme -- {@value #OP_SCHEME_EXP}
 	 */
 	@StringSetter(OPERATIONAL_SCHEME)
-	public void setOperationalScheme(String operationalScheme) {
-
-		this.operationalScheme = OperationalScheme.valueOf(operationalScheme);
+	public void setOperationalScheme(OperationalScheme operationalScheme) {
+		this.operationalScheme = operationalScheme;
 	}
 
 	/**
@@ -466,7 +465,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	 * @param-- {@value #ESTIMATED_DRT_SPEED_EXP}
 	 */
 	@StringSetter(ESTIMATED_DRT_SPEED)
-	public void setEstimatedSpeed(double estimatedSpeed) {
+	public void setEstimatedDrtSpeed(double estimatedSpeed) {
 		this.estimatedDrtSpeed = estimatedSpeed;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
@@ -230,6 +231,11 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 		}
 		if (getParameterSets(MinCostFlowRebalancingParams.SET_NAME).size() > 1) {
 			throw new RuntimeException("More then one rebalancing parameter sets is specified");
+		}
+
+		if (useModeFilteredSubnetwork) {
+			DvrpRoutingNetworkProvider.
+					checkUseModeFilteredSubnetworkAllowed(config, mode);
 		}
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -54,9 +54,7 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 import com.google.inject.Inject;
-import com.google.inject.Key;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -73,7 +71,8 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(),
+				drtCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new FleetModule(getMode(), drtCfg.getVehiclesFileUrl(getConfig().getContext()),

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeModule.java
@@ -55,9 +55,7 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 import com.google.inject.Inject;
-import com.google.inject.Key;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -74,7 +72,8 @@ public final class EDrtModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(),
+				drtCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new EvDvrpFleetModule(getMode(), drtCfg.getVehiclesFile()));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkConfigConsistencyChecker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkConfigConsistencyChecker.java
@@ -45,7 +45,7 @@ public class DvrpBenchmarkConfigConsistencyChecker implements ConfigConsistencyC
 			log.warn("StorageCapFactor should be large enough (e.g. 100) to obtain deterministic (fixed) travel times");
 		}
 
-		if (config.network().isTimeVariantNetwork() && DvrpConfigGroup.get(config).getNetworkMode() != null) {
+		if (config.network().isTimeVariantNetwork() && !DvrpConfigGroup.get(config).getNetworkModes().isEmpty()) {
 			throw new RuntimeException("The current version of RunTaxiBenchmark does not support this case: "
 					+ "@Named(DvrpModule.DVRP_ROUTING) Network would consist of links having "
 					+ "VariableIntervalTimeVariantAttributes instead of FixedIntervalTimeVariantAttributes.");

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
@@ -23,7 +23,6 @@ package org.matsim.contrib.dvrp.examples.onetaxi;
 import java.net.URL;
 
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.DefaultPassengerRequestValidator;
@@ -38,9 +37,7 @@ import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynRoutingModule;
 
-import com.google.inject.Key;
 import com.google.inject.Singleton;
-import com.google.inject.name.Names;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -56,7 +53,7 @@ public class OneTaxiModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(), false));
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));
 
 		install(new FleetModule(getMode(), fleetSpecificationUrl));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
@@ -24,7 +24,6 @@ import java.net.URL;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
@@ -38,7 +37,6 @@ import org.matsim.vehicles.VehicleCapacityImpl;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
-import com.google.inject.Key;
 import com.google.inject.name.Names;
 
 /**
@@ -55,7 +53,7 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(), false));
 
 		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
 				.toInstance(createTruckType());

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingNetworkProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingNetworkProvider.java
@@ -51,13 +51,13 @@ public class DvrpRoutingNetworkProvider implements Provider<Network> {
 
 	@Override
 	public Network get() {
-		if (dvrpCfg.getNetworkMode() == null) { // no mode filtering
+		if (dvrpCfg.getNetworkModes().isEmpty()) { // no mode filtering
 			return network;
+		} else {
+			Network dvrpNetwork = NetworkUtils.createNetwork();
+			new TransportModeNetworkFilter(network).filter(dvrpNetwork, dvrpCfg.getNetworkModes());
+			return dvrpNetwork;
 		}
-
-		Network dvrpNetwork = NetworkUtils.createNetwork();
-		new TransportModeNetworkFilter(network).filter(dvrpNetwork, Collections.singleton(dvrpCfg.getNetworkMode()));
-		return dvrpNetwork;
 	}
 
 	public static AbstractDvrpModeModule createDvrpModeRoutingNetworkModule(String mode,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingNetworkProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingNetworkProvider.java
@@ -19,6 +19,7 @@
 package org.matsim.contrib.dvrp.router;
 
 import java.util.Collections;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -27,6 +28,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.config.Config;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.algorithms.NetworkCleaner;
 import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
@@ -66,6 +68,7 @@ public class DvrpRoutingNetworkProvider implements Provider<Network> {
 			@Override
 			public void install() {
 				if (useModeFilteredSubnetwork) {
+					checkUseModeFilteredSubnetworkAllowed(getConfig(), getMode());
 					bindModal(Network.class).toProvider(ModalProviders.createProvider(getMode(), getter -> {
 						Network subnetwork = NetworkUtils.createNetwork();
 						new TransportModeNetworkFilter(
@@ -80,5 +83,14 @@ public class DvrpRoutingNetworkProvider implements Provider<Network> {
 				}
 			}
 		};
+	}
+
+	public static void checkUseModeFilteredSubnetworkAllowed(Config config, String mode) {
+		Set<String> dvrpNetworkModes = DvrpConfigGroup.get(config).getNetworkModes();
+		if (!dvrpNetworkModes.isEmpty() && !dvrpNetworkModes.contains(mode)) {
+			throw new RuntimeException("DvrpConfigGroup.networkModes must contain DVRP mode: "
+					+ mode
+					+ " when 'useModeFilteredSubnetwork' is enabled for this mode");
+		}
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeModule.java
@@ -20,7 +20,6 @@
 
 package org.matsim.contrib.etaxi.run;
 
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
@@ -34,9 +33,6 @@ import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
-
-import com.google.inject.Key;
-import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -53,7 +49,8 @@ public final class ETaxiModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(),
+				taxiCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
@@ -50,6 +50,8 @@ import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * For a fair and consistent benchmarking of taxi dispatching algorithms we assume that link travel times are
  * deterministic. To simulate this property, we remove (1) all other traffic, and (2) link capacity constraints (e.g. by
@@ -76,7 +78,7 @@ public class RunETaxiBenchmark {
 		config.controler().setWritePlansInterval(0);
 		config.controler().setCreateGraphs(false);
 
-		DvrpConfigGroup.get(config).setNetworkMode(null);// to switch off network filtering
+		DvrpConfigGroup.get(config).setNetworkModes(ImmutableSet.of());// to switch off network filtering
 		config.addConfigConsistencyChecker(new DvrpBenchmarkConfigConsistencyChecker());
 
 		String mode = TaxiConfigGroup.get(config).getMode();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/benchmark/RunTaxiBenchmark.java
@@ -40,6 +40,8 @@ import org.matsim.core.network.FixedIntervalTimeVariantLinkFactory;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.scenario.ScenarioUtils.ScenarioBuilder;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * For a fair and consistent benchmarking of taxi dispatching algorithms we assume that link travel times are
  * deterministic. To simulate this property, we remove (1) all other traffic, and (2) link capacity constraints (e.g. by
@@ -63,7 +65,7 @@ public class RunTaxiBenchmark {
 		config.controler().setWritePlansInterval(0);
 		config.controler().setCreateGraphs(false);
 
-		DvrpConfigGroup.get(config).setNetworkMode(null);// to switch off network filtering
+		DvrpConfigGroup.get(config).setNetworkModes(ImmutableSet.of());// to switch off network filtering
 		config.addConfigConsistencyChecker(new DvrpBenchmarkConfigConsistencyChecker());
 
 		String mode = TaxiConfigGroup.get(config).getMode();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -48,6 +48,14 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	static final String MODE_EXP = "Mode which will be handled by PassengerEngine and VrpOptimizer "
 			+ "(passengers'/customers' perspective)";
 
+	public static final String USE_MODE_FILTERED_SUBNETWORK = "useModeFilteredSubnetwork";
+	static final String USE_MODE_FILTERED_SUBNETWORK_EXP =
+			"Limit the operation of vehicles to links (of the 'dvrp_routing'"
+					+ " network) with 'allowedModes' containing this 'mode'."
+					+ " For backward compatibility, the value is set to false by default"
+					+ " -- this means that the vehicles are allowed to operate on all links of the 'dvrp_routing' network."
+					+ " The 'dvrp_routing' is defined by DvrpConfigGroup.networkModes)";
+
 	public static final String DESTINATION_KNOWN = "destinationKnown";
 	static final String DESTINATION_KNOWN_EXP =
 			"If false, the drop-off location remains unknown to the optimizer and scheduler"
@@ -107,6 +115,8 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@NotBlank
 	private String mode = TransportMode.taxi; // travel mode (passengers'/customers' perspective)
 
+	private boolean useModeFilteredSubnetwork = false;
+
 	private boolean destinationKnown = false;
 	private boolean vehicleDiversion = false;
 
@@ -162,6 +172,7 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
 		map.put(MODE, MODE_EXP);
+		map.put(USE_MODE_FILTERED_SUBNETWORK, USE_MODE_FILTERED_SUBNETWORK_EXP);
 		map.put(DESTINATION_KNOWN, DESTINATION_KNOWN_EXP);
 		map.put(VEHICLE_DIVERSION, VEHICLE_DIVERSION_EXP);
 		map.put(PICKUP_DURATION, PICKUP_DURATION_EXP);
@@ -193,6 +204,22 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@StringSetter(MODE)
 	public void setMode(String mode) {
 		this.mode = mode;
+	}
+
+	/**
+	 * @return {@value #USE_MODE_FILTERED_SUBNETWORK_EXP}
+	 */
+	@StringGetter(USE_MODE_FILTERED_SUBNETWORK)
+	public boolean isUseModeFilteredSubnetwork() {
+		return useModeFilteredSubnetwork;
+	}
+
+	/**
+	 * @param useModeFilteredSubnetwork {@value #USE_MODE_FILTERED_SUBNETWORK_EXP}
+	 */
+	@StringSetter(USE_MODE_FILTERED_SUBNETWORK)
+	public void setUseModeFilteredSubnetwork(boolean useModeFilteredSubnetwork) {
+		this.useModeFilteredSubnetwork = useModeFilteredSubnetwork;
 	}
 
 	/**

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -29,6 +29,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 
 import org.matsim.api.core.v01.TransportMode;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.DefaultTaxiOptimizerProvider;
@@ -165,6 +166,11 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 		if (isVehicleDiversion() && !isOnlineVehicleTracker()) {
 			throw new RuntimeException(
 					TaxiConfigGroup.VEHICLE_DIVERSION + " requires " + TaxiConfigGroup.ONLINE_VEHICLE_TRACKER);
+		}
+
+		if (useModeFilteredSubnetwork) {
+			DvrpRoutingNetworkProvider.
+					checkUseModeFilteredSubnetworkAllowed(config, mode);
 		}
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
@@ -20,7 +20,6 @@
 
 package org.matsim.contrib.taxi.run;
 
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
@@ -33,9 +32,6 @@ import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
-
-import com.google.inject.Key;
-import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -52,7 +48,8 @@ public final class TaxiModeModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
-		bindModal(Network.class).to(Key.get(Network.class, Names.named(DvrpRoutingNetworkProvider.DVRP_ROUTING)));
+		install(DvrpRoutingNetworkProvider.createDvrpModeRoutingNetworkModule(getMode(),
+				taxiCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		addRoutingModuleBinding(getMode()).toInstance(new DynRoutingModule(getMode()));


### PR DESCRIPTION
Example:
```
dvrpCfg.networkModes = "drt1,drt2"; // in the past, only one mode allowed here, now we have a set

drtCfg1.mode = "drt1";
drtCfg1.useModeFilteredSubnetwork = true; //new param

drtCfg2.mode = "drt2";
drtCfg2.useModeFilteredSubnetwork = true; //new param

taxiCfg.mode = "taxi";
taxiCfg.useModeFilteredSubnetwork = false; //new param
```
The DVRP network will consists of links with modes: "drt1" and/or "drt2"
Mode "drt1" will use a subnetwork of links with the mode "drt1"
Mode "drt2" will use a subnetwork of links with the mode "drt2"
Mode "taxi" will use the DVRP network. (no filtering)

====

For backward compatibility, the defaults for taxi and drt are: `useModeFilteredSubnetwork = false`
