### PR TITLE
fix integration tests

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExamplewithLTHConsumptionModel.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExamplewithLTHConsumptionModel.java
@@ -85,8 +85,8 @@ public class RunEvExamplewithLTHConsumptionModel {
 
 		VehicleTypeSpecificDriveEnergyConsumptionFactory driveEnergyConsumptionFactory = new VehicleTypeSpecificDriveEnergyConsumptionFactory();
 		driveEnergyConsumptionFactory.addEnergyConsumptionModelFactory("defaultVehicleType",
-				new LTHConsumptionModelReader(Id.create("defaultVehicleType", VehicleType.class)).readFile(
-						ConfigGroup.getInputFileURL(config.getContext(), "MidCarMap.csv").getFile()));
+				new LTHConsumptionModelReader(Id.create("defaultVehicleType", VehicleType.class)).readURL(
+						ConfigGroup.getInputFileURL(config.getContext(), "MidCarMap.csv")));
 
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new EvModule());

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/LTHConsumptionModelReader.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/LTHConsumptionModelReader.java
@@ -23,9 +23,7 @@ package org.matsim.contrib.ev.infrastructure;/*
  * created by jbischoff, 23.08.2018
  */
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.primitives.Doubles;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.discharging.LTHDriveEnergyConsumption;
 import org.matsim.core.utils.io.tabularFileParser.TabularFileHandler;
@@ -33,7 +31,9 @@ import org.matsim.core.utils.io.tabularFileParser.TabularFileParser;
 import org.matsim.core.utils.io.tabularFileParser.TabularFileParserConfig;
 import org.matsim.vehicles.VehicleType;
 
-import com.google.common.primitives.Doubles;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class reads Energy consumption files from CSV as used in the IDEAS project between TU Berlin and LTH Lund.
@@ -48,12 +48,12 @@ public class LTHConsumptionModelReader {
 		this.vehicleTypeId = vehicleTypeId;
 	}
 
-	public LTHDriveEnergyConsumption.Factory readFile(String filename) {
+	public LTHDriveEnergyConsumption.Factory readURL(URL fileUrl) {
 		List<Double> speeds = new ArrayList<>();
 		List<Double> slopes = new ArrayList<>();
 		TabularFileParserConfig tabularFileParserConfig = new TabularFileParserConfig();
 		tabularFileParserConfig.setDelimiterTags(new String[] { "," });
-		tabularFileParserConfig.setFileName(filename);
+		tabularFileParserConfig.setUrl(fileUrl);
 
 		new TabularFileParser().parse(tabularFileParserConfig, row -> {
 			if (speeds.isEmpty()) {


### PR DESCRIPTION
URL.getFile() does not return a valid path to a file in the filesystem, but returns the filename-part of the URL. That filename-part uses a special encoding for certain characters (e.g. a whitespace is encoded as %20) which is only valid in URLs, but not in the local filesystem. Thus file-access in the local filesystem might file when using URL.getFile() when the path or filename contains whitespace or other special characters. Fix this by changing the file access to use the URLs instead of the filename-Strings.