### PR TITLE
fix EventsToLegs

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
@@ -43,7 +43,6 @@ import org.matsim.core.router.StageActivityTypes;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
-import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 /**
@@ -64,7 +63,6 @@ public class StopBasedDrtRoutingModule implements RoutingModule {
 	private final DrtConfigGroup drtCfg;
 	private final DrtRoutingModule drtRoutingModule;
 
-	@Inject
 	public StopBasedDrtRoutingModule(PopulationFactory populationFactory, DrtRoutingModule drtRoutingModule,
 			@Named(TransportMode.walk) RoutingModule walkRouter, AccessEgressStopFinder stopFinder,
 			DrtConfigGroup drtCfg) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -101,7 +101,8 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			case serviceAreaBased:
 			case stopbased:
 				if (drtCfg.getOperationalScheme() == DrtConfigGroup.OperationalScheme.serviceAreaBased) {
-					bindModal(TransitSchedule.class).toProvider(new ShapeFileStopProvider(getConfig(), drtCfg));
+					bindModal(TransitSchedule.class).toProvider(new ShapeFileStopProvider(getConfig(), drtCfg))
+							.asEagerSingleton();
 				} else {
 					bindModal(TransitSchedule.class).toInstance(readTransitSchedule());
 				}

--- a/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
@@ -19,12 +19,28 @@
 
 package org.matsim.core.scoring;
 
-import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.events.*;
-import org.matsim.api.core.v01.events.handler.*;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.events.PersonEntersVehicleEvent;
+import org.matsim.api.core.v01.events.TransitDriverStartsEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
+import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
+import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
+import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
+import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
+import org.matsim.api.core.v01.events.handler.TransitDriverStartsEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
@@ -45,30 +61,35 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
-import java.util.*;
-
+import com.google.inject.Inject;
 
 /**
- * 
  * Converts a stream of Events into a stream of Legs. Passes Legs to a single LegHandler which must be registered with this class.
  * Mainly intended for scoring, but can be used for any kind of Leg related statistics. Essentially, it allows you to read
  * Legs from the simulation like you would read Legs from Plans, except that the Plan does not even need to exist.
- * 
+ * <p>
  * Note that the instances of Leg passed to the LegHandler will never be identical to those in the Scenario! Even
  * in a "no-op" simulation which only reproduces the Plan, new instances will be created. So if you attach your own data
  * to the Legs in the Scenario, that's your own lookout.
- * 
- * @author michaz
  *
+ * @author michaz
  */
