### PR TITLE
Http downloads from the SVN server will be forbidden according to jwilk

### DIFF
--- a/matsim/src/test/java/org/matsim/other/DownloadAndReadXmlTest.java
+++ b/matsim/src/test/java/org/matsim/other/DownloadAndReadXmlTest.java
@@ -41,7 +41,11 @@ public class DownloadAndReadXmlTest {
 	
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils();
 
+	@Ignore
 	@Test
+	/**
+	 * Http downloads from the SVN server will be forbidden soon, according to jwilk.
+	 */
 	public final void testHttpFromSvn() {
 		
 		Config config = ConfigUtils.createConfig();


### PR DESCRIPTION
currently the http download from vsp public SVN doesn't work (re-directs, java does not accept re-directing), jwilk said he will forbid it anyway in the future

ignore http test