### PR TITLE
minor fix: catch all subcases of 'cannot find declaration of element' exceptions and not only a specific one.

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierVehicleTypeReader.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierVehicleTypeReader.java
@@ -43,7 +43,7 @@ public class CarrierVehicleTypeReader implements MatsimReader{
 			reader.readFile( filename );
 		} catch (Exception e) {
 			log.warn("### Exception: Message=" + e.getMessage() + " ; cause=" + e.getCause() + " ; class=" + e.getClass());
-			if (e.getCause().getMessage().contains("cvc-elt.1.a")) { // "Cannot find the declaration of element" -> exception comes most probably because no validation information was found
+			if (e.getCause().getMessage().contains("cvc-elt.1")) { // "Cannot find the declaration of element" -> exception comes most probably because no validation information was found
 				log.warn("read with validation = true failed. Try it again without validation. filename: " + filename);
 				reader.setValidating(false);
 				reader.readFile(filename);


### PR DESCRIPTION
minor fix: catch all subcases of 'cannot find declaration of element' exceptions and not only a specific one.