### PR TITLE
Update DrtConfigGroup.java

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -62,7 +62,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 			"Limit the operation of vehicles to links (of the 'dvrp_routing'"
 					+ " network) with 'allowedModes' containing this 'mode'."
 					+ " For backward compatibility, the value is set to false by default"
-					+ " -- this means that the vehicles are allowed to operate on all links of the 'dvrp_routing' network."
+					+ " - this means that the vehicles are allowed to operate on all links of the 'dvrp_routing' network."
 					+ " The 'dvrp_routing' is defined by DvrpConfigGroup.networkModes)";
 
 	public static final String STOP_DURATION = "stopDuration";


### PR DESCRIPTION
change '--' to '-' in a comment to be able to read in the output config xml-file (which by default contains all comments).