### PR TITLE
an exception thrown in the finally block prevents that an exception t…

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -255,8 +255,8 @@ public final class QSim extends Thread implements VisMobsim, Netsim, ActivityEnd
 			try {
 				cleanupSim();
 			} catch(Exception e) {
-				log.warn("exception in finally block - this may be a follow-up exception of an exception thrown in the try block.");
-				e.printStackTrace();
+				log.warn( "exception in finally block - " +
+						  "this may be a follow-up exception of an exception thrown in the try block.", e);
 			}
 		}
 	}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -252,7 +252,12 @@ public final class QSim extends Thread implements VisMobsim, Netsim, ActivityEnd
 			// We really want to perform that. For instance, with QNetsimEngine, threads are cleaned up in this method.
 			// Without this finally, in case of a crash, threads are not closed, which lead to process hanging forever
 			// at least on the eth euler cluster (but not on our local machines at ivt!?) td oct 15
-			cleanupSim();
+			try {
+				cleanupSim();
+			} catch(Exception e) {
+				log.warn("exception in finally block - this may be a follow-up exception of an exception thrown in the try block.");
+				e.printStackTrace();
+			}
 		}
 	}
 


### PR DESCRIPTION
…hrown in the try block is visible for the user - this makes debugging hard - therefore properly catch exceptions in the finally block

In my case I had the pleasure of encountering:
```
java.lang.NullPointerException
	at org.matsim.contrib.util.XYDataCollector.notifyMobsimBeforeCleanup(XYDataCollector.java:90)
	at org.matsim.core.mobsim.qsim.MobsimListenerManager.fireQueueSimulationBeforeCleanupEvent(MobsimListenerManager.java:98)
	at org.matsim.core.mobsim.qsim.QSim.cleanupSim(QSim.java:320)
	at org.matsim.core.mobsim.qsim.QSim.run(QSim.java:256)
	at org.matsim.core.controler.NewControler.runMobSim(NewControler.java:126)
	[...]
```