### PR TITLE
 CreatePseudoNetwork: link freeSpeed+capacity configurable, high defaults for both

### DIFF
--- a/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
@@ -57,6 +57,9 @@ public class CreatePseudoNetwork {
 	private final TransitSchedule schedule;
 	private final Network network;
 	private final String prefix;
+	private final double linkFreeSpeed;
+	private final double linkCapacity;
+	
 
 	private final Map<Tuple<Node, Node>, Link> links = new HashMap<Tuple<Node, Node>, Link>();
 	private final Map<Tuple<Node, Node>, TransitStopFacility> stopFacilities = new HashMap<Tuple<Node, Node>, TransitStopFacility>();
@@ -71,6 +74,17 @@ public class CreatePseudoNetwork {
 		this.schedule = schedule;
 		this.network = network;
 		this.prefix = networkIdPrefix;
+		this.linkFreeSpeed = 100.0 / 3.6;
+		this.linkCapacity = 100000.0;
+	}
+	
+	public CreatePseudoNetwork(final TransitSchedule schedule, final Network network, final String networkIdPrefix, 
+			final double linkFreeSpeed, final double linkCapacity) {
+		this.schedule = schedule;
+		this.network = network;
+		this.prefix = networkIdPrefix;
+		this.linkFreeSpeed = linkFreeSpeed;
+		this.linkCapacity = linkCapacity;
 	}
 
 	public void createNetwork() {
@@ -160,8 +174,8 @@ public class CreatePseudoNetwork {
 		} else {
 			link.setLength(CoordUtils.calcEuclideanDistance(fromNode.getCoord(), toNode.getCoord()));
 		}
-		link.setFreespeed(100.0 / 3.6);
-		link.setCapacity(100000);
+		link.setFreespeed(linkFreeSpeed);
+		link.setCapacity(linkCapacity);
 		link.setNumberOfLanes(1);
 		this.network.addLink(link);
 		link.setAllowedModes(this.transitModes);

--- a/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
@@ -161,7 +161,7 @@ public class CreatePseudoNetwork {
 			link.setLength(CoordUtils.calcEuclideanDistance(fromNode.getCoord(), toNode.getCoord()));
 		}
 		link.setFreespeed(100.0 / 3.6);
-		link.setCapacity(500);
+		link.setCapacity(100000);
 		link.setNumberOfLanes(1);
 		this.network.addLink(link);
 		link.setAllowedModes(this.transitModes);


### PR DESCRIPTION
We recently had some scenarios in which pt was significantly delayed due to low link freespeed and link capacity in the pt network. 

Even the old value for link capacity was rather high for having traffic jam of pt vehicles at flowCapacityFactor=1, we don't have realistic queuing effects of pt links anyway, so rather avoid queuing effects (as these cause often unexpected and hard to find pt delays)

So I think higher defaults are good and will save us lots of hard to find delays in pt simulation. But we can still make this configurable if someone wants to use lower speeds and capacities.