### PR TITLE
Update JFreeChart to version 1.5.0

### DIFF
--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunner.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunner.java
@@ -23,7 +23,7 @@
 package org.matsim.contrib.analysis.vsp.traveltimedistance;
 
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.annotations.XYAnnotation;
 import org.jfree.chart.annotations.XYLineAnnotation;
@@ -156,8 +156,8 @@ public class TravelTimeValidationRunner {
 			           yAxisd.getRange().getUpperBound());
 			((XYPlot) chart.getPlot()).addAnnotation(diagonald);
 			
-			ChartUtilities.writeChartAsPNG(new FileOutputStream(folder+"/validated_traveltimes" + ".png"), chart2, 1500, 1500);
-			ChartUtilities.writeChartAsPNG(new FileOutputStream(folder+"/validated_traveldistances.png"), chart, 1500, 1500);
+			ChartUtils.writeChartAsPNG(new FileOutputStream(folder+"/validated_traveltimes" + ".png"), chart2, 1500, 1500);
+			ChartUtils.writeChartAsPNG(new FileOutputStream(folder+"/validated_traveldistances.png"), chart, 1500, 1500);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtRequestAnalyzer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtRequestAnalyzer.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.data.xy.XYSeries;
 import org.matsim.api.core.v01.Coord;
@@ -173,7 +173,7 @@ public class DrtRequestAnalyzer implements PassengerRequestRejectedEventHandler,
 						"Initially planned wait time [s]", times, Pair.of(0., drtCfg.getMaxWaitTime()));
 				//			xAxis.setLowerBound(0);
 				//			yAxis.setLowerBound(0);
-				ChartUtilities.writeChartAsPNG(new FileOutputStream(plotFileName), chart2, 1500, 1500);
+				ChartUtils.writeChartAsPNG(new FileOutputStream(plotFileName), chart2, 1500, 1500);
 			}
 		} catch (IOException e) {
 			throw new RuntimeException(e);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/chart/RouteCharts.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/chart/RouteCharts.java
@@ -75,7 +75,7 @@ public class RouteCharts {
 		renderer.setSeriesLinesVisible(0, false);
 		renderer.setSeriesItemLabelsVisible(0, true);
 
-		renderer.setBaseItemLabelGenerator(new XYItemLabelGenerator() {
+		renderer.setDefaultItemLabelGenerator(new XYItemLabelGenerator() {
 			public String generateLabel(XYDataset dataset, int series, int item) {
 				return ((CoordDataset)dataset).getText(series, item);
 			}
@@ -117,7 +117,7 @@ public class RouteCharts {
 		renderer.setSeriesLinesVisible(0, false);
 		renderer.setSeriesItemLabelsVisible(0, true);
 
-		renderer.setBaseItemLabelGenerator(new LabelGenerator());
+		renderer.setDefaultItemLabelGenerator(new LabelGenerator());
 
 		Paint[] paints = DefaultDrawingSupplier.DEFAULT_PAINT_SEQUENCE;
 		Shape[] shapes = DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/chart/ScheduleCharts.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/chart/ScheduleCharts.java
@@ -110,7 +110,7 @@ public class ScheduleCharts {
 			setShadowVisible(false);
 			setDrawBarOutline(true);
 
-			setBaseToolTipGenerator(new XYToolTipGenerator() {
+			setDefaultToolTipGenerator(new XYToolTipGenerator() {
 				@Override
 				public String generateToolTip(XYDataset dataset, int series, int item) {
 					return getTask(series, item).getDescription();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/chart/ChartSaveUtils.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/chart/ChartSaveUtils.java
@@ -10,7 +10,7 @@ import org.jfree.chart.*;
 public class ChartSaveUtils {
 	public static void saveAsPNG(JFreeChart chart, String filename, int width, int height) {
 		try {
-			ChartUtilities.writeChartAsPNG(new FileOutputStream(filename + ".png"), chart, width, height);
+			ChartUtils.writeChartAsPNG(new FileOutputStream(filename + ".png"), chart, width, height);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -84,6 +84,12 @@
 		    <groupId>com.graphhopper</groupId>
 		    <artifactId>jsprit-analysis</artifactId>
 	    	<version>1.7.2</version>
+	    	<exclusions>
+				<exclusion>
+					<groupId>org.jfree</groupId>
+					<artifactId>jfreechart</artifactId>
+				</exclusion>
+	    	</exclusions>
 		</dependency>
 	
 		<dependency>

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/analysis/LegHistogram.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/analysis/LegHistogram.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -364,7 +364,7 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 	 */
 	public void writeGraphic(final String filename) {
 		try {
-			ChartUtilities.saveChartAsPNG(new File(filename), getGraphic(), 1024, 768);
+			ChartUtils.saveChartAsPNG(new File(filename), getGraphic(), 1024, 768);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -382,7 +382,7 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 	 */
 	public void writeGraphic(final String filename, final String legMode) {
 		try {
-			ChartUtilities.saveChartAsPNG(new File(filename), getGraphic(legMode), 1024, 768);
+			ChartUtils.saveChartAsPNG(new File(filename), getGraphic(legMode), 1024, 768);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
+++ b/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.log4j.Logger;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.AxisLocation;
 import org.jfree.chart.axis.NumberAxis;
@@ -595,7 +595,7 @@ public class CreateAutomatedFDTest {
 		JFreeChart chart = new JFreeChart("Fundamental diagrams", JFreeChart.DEFAULT_TITLE_FONT, plot, true);
 
 		try {
-			ChartUtilities.saveChartAsPNG(new File(outFile), chart, 800, 600);
+			ChartUtils.saveChartAsPNG(new File(outFile), chart, 800, 600);
 		} catch (IOException e) {
 			throw new RuntimeException("Data is not plotted. Reason "+e);
 		}

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingchoice/PC2/analysis/ParkingGroupOccupancies.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingchoice/PC2/analysis/ParkingGroupOccupancies.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.PlotOrientation;
@@ -96,7 +96,7 @@ public abstract class ParkingGroupOccupancies implements BasicEventHandler {
 	public void savePlot(String fileName) {
 		final JFreeChart chart = LineChart.createChart(xySeriesCollection, "Parking Group Occupancies");
 		try {
-			ChartUtilities.saveChartAsPNG(new File(fileName), chart,  800, 600, null, true, 9);
+			ChartUtils.saveChartAsPNG(new File(fileName), chart,  800, 600, null, true, 9);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingchoice/lib/GeneralLib.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingchoice/lib/GeneralLib.java
@@ -41,7 +41,7 @@ import java.util.StringTokenizer;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.PlotOrientation;
@@ -503,7 +503,7 @@ public class GeneralLib {
 		int width = 500;
 		int height = 300;
 		try {
-			ChartUtilities.saveChartAsPNG(new File(fileName), chart, width,
+			ChartUtils.saveChartAsPNG(new File(fileName), chart, width,
 					height);
 		} catch (IOException e) {
 
@@ -548,7 +548,7 @@ public class GeneralLib {
 		int height = 300;
 
 		try {
-			ChartUtilities.saveChartAsPNG(new File(fileName), chart, width,
+			ChartUtils.saveChartAsPNG(new File(fileName), chart, width,
 					height);
 		} catch (IOException e) {
 

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/analysis/CourtesyHistogramListener.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/analysis/CourtesyHistogramListener.java
@@ -21,7 +21,7 @@ package org.matsim.contrib.socnetsim.usage.analysis;
 import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -127,7 +127,7 @@ public class CourtesyHistogramListener  implements IterationEndsListener, Iterat
 
 	public static void writeGraphic(CourtesyHistogram courtesyHistogram, final String actType, final String filename) {
 		try {
-            ChartUtilities.saveChartAsPNG(
+            ChartUtils.saveChartAsPNG(
 					new File(filename),
 					getGraphic(
 							courtesyHistogram.getDataFrames().get( actType ),

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -354,7 +354,7 @@
 		<dependency>
 			<groupId>org.jfree</groupId>
 			<artifactId>jfreechart</artifactId>
-			<version>1.0.19</version>
+			<version>1.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -383,7 +383,7 @@
 		<dependency>
 			<groupId>org.jfree</groupId>
 			<artifactId>jcommon</artifactId>
-			<version>1.0.23</version>
+			<version>1.0.24</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>

--- a/matsim/src/main/java/org/matsim/analysis/LegHistogramChart.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogramChart.java
@@ -23,7 +23,7 @@
 package org.matsim.analysis;
 
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -92,7 +92,7 @@ public class LegHistogramChart {
 	 */
 	public static void writeGraphic(LegHistogram legHistogram, final String filename) {
 		try {
-            ChartUtilities.saveChartAsPNG(new File(filename), getGraphic(legHistogram.getAllModesData(), "all", legHistogram.getIteration()), 1024, 768);
+            ChartUtils.saveChartAsPNG(new File(filename), getGraphic(legHistogram.getAllModesData(), "all", legHistogram.getIteration()), 1024, 768);
 		} catch (IOException e) {
             throw new UncheckedIOException(e);
 		}
@@ -110,7 +110,7 @@ public class LegHistogramChart {
 	 */
 	public static void writeGraphic(LegHistogram legHistogram, final String filename, final String legMode) {
 		try {
-            ChartUtilities.saveChartAsPNG(new File(filename), getGraphic(legHistogram.getDataForMode(legMode), legMode, legHistogram.getIteration()), 1024, 768);
+			ChartUtils.saveChartAsPNG(new File(filename), getGraphic(legHistogram.getDataForMode(legMode), legMode, legHistogram.getIteration()), 1024, 768);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/matsim/src/main/java/org/matsim/core/utils/charts/ChartUtil.java
+++ b/matsim/src/main/java/org/matsim/core/utils/charts/ChartUtil.java
@@ -25,13 +25,13 @@ import java.awt.Image;
 import java.io.File;
 import java.io.IOException;
 
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.title.ImageTitle;
 import org.jfree.chart.title.Title;
-import org.jfree.ui.HorizontalAlignment;
-import org.jfree.ui.RectangleEdge;
-import org.jfree.ui.VerticalAlignment;
+import org.jfree.chart.ui.HorizontalAlignment;
+import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.chart.ui.VerticalAlignment;
 import org.matsim.core.gbl.MatsimResource;
 
 /**
@@ -64,7 +64,7 @@ public abstract class ChartUtil {
 	 */
 	public void saveAsPng(final String filename, final int width, final int height) {
 		try {
-			ChartUtilities.saveChartAsPNG(new File(filename), getChart(), width, height, null, true, 9);
+			ChartUtils.saveChartAsPNG(new File(filename), getChart(), width, height, null, true, 9);
 		} catch (IOException e) {
 			e.printStackTrace();
 		} catch ( Exception e ) {

--- a/matsim/src/main/java/org/matsim/counts/algorithms/CountSimComparisonKMLWriter.java
+++ b/matsim/src/main/java/org/matsim/counts/algorithms/CountSimComparisonKMLWriter.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -828,7 +828,7 @@ public class CountSimComparisonKMLWriter<T> extends CountSimComparisonWriter {
 	 */
 	private void writeChartToKmz(final String filename, final JFreeChart chart) throws IOException {
 		byte [] img;
-		img = ChartUtilities.encodeAsPNG(chart.createBufferedImage(CHARTWIDTH, CHARTHEIGHT));
+		img = ChartUtils.encodeAsPNG(chart.createBufferedImage(CHARTWIDTH, CHARTHEIGHT));
 		this.writer.addNonKMLFile(img, filename);
 	}
 

--- a/matsim/src/main/java/org/matsim/counts/algorithms/graphs/CountsSimReal24Graph.java
+++ b/matsim/src/main/java/org/matsim/counts/algorithms/graphs/CountsSimReal24Graph.java
@@ -149,7 +149,7 @@ public final class CountsSimReal24Graph extends CountsGraph{
 
 		//regular values
 		XYLineAndShapeRenderer renderer = new XYLineAndShapeRenderer();
-		renderer.setLinesVisible(false);
+		renderer.setDefaultLinesVisible(false);
 		renderer.setURLGenerator(url_gen);
 		renderer.setSeriesPaint(0, Color.black);
 		renderer.setSeriesToolTipGenerator(0, tt_gen);
@@ -157,7 +157,7 @@ public final class CountsSimReal24Graph extends CountsGraph{
 		
 		//outliers
 		XYLineAndShapeRenderer renderer2 = new XYLineAndShapeRenderer();
-		renderer2.setLinesVisible(false);
+		renderer2.setDefaultLinesVisible(false);
 		renderer2.setSeriesPaint(0, Color.red);
 		renderer2.setSeriesShape(0, new Ellipse2D.Double(-3.0, -3.0, 6.0, 6.0));
 	
@@ -169,11 +169,11 @@ public final class CountsSimReal24Graph extends CountsGraph{
 		dataset1.addSeries("f05x", new double[][] {{200.0, maxCountValue},{100.0, 0.5*maxCountValue}});
 		
 		XYLineAndShapeRenderer renderer3 = new XYLineAndShapeRenderer();
-		renderer3.setShapesVisible(false);
+		renderer3.setDefaultShapesVisible(false);
 		renderer3.setSeriesPaint(0, Color.blue);
 		renderer3.setSeriesPaint(1, Color.blue);
 		renderer3.setSeriesPaint(2, Color.blue);
-		renderer3.setBaseSeriesVisibleInLegend(false);		
+		renderer3.setDefaultSeriesVisibleInLegend(false);		
 		renderer3.setSeriesItemLabelsVisible(0, true);
 		renderer3.setSeriesItemLabelsVisible(1, false);
 		renderer3.setSeriesItemLabelsVisible(2, false);

--- a/matsim/src/main/java/org/matsim/counts/algorithms/graphs/CountsSimRealPerHourGraph.java
+++ b/matsim/src/main/java/org/matsim/counts/algorithms/graphs/CountsSimRealPerHourGraph.java
@@ -148,7 +148,7 @@ public final class CountsSimRealPerHourGraph extends CountsGraph{
 
 		//regular values
 		XYLineAndShapeRenderer renderer = new XYLineAndShapeRenderer();
-		renderer.setLinesVisible(false);
+		renderer.setDefaultLinesVisible(false);
 		renderer.setURLGenerator(url_gen);
 		renderer.setSeriesPaint(0, Color.black);
 		renderer.setSeriesToolTipGenerator(0, tt_gen);
@@ -158,7 +158,7 @@ public final class CountsSimRealPerHourGraph extends CountsGraph{
 		
 		//outliers
 		XYLineAndShapeRenderer renderer2 = new XYLineAndShapeRenderer();
-		renderer2.setLinesVisible(false);
+		renderer2.setDefaultLinesVisible(false);
 		renderer2.setSeriesPaint(0, Color.red);
 		renderer2.setSeriesShape(0, new Ellipse2D.Double(-3.0, -3.0, 6.0, 6.0));
 
@@ -171,11 +171,11 @@ public final class CountsSimRealPerHourGraph extends CountsGraph{
 		dataset1.addSeries("f05x", new double[][] {{2.0, 10000.0},{1.0, 5000.0}});
 		
 		XYLineAndShapeRenderer renderer3 = new XYLineAndShapeRenderer();
-		renderer3.setShapesVisible(false);
+		renderer3.setDefaultShapesVisible(false);
 		renderer3.setSeriesPaint(0, Color.blue);
 		renderer3.setSeriesPaint(1, Color.blue);
 		renderer3.setSeriesPaint(2, Color.blue);
-		renderer3.setBaseSeriesVisibleInLegend(false);		
+		renderer3.setDefaultSeriesVisibleInLegend(false);		
 		renderer3.setSeriesItemLabelsVisible(0, true);
 		renderer3.setSeriesItemLabelsVisible(1, false);
 		renderer3.setSeriesItemLabelsVisible(2, false);

--- a/matsim/src/main/java/org/matsim/counts/algorithms/graphs/helper/OutputDelegate.java
+++ b/matsim/src/main/java/org/matsim/counts/algorithms/graphs/helper/OutputDelegate.java
@@ -21,7 +21,7 @@
 package org.matsim.counts.algorithms.graphs.helper;
 
 import org.jfree.chart.ChartRenderingInfo;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.entity.StandardEntityCollection;
 import org.matsim.core.gbl.MatsimResource;
@@ -114,7 +114,7 @@ public class OutputDelegate {
 			if (!indexFile){
 				 info = new ChartRenderingInfo(new StandardEntityCollection());
 				 file1 = new File(iter_path+"/png/"+fileName+".png");
-				ChartUtilities.saveChartAsPNG(file1, chart, width, height, info);
+				 ChartUtils.saveChartAsPNG(file1, chart, width, height, info);
 			}
 
 			writer = new PrintWriter(new BufferedOutputStream(new FileOutputStream(file2)));
@@ -171,7 +171,7 @@ public class OutputDelegate {
 			writer.println("<div id=\"contents\">");
 			writer.println("<p>");
 			if (!indexFile) {
-				ChartUtilities.writeImageMap(writer, "chart", info, true);
+				ChartUtils.writeImageMap(writer, "chart", info, true);
 
 				/*
 	        	chart=cg.getChart();

--- a/matsim/src/main/java/org/matsim/pt/analysis/RouteTimeDiagram.java
+++ b/matsim/src/main/java/org/matsim/pt/analysis/RouteTimeDiagram.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.plot.XYPlot;
@@ -151,7 +151,7 @@ public class RouteTimeDiagram implements VehicleArrivesAtFacilityEventHandler, V
 		}
 
 		try {
-			ChartUtilities.saveChartAsPNG(new File(filename), c, 1024, 768, null, true, 9);
+			ChartUtils.saveChartAsPNG(new File(filename), c, 1024, 768, null, true, 9);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/matsim/src/main/java/org/matsim/pt/counts/obsolete/PtCountSimComparisonKMLWriter.java
+++ b/matsim/src/main/java/org/matsim/pt/counts/obsolete/PtCountSimComparisonKMLWriter.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -765,7 +765,7 @@ public final class PtCountSimComparisonKMLWriter extends PtCountSimComparisonWri
 	private void writeChartToKmz(final String filename, final JFreeChart chart)
 			throws IOException {
 		byte[] img;
-		img = ChartUtilities.encodeAsPNG(chart.createBufferedImage(CHARTWIDTH,
+		img = ChartUtils.encodeAsPNG(chart.createBufferedImage(CHARTWIDTH,
 				CHARTHEIGHT));
 		this.writer.addNonKMLFile(img, filename);
 	}

--- a/matsim/src/main/java/org/matsim/pt/counts/obsolete/PtCountsSimRealPerHourGraph.java
+++ b/matsim/src/main/java/org/matsim/pt/counts/obsolete/PtCountsSimRealPerHourGraph.java
@@ -160,7 +160,7 @@ public final class PtCountsSimRealPerHourGraph extends CountsGraph {
 
 		// regular values
 		XYLineAndShapeRenderer renderer = new XYLineAndShapeRenderer();
-		renderer.setLinesVisible(false);
+		renderer.setDefaultLinesVisible(false);
 		renderer.setURLGenerator(url_gen);
 		renderer.setSeriesPaint(0, Color.black);
 		renderer.setSeriesToolTipGenerator(0, tt_gen);
@@ -169,7 +169,7 @@ public final class PtCountsSimRealPerHourGraph extends CountsGraph {
 
 		// outliers
 		XYLineAndShapeRenderer renderer2 = new XYLineAndShapeRenderer();
-		renderer2.setLinesVisible(false);
+		renderer2.setDefaultLinesVisible(false);
 		renderer2.setSeriesPaint(0, Color.red);
 		renderer2.setSeriesShape(0, new Ellipse2D.Double(-3.0, -3.0, 6.0, 6.0));
 
@@ -183,11 +183,11 @@ public final class PtCountsSimRealPerHourGraph extends CountsGraph {
 				{ 1.0, 5000.0 } });
 
 		XYLineAndShapeRenderer renderer3 = new XYLineAndShapeRenderer();
-		renderer3.setShapesVisible(false);
+		renderer3.setDefaultShapesVisible(false);
 		renderer3.setSeriesPaint(0, Color.blue);
 		renderer3.setSeriesPaint(1, Color.blue);
 		renderer3.setSeriesPaint(2, Color.blue);
-		renderer3.setBaseSeriesVisibleInLegend(false);
+		renderer3.setDefaultSeriesVisibleInLegend(false);
 		renderer3.setSeriesItemLabelsVisible(0, true);
 		renderer3.setSeriesItemLabelsVisible(1, false);
 		renderer3.setSeriesItemLabelsVisible(2, false);


### PR DESCRIPTION
There are a couple of features missing in the old JFreeChart from 2014. This PR updates the version to current 1.5.0 from 2017.

@kainagel, @mrieser, @tduberne, @michalmac  This may probably have impact on third-party analysis tools. Do you think it is good to merge?

Some guidelines for fixing code after the update:
- Function calls containing the keyword `Base` or which have a general purpose have been transformed to `Default`, e.g. `setLinesVisible` -> `setDefaultLinesVisible`
- `ChartUtilities` was renamed to `ChartUtils`