-public final class EventsToLegs implements PersonDepartureEventHandler, PersonArrivalEventHandler, LinkEnterEventHandler,
-        TeleportationArrivalEventHandler, TransitDriverStartsEventHandler, PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler, VehicleArrivesAtFacilityEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler {
+public final class EventsToLegs
+		implements PersonDepartureEventHandler, PersonArrivalEventHandler, LinkEnterEventHandler,
+		TeleportationArrivalEventHandler, TransitDriverStartsEventHandler, PersonEntersVehicleEventHandler,
+		VehicleArrivesAtFacilityEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler {
 
+	private static class PendingTransitTravel {
+		final Id<Vehicle> vehicleId;
+		final Id<TransitStopFacility> accessStop;
 
-    private Map<Id<Vehicle>, Set<Id<Person>>> vehicle2passengers = new HashMap<>();
+		PendingTransitTravel(Id<Vehicle> vehicleId, Id<TransitStopFacility> accessStop) {
+			this.vehicleId = vehicleId;
+			this.accessStop = accessStop;
+		}
+	}
 
 	private static class LineAndRoute {
-
 		final Id<TransitLine> transitLineId;
 		final Id<TransitRoute> transitRouteId;
 		final Id<Person> driverId;
@@ -82,13 +103,35 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 
 		@Override
 		public String toString() {
-			return "[" + super.toString() + 
-					" transitLineId=" + transitLineId +
-					" transitRouteId=" + transitRouteId +
-					" driverId=" + driverId +
-					" lastFacilityId=" + lastFacilityId + "]" ;
+			return "["
+					+ super.toString()
+					+ " transitLineId="
+					+ transitLineId
+					+ " transitRouteId="
+					+ transitRouteId
+					+ " driverId="
+					+ driverId
+					+ " lastFacilityId="
+					+ lastFacilityId
+					+ "]";
 		}
+	}
 
+	private static class PendingVehicleTravel {
+		private final int accessLinkIdx;
+		private final VehicleRoute route;
+		private double relativePositionOnDepartureLink;
+
+		private PendingVehicleTravel(VehicleRoute route, int accessLinkIdx) {
+			this.route = route;
+			this.accessLinkIdx = accessLinkIdx;
+		}
+	}
+
+	private static class VehicleRoute {
+		private final List<Id<Link>> links = new ArrayList<>();
+		private final List<PendingVehicleTravel> newVehicleTravels = new ArrayList<>();
+		private double relativePositionOnLastArrivalLink;
 	}
 
 	public interface LegHandler {
@@ -98,56 +141,52 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 	private Network network;
 	private TransitSchedule transitSchedule = null;
 
-	@Inject(optional=true)
+	@Inject(optional = true)
 	public void setTransitSchedule(TransitSchedule transitSchedule) {
 		this.transitSchedule = transitSchedule;
 	}
+
 	private Map<Id<Person>, Leg> legs = new HashMap<>();
 	private Map<Id<Person>, List<Id<Link>>> experiencedRoutes = new HashMap<>();
 	private Map<Id<Person>, Double> relPosOnDepartureLinkPerPerson = new HashMap<>();
 	private Map<Id<Person>, Double> relPosOnArrivalLinkPerPerson = new HashMap<>();
+
 	private Map<Id<Person>, TeleportationArrivalEvent> routelessTravels = new HashMap<>();
 	private Map<Id<Person>, PendingTransitTravel> transitTravels = new HashMap<>();
+	private Map<Id<Person>, PendingVehicleTravel> vehicleTravels = new HashMap<>();
+
 	private Map<Id<Vehicle>, LineAndRoute> transitVehicle2currentRoute = new HashMap<>();
+	private Map<Id<Vehicle>, VehicleRoute> vehicle2route = new HashMap<>();
+
 	private List<LegHandler> legHandlers = new ArrayList<>();
 
-    EventsToLegs(Scenario scenario) {
+	EventsToLegs(Scenario scenario) {
 		this.network = scenario.getNetwork();
 		if (scenario.getConfig().transit().isUseTransit()) {
 			this.transitSchedule = scenario.getTransitSchedule();
 		}
 	}
 
-
-    @Inject
-    EventsToLegs(Network network) {
-        this.network = network;
-    }
-
-    @Override
-    public void handleEvent(PersonEntersVehicleEvent event) {
-        LineAndRoute lineAndRoute = transitVehicle2currentRoute.get(event.getVehicleId());
-        if (lineAndRoute != null
-                && !event.getPersonId().equals(lineAndRoute.driverId)) { // transit drivers are not considered to travel by transit
-            transitTravels.put(event.getPersonId(), new PendingTransitTravel(event.getVehicleId(), lineAndRoute.lastFacilityId));
-        } else {
-            Set<Id<Person>> passengersInVehicle = vehicle2passengers.getOrDefault(event.getVehicleId(), new HashSet<>());
-            passengersInVehicle.add(event.getPersonId());
-            vehicle2passengers.put(event.getVehicleId(), passengersInVehicle);
-        }
-    }
+	@Inject
+	EventsToLegs(Network network) {
+		this.network = network;
+	}
 
 	@Override
 	public void reset(int iteration) {
 		legs.clear();
 		experiencedRoutes.clear();
+
 		transitTravels.clear();
+		vehicleTravels.clear();
 		routelessTravels.clear();
+
 		transitVehicle2currentRoute.clear();
+		vehicle2route.clear();
 
+		relPosOnDepartureLinkPerPerson.clear();
+		relPosOnArrivalLinkPerPerson.clear();
 	}
-
-
 
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
@@ -161,36 +200,55 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 	}
 
 	@Override
-    public void handleEvent(PersonLeavesVehicleEvent event) {
-        if (vehicle2passengers.containsKey(event.getVehicleId())) {
-            vehicle2passengers.get(event.getVehicleId()).remove(event.getPersonId());
-        }
+	public void handleEvent(PersonEntersVehicleEvent event) {
+		LineAndRoute lineAndRoute = transitVehicle2currentRoute.get(event.getVehicleId());
+		if (lineAndRoute != null) {
+			if (!event.getPersonId().equals(lineAndRoute.driverId)) {
+				// transit drivers are not considered to travel by transit
+				transitTravels.put(event.getPersonId(),
+						new PendingTransitTravel(event.getVehicleId(), lineAndRoute.lastFacilityId));
+			}
+		} else {
+			VehicleRoute route = vehicle2route.computeIfAbsent(event.getVehicleId(), vehicleId -> new VehicleRoute());
+			int currentLinkIdx = Math.max(0, route.links.size() - 1);
+			PendingVehicleTravel vehicleTravel = new PendingVehicleTravel(route, currentLinkIdx);
+			vehicleTravels.put(event.getPersonId(), vehicleTravel);
+			route.newVehicleTravels.add(vehicleTravel);
+		}
+	}
+
+	@Override
+	public void handleEvent(VehicleEntersTrafficEvent event) {
+		VehicleRoute route = vehicle2route.get(event.getVehicleId());
+		if (route != null) {
+			if (route.links.isEmpty()) {
+				route.links.add(event.getLinkId());
+			} else {
+				// in case vehicle was teleported (TODO assuming teleportation is not possible with people on board??)
+				route.links.set(route.links.size() - 1, event.getLinkId());
+			}
+
+			//update relativePositionOnDepartureLink for each new passenger and the driver
+			route.newVehicleTravels.forEach(
+					vehicleTravel -> vehicleTravel.relativePositionOnDepartureLink = event.getRelativePositionOnLink());
+			route.newVehicleTravels.clear();
+		}
 	}
 
 	@Override
 	public void handleEvent(LinkEnterEvent event) {
-        vehicle2passengers.get(event.getVehicleId())
-				.forEach(p -> experiencedRoutes.computeIfPresent(p, (personId, ids) -> {
-					ids.add(event.getLinkId());
-					return ids;
-				}));
-
-    }
-
-    @Override
-    public void handleEvent(VehicleEntersTrafficEvent event) {
-
-        // remember the relative position on the link
-        if (vehicle2passengers.containsKey(event.getVehicleId())) {
-            vehicle2passengers.get(event.getVehicleId())
-                    .forEach(personId -> relPosOnDepartureLinkPerPerson.put(personId, event.getRelativePositionOnLink()));
-        }
-
-    }
+		VehicleRoute route = vehicle2route.get(event.getVehicleId());
+		if (route != null) {
+			route.links.add(event.getLinkId());
+		}
+	}
 
 	@Override
-	public void handleEvent(TeleportationArrivalEvent travelEvent) {
-		routelessTravels.put(travelEvent.getPersonId(), travelEvent);
+	public void handleEvent(VehicleLeavesTrafficEvent event) {
+		VehicleRoute route = vehicle2route.get(event.getVehicleId());
+		if (route != null) {
+			route.relativePositionOnLastArrivalLink = event.getRelativePositionOnLink();
+		}
 	}
 
 	@Override
@@ -202,64 +260,87 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 	}
 
 	@Override
+	public void handleEvent(TeleportationArrivalEvent travelEvent) {
+		routelessTravels.put(travelEvent.getPersonId(), travelEvent);
+	}
+
+	@Override
 	public void handleEvent(PersonArrivalEvent event) {
 		Leg leg = legs.get(event.getPersonId());
-		leg.setTravelTime( event.getTime() - leg.getDepartureTime() );
+		leg.setTravelTime(event.getTime() - leg.getDepartureTime());
 		double travelTime = leg.getDepartureTime() + leg.getTravelTime() - leg.getDepartureTime();
 		leg.setTravelTime(travelTime);
 		List<Id<Link>> experiencedRoute = experiencedRoutes.get(event.getPersonId());
-		assert experiencedRoute.size() >= 1  ;
+		assert experiencedRoute.size() >= 1;
 		PendingTransitTravel pendingTransitTravel;
+		PendingVehicleTravel pendingVehicleTravel;
 		if (experiencedRoute.size() > 1) { // different links processed
 			NetworkRoute networkRoute = RouteUtils.createNetworkRoute(experiencedRoute, null);
 			networkRoute.setTravelTime(travelTime);
 
 			/* use the relative position of vehicle enter/leave traffic events on first/last links
-			 * to calculate the correct route distance including the first/last link. 
+			 * to calculate the correct route distance including the first/last link.
 			 * (see MATSIM-227) tt feb'16
 			 */
 			double relPosOnDepartureLink = relPosOnDepartureLinkPerPerson.get(event.getPersonId());
 			Double relPosOnArrivalLink = relPosOnArrivalLinkPerPerson.get(event.getPersonId());
-			Gbl.assertNotNull( relPosOnArrivalLink );
-			networkRoute.setDistance(RouteUtils.calcDistance(networkRoute, relPosOnDepartureLink, 
-					relPosOnArrivalLink, network));
+			Gbl.assertNotNull(relPosOnArrivalLink);
+			networkRoute.setDistance(
+					RouteUtils.calcDistance(networkRoute, relPosOnDepartureLink, relPosOnArrivalLink, network));
 
 			leg.setRoute(networkRoute);
 		} else if ((pendingTransitTravel = transitTravels.remove(event.getPersonId())) != null) {
 			// i.e. experiencedRoute.size()==1 && pending transit travel (= person has entered a vehicle)
 
 			final LineAndRoute lineAndRoute = transitVehicle2currentRoute.get(pendingTransitTravel.vehicleId);
-			assert lineAndRoute!=null ;
+			assert lineAndRoute != null;
 
-			final TransitStopFacility accessFacility = transitSchedule.getFacilities().get(pendingTransitTravel.accessStop);
-			assert accessFacility!=null ;
+			final TransitStopFacility accessFacility = transitSchedule.getFacilities()
+					.get(pendingTransitTravel.accessStop);
+			assert accessFacility != null;
 
 			final TransitLine line = transitSchedule.getTransitLines().get(lineAndRoute.transitLineId);
-			assert line!=null ;
+			assert line != null;
 
 			final TransitRoute route = line.getRoutes().get(lineAndRoute.transitRouteId);
-			assert route!=null ;
+			assert route != null;
 
 			final Id<TransitStopFacility> lastFacilityId = lineAndRoute.lastFacilityId;
-			if ( lastFacilityId==null ) {
+			if (lastFacilityId == null) {
 				Logger.getLogger(this.getClass()).warn("breakpoint");
 			}
-			assert lastFacilityId!=null ;
+			assert lastFacilityId != null;
 
 			final TransitStopFacility egressFacility = transitSchedule.getFacilities().get(lastFacilityId);
-			assert egressFacility!=null ;
+			assert egressFacility != null;
 
-			ExperimentalTransitRoute experimentalTransitRoute = new ExperimentalTransitRoute(
-					accessFacility,
-					line, 
-					route,
-					egressFacility);
+			ExperimentalTransitRoute experimentalTransitRoute = new ExperimentalTransitRoute(accessFacility, line,
+					route, egressFacility);
 			experimentalTransitRoute.setTravelTime(travelTime);
-			experimentalTransitRoute.setDistance(RouteUtils.calcDistance(experimentalTransitRoute, transitSchedule, network));
+			experimentalTransitRoute.setDistance(
+					RouteUtils.calcDistance(experimentalTransitRoute, transitSchedule, network));
 			leg.setRoute(experimentalTransitRoute);
+		} else if ((pendingVehicleTravel = vehicleTravels.remove(event.getPersonId())) != null) {
+			VehicleRoute vehicleRoute = pendingVehicleTravel.route;
+			List<Id<Link>> traveledLinks = vehicleRoute.links.subList(pendingVehicleTravel.accessLinkIdx,
+					vehicleRoute.links.size());
+			Route route;
+			if (traveledLinks.isEmpty()) {//special case: enter and leave vehicle without entering traffic
+				route = RouteUtils.createGenericRouteImpl(experiencedRoute.get(0), event.getLinkId());
+				route.setDistance(0.0);
+			} else {
+				route = RouteUtils.createNetworkRoute(traveledLinks, null);
+				double relPosOnDepartureLink = pendingVehicleTravel.relativePositionOnDepartureLink;
+				double relPosOnArrivalLink = vehicleRoute.relativePositionOnLastArrivalLink;
+				route.setDistance(
+						RouteUtils.calcDistance((NetworkRoute)route, relPosOnDepartureLink, relPosOnArrivalLink,
+								network));
+			}
+			route.setTravelTime(travelTime);
+			leg.setRoute(route);
+
 		} else {
 			// i.e. experiencedRoute.size()==1 and no pendingTransitTravel
-
 			TeleportationArrivalEvent travelEvent = routelessTravels.remove(event.getPersonId());
 			Route genericRoute = RouteUtils.createGenericRouteImpl(experiencedRoute.get(0), event.getLinkId());
 			genericRoute.setTravelTime(travelTime);
@@ -270,6 +351,7 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 			}
 			leg.setRoute(genericRoute);
 		}
+
 		for (LegHandler legHandler : legHandlers) {
 			legHandler.handleLeg(new PersonExperiencedLeg(event.getPersonId(), leg));
 		}
@@ -277,34 +359,12 @@ public final class EventsToLegs implements PersonDepartureEventHandler, PersonAr
 
 	@Override
 	public void handleEvent(TransitDriverStartsEvent event) {
-		LineAndRoute lineAndRoute = new LineAndRoute(event.getTransitLineId(), event.getTransitRouteId(), event.getDriverId());
+		LineAndRoute lineAndRoute = new LineAndRoute(event.getTransitLineId(), event.getTransitRouteId(),
+				event.getDriverId());
 		transitVehicle2currentRoute.put(event.getVehicleId(), lineAndRoute);
 	}
 
 	public void addLegHandler(LegHandler legHandler) {
 		this.legHandlers.add(legHandler);
 	}
-
-	@Override
-	public void handleEvent(VehicleLeavesTrafficEvent event) {
-
-		// remember the relative position on the link
-        if (vehicle2passengers.containsKey(event.getVehicleId())) {
-            vehicle2passengers.get(event.getVehicleId())
-                    .forEach(personId -> relPosOnArrivalLinkPerPerson.put(personId, event.getRelativePositionOnLink()));
-        }
-    }
-
-    private static class PendingTransitTravel {
-
-        final Id<Vehicle> vehicleId;
-        final Id<TransitStopFacility> accessStop;
-
-        PendingTransitTravel(Id<Vehicle> vehicleId, Id<TransitStopFacility> accessStop) {
-            this.vehicleId = vehicleId;
-            this.accessStop = accessStop;
-        }
-
-    }
-
 }

--- a/matsim/src/test/java/org/matsim/core/scoring/EventsToLegsTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/EventsToLegsTest.java
@@ -24,7 +24,12 @@ import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.events.PersonEntersVehicleEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
@@ -48,10 +53,7 @@ public class EventsToLegsTest {
 		eventsToLegs.handleEvent(new PersonDepartureEvent(10.0, Id.create("1", Person.class), Id.create("l1", Link.class), "walk"));
 		eventsToLegs.handleEvent(new TeleportationArrivalEvent(30.0, Id.create("1", Person.class), 50.0));
 		eventsToLegs.handleEvent(new PersonArrivalEvent(30.0, Id.create("1", Person.class), Id.create("l2", Link.class), "walk"));
-		Assert.assertNotNull(lh.handledLeg);
-		Assert.assertEquals(10.0, lh.handledLeg.getLeg().getDepartureTime(), 1e-9);
-		Assert.assertEquals(20.0, lh.handledLeg.getLeg().getTravelTime(), 1e-9);
-		Assert.assertEquals(50.0, lh.handledLeg.getLeg().getRoute().getDistance(), 1e-9);
+		assertLeg(lh, 10., 20., 50.0, "walk");
 	}
 
 	@Test
@@ -69,18 +71,91 @@ public class EventsToLegsTest {
 		eventsToLegs.handleEvent(new LinkEnterEvent(16.0, vehId, Id.createLinkId("l3")));
 		eventsToLegs.handleEvent(new VehicleLeavesTrafficEvent(30.0, agentId, Id.createLinkId("l3"), vehId, "car", 1.0));
 		eventsToLegs.handleEvent(new PersonArrivalEvent(30.0, agentId, Id.createLinkId("l3"), "car"));
-		Assert.assertNotNull(lh.handledLeg);
-		Assert.assertEquals(10.0,lh.handledLeg.getLeg().getDepartureTime(), 1e-9);
-		Assert.assertEquals(20.0,lh.handledLeg.getLeg().getTravelTime(), 1e-9);
-		Assert.assertEquals(20.0,lh.handledLeg.getLeg().getRoute().getTravelTime(), 1e-9);
-		Assert.assertEquals(550.0,lh.handledLeg.getLeg().getRoute().getDistance(), 1e-9);
+		assertLeg(lh, 10., 20., 550.0, "car");
 	}
-	
+
+	@Test
+	public void testCreatesLegWithRoute_jointTrip() {
+		Scenario scenario = createTriangularNetwork();
+		EventsToLegs eventsToLegs = new EventsToLegs(scenario);
+		RememberingLegHandler lh = new RememberingLegHandler();
+		eventsToLegs.addLegHandler(lh);
+		Id<Vehicle> vehId = Id.create("veh1", Vehicle.class);
+
+		//agent 1 enters vehicle
+		Id<Person> agentId1 = Id.create("1", Person.class);
+		eventsToLegs.handleEvent(new PersonDepartureEvent(10.0, agentId1, Id.createLinkId("l1"), "car"));
+		eventsToLegs.handleEvent(new PersonEntersVehicleEvent(10.0, agentId1, vehId));
+
+		//agent 2 enters vehicle
+		Id<Person> agentId2 = Id.create("2", Person.class);
+		eventsToLegs.handleEvent(new PersonDepartureEvent(10.0, agentId2, Id.createLinkId("l1"), "ride"));
+		eventsToLegs.handleEvent(new PersonEntersVehicleEvent(10.0, agentId2, vehId));
+
+		//vehicle drives from l1 to l2
+		eventsToLegs.handleEvent(
+				new VehicleEntersTrafficEvent(10.0, agentId1, Id.createLinkId("l1"), vehId, "car", 1.0));
+		eventsToLegs.handleEvent(new LinkEnterEvent(11.0, vehId, Id.createLinkId("l2")));
+		eventsToLegs.handleEvent(
+				new VehicleLeavesTrafficEvent(15.0, agentId1, Id.createLinkId("l2"), vehId, "car", 1.0));
+
+		//agent 2 leaves vehicle
+		eventsToLegs.handleEvent(new PersonArrivalEvent(15.0, agentId2, Id.createLinkId("l2"), "ride"));
+		assertLeg(lh, 10., 5., 500.0, "ride");
+
+		//vehicle drives from l2 to l3
+		eventsToLegs.handleEvent(
+				new VehicleEntersTrafficEvent(15.0, agentId1, Id.createLinkId("l2"), vehId, "car", 1.0));
+		eventsToLegs.handleEvent(new LinkEnterEvent(16.0, vehId, Id.createLinkId("l3")));
+		eventsToLegs.handleEvent(
+				new VehicleLeavesTrafficEvent(30.0, agentId1, Id.createLinkId("l3"), vehId, "car", 1.0));
+
+		eventsToLegs.handleEvent(new PersonArrivalEvent(30.0, agentId1, Id.createLinkId("l3"), "car"));
+		assertLeg(lh, 10., 20., 550.0, "car");
+	}
+
+	@Test
+	public void testCreatesLegWithRoute_withoutEnteringTraffic() {
+		Scenario scenario = createTriangularNetwork();
+		EventsToLegs eventsToLegs = new EventsToLegs(scenario);
+		RememberingLegHandler lh = new RememberingLegHandler();
+		eventsToLegs.addLegHandler(lh);
+		Id<Vehicle> vehId = Id.create("veh1", Vehicle.class);
+
+		Id<Person> agentId1 = Id.create("1", Person.class);
+		eventsToLegs.handleEvent(new PersonDepartureEvent(10.0, agentId1, Id.createLinkId("l1"), "car"));
+		eventsToLegs.handleEvent(new PersonEntersVehicleEvent(10.0, agentId1, vehId));
+		//driver leaves out vehicle after 10 seconds, no driving at all
+		eventsToLegs.handleEvent(new PersonArrivalEvent(20.0, agentId1, Id.createLinkId("l1"), "car"));
+		assertLeg(lh, 10., 10., 0.0, "car");
+	}
+
+	@Test
+	public void testCreatesLegWithRoute_withLeavingTrafficOnTheSameLink() {
+		Scenario scenario = createTriangularNetwork();
+		EventsToLegs eventsToLegs = new EventsToLegs(scenario);
+		RememberingLegHandler lh = new RememberingLegHandler();
+		eventsToLegs.addLegHandler(lh);
+		Id<Vehicle> vehId = Id.create("veh1", Vehicle.class);
+
+		Id<Person> agentId1 = Id.create("1", Person.class);
+		eventsToLegs.handleEvent(new PersonDepartureEvent(10.0, agentId1, Id.createLinkId("l1"), "car"));
+		eventsToLegs.handleEvent(new PersonEntersVehicleEvent(10.0, agentId1, vehId));
+		//driver leaves out vehicle after 10 seconds of driving from one end to the other of the initial link
+		eventsToLegs.handleEvent(
+				new VehicleEntersTrafficEvent(10.0, agentId1, Id.createLinkId("l1"), vehId, "car", 0.0));
+		eventsToLegs.handleEvent(
+				new VehicleLeavesTrafficEvent(25.0, agentId1, Id.createLinkId("l1"), vehId, "car", 1.0));
+		eventsToLegs.handleEvent(new PersonArrivalEvent(20.0, agentId1, Id.createLinkId("l1"), "car"));
+		assertLeg(lh, 10., 10., 500.0, "car");
+	}
+
+
 	private static Scenario createTriangularNetwork() {
 		MutableScenario scenario = (MutableScenario) ScenarioUtils.createScenario(ConfigUtils.createConfig());
 
         Network network = scenario.getNetwork();
-		
+
 		// add nodes
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("n1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("n2", Node.class), new Coord((double) 50, (double) 100));
@@ -100,14 +175,24 @@ public class EventsToLegsTest {
 		final Node fromNode3 = node4;
 		final Node toNode3 = node1;
 		NetworkUtils.createAndAddLink(network,Id.create("l4", Link.class), fromNode3, toNode3, 50.0, 0.1, 3600.0, (double) 1 );
-		
+
 		return scenario;
 	}
-	
+
+	private void assertLeg(RememberingLegHandler lh, double departureTime, double travelTime, double distance,
+			String mode) {
+		Assert.assertNotNull(lh.handledLeg);
+		Assert.assertEquals(departureTime, lh.handledLeg.getLeg().getDepartureTime(), 1e-9);
+		Assert.assertEquals(travelTime, lh.handledLeg.getLeg().getTravelTime(), 1e-9);
+		Assert.assertEquals(travelTime, lh.handledLeg.getLeg().getRoute().getTravelTime(), 1e-9);
+		Assert.assertEquals(distance, lh.handledLeg.getLeg().getRoute().getDistance(), 1e-9);
+		Assert.assertEquals(mode, lh.handledLeg.getLeg().getMode());
+	}
+
 	private static class RememberingLegHandler implements LegHandler {
 
 		/*package*/ PersonExperiencedLeg handledLeg = null;
-		
+
 		@Override
 		public void handleLeg(PersonExperiencedLeg leg) {
 			this.handledLeg = leg;


### PR DESCRIPTION
Fix bugs:
1. vehicle2passengers were not cleaned between iterations (should be fine as long as no trip gets "interrupted" by QSim endTime  (the critical one)
2. relPosOnDepartureLinkPerPerson and relPosOnArrivalLinkPerPerson is not handled properly (when we have intermediate stops when sharing rides)

Improvements:
1. record routes for vehicles (instead for each agent) and later assign a sublist of links to passengers/drivers upon their arrival
2. add more unit tests (shared rides and special boundary cases)