### PR TITLE
replace file access with URL instead of String/filename.

### DIFF
--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeUsingTollFactor.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeUsingTollFactor.java
@@ -20,11 +20,6 @@
 
 package org.matsim.contrib.roadpricing;
 
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -32,6 +27,11 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.roadpricing.RoadPricingSchemeImpl.Cost;
 import org.matsim.vehicles.Vehicle;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author nagel

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeUsingTollFactor.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeUsingTollFactor.java
@@ -59,14 +59,13 @@ public final class RoadPricingSchemeUsingTollFactor implements RoadPricingScheme
 	 * @param tollFactor the implementation instance of toll factors.
 	 * @param scenario
 	 */
-	private RoadPricingSchemeUsingTollFactor( String pricingSchemeFileName, TollFactor tollFactor, Scenario scenario ) {
+	private RoadPricingSchemeUsingTollFactor(URL pricingSchemeFileName, TollFactor tollFactor, Scenario scenario ) {
 
 		// read the road pricing scheme from file
 		RoadPricingSchemeImpl scheme = RoadPricingUtils.createAndRegisterMutableScheme(scenario );
 		RoadPricingReaderXMLv1 rpReader = new RoadPricingReaderXMLv1(scheme);
-		System.out.println(new File(pricingSchemeFileName).getAbsolutePath());
 		try {
-			rpReader.readFile(pricingSchemeFileName);
+			rpReader.readURL(pricingSchemeFileName);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -75,8 +74,8 @@ public final class RoadPricingSchemeUsingTollFactor implements RoadPricingScheme
 
 	}
 
-	public static void createAndRegisterRoadPricingSchemeUsingTollFactor( String pricingSchemeFileName, TollFactor tollFactor,
-																	  Scenario scenario ){
+	public static void createAndRegisterRoadPricingSchemeUsingTollFactor(URL pricingSchemeFileName, TollFactor tollFactor,
+																																			 Scenario scenario ){
 		new RoadPricingSchemeUsingTollFactor( pricingSchemeFileName, tollFactor, scenario );
 		// yy todo: inline constructor. kai, jul'19
 	}

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/run/RunRoadPricingUsingTollFactorExample.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/run/RunRoadPricingUsingTollFactorExample.java
@@ -70,7 +70,7 @@ public class RunRoadPricingUsingTollFactorExample {
 
 		// instantiate the road pricing scheme, with the toll factor inserted:
 		URL roadpricingUrl = IOUtils.newUrl(config.getContext(), rpConfig.getTollLinksFile());
-		RoadPricingSchemeUsingTollFactor.createAndRegisterRoadPricingSchemeUsingTollFactor(roadpricingUrl.getFile(), tollFactor, scenario );
+		RoadPricingSchemeUsingTollFactor.createAndRegisterRoadPricingSchemeUsingTollFactor(roadpricingUrl, tollFactor, scenario );
 
 
 		// instantiate the control(l)er:


### PR DESCRIPTION
URL.getFile() does not return a valid path to a file in the filesystem, but returns the filename-part of the URL. That filename-part uses a special encoding for certain characters (e.g. a whitespace is encoded as %20) which is only valid in URLs, but not in the local filesystem. Thus file-access in the local filesystem might file when using URL.getFile() when the path or filename contains whitespace or other special characters. Fix this by changing the file access to use the URLs instead of the filename-Strings.