### PR TITLE
Drt stop search radius

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultAccessEgressStopFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultAccessEgressStopFinder.java
@@ -18,44 +18,37 @@
 
 package org.matsim.contrib.drt.routing;
 
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.routing.StopBasedDrtRoutingModule.AccessEgressStopFinder;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.util.distance.DistanceUtils;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
+import org.matsim.core.utils.collections.QuadTree;
+import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
-import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 /**
  * @author michalm
  */
 public class DefaultAccessEgressStopFinder implements AccessEgressStopFinder {
-
+	private static final Logger LOGGER = Logger.getLogger(DefaultAccessEgressStopFinder.class);
+	
 	private final Network network;
-	private final Map<Id<TransitStopFacility>, TransitStopFacility> stops;
 	private final double maxWalkDistance;
-	private final double walkBeelineFactor;
+	private final double extensionRadius = 300.0; // not configurable, not sure whether it should be - gl-oct'19
+	private final QuadTree<TransitStopFacility> stopsQT;
 
-	public DefaultAccessEgressStopFinder(TransitSchedule transitSchedule, DrtConfigGroup drtconfig,
-			PlansCalcRouteConfigGroup planscCalcRouteCfg, Network network) {
+	public DefaultAccessEgressStopFinder(DrtConfigGroup drtconfig,Network network, QuadTree<TransitStopFacility> stopsQT) {
 		this.network = network;
-		this.stops = transitSchedule.getFacilities();
 		this.maxWalkDistance = drtconfig.getMaxWalkDistance();
-		this.walkBeelineFactor = planscCalcRouteCfg.getModeRoutingParams()
-				.get(TransportMode.walk)
-				.getBeelineDistanceFactor();
+		this.stopsQT = stopsQT;
 	}
 
 	@Override
@@ -77,7 +70,7 @@ public class DefaultAccessEgressStopFinder implements AccessEgressStopFinder {
 	private TransitStopFacility findAccessFacility(Facility fromFacility, Facility toFacility) {
 		Coord fromCoord = StopBasedDrtRoutingModule.getFacilityCoord(fromFacility, network);
 		Coord toCoord = StopBasedDrtRoutingModule.getFacilityCoord(toFacility, network);
-		Set<TransitStopFacility> stopCandidates = findStopCandidates(fromCoord);
+		Collection<TransitStopFacility> stopCandidates = findStopCandidates(fromCoord);
 		TransitStopFacility accessFacility = null;
 		double bestHeading = Double.MAX_VALUE;
 		for (TransitStopFacility stop : stopCandidates) {
@@ -101,7 +94,7 @@ public class DefaultAccessEgressStopFinder implements AccessEgressStopFinder {
 	private TransitStopFacility findEgressFacility(TransitStopFacility fromStopFacility, Facility toFacility) {
 		Coord fromCoord = fromStopFacility.getCoord();
 		Coord toCoord = StopBasedDrtRoutingModule.getFacilityCoord(toFacility, network);
-		Set<TransitStopFacility> stopCandidates = findStopCandidates(toCoord);
+		Collection<TransitStopFacility> stopCandidates = findStopCandidates(toCoord);
 
 		TransitStopFacility egressFacility = null;
 		double bestHeading = Double.MAX_VALUE;
@@ -131,19 +124,19 @@ public class DefaultAccessEgressStopFinder implements AccessEgressStopFinder {
 				destinationVector[0] * destinationVector[0] + destinationVector[1] * destinationVector[1])));
 	}
 
-	private Set<TransitStopFacility> findStopCandidates(Coord coord) {
-		Set<TransitStopFacility> candidates = new LinkedHashSet<>();
-		double extensionRadius = 0.0;
-		while (candidates.isEmpty()) {
-			double maxBeelineDistance = ((maxWalkDistance + extensionRadius) / walkBeelineFactor);
-			double maxSquaredBeelineDistance = maxBeelineDistance * maxBeelineDistance;
-			candidates = stops.values().stream()
-					.filter(s -> DistanceUtils.calculateSquaredDistance(coord, s.getCoord())
-							< maxSquaredBeelineDistance)
-					.collect(Collectors.toSet());
-			extensionRadius += maxWalkDistance;
+	private Collection<TransitStopFacility> findStopCandidates(Coord coord) {
+		TransitStopFacility closestStop = stopsQT.getClosest(coord.getX(), coord.getY());
+		if (closestStop == null) {
+			// no stops, e.g. empty TransitSchedule file loaded / no suitable links in drt service area
+			LOGGER.error("No drt stop could be found for coord x=" + coord.getX() + ", y=" + coord.getY() + " (neither within nor outside the maxWalkDistance).");
+			throw new RuntimeException("No drt stop could be found");
 		}
-		return candidates;
+		double closestStopDistance = CoordUtils.calcEuclideanDistance(coord, closestStop.getCoord());
+		if (closestStopDistance > maxWalkDistance) {
+			return Collections.emptySet();
+		}
+		double searchRadius = Math.max(closestStopDistance + extensionRadius, maxWalkDistance);
+		return stopsQT.getDisk(coord.getX(), coord.getY(), searchRadius);
 	}
 
 	private double[] getVector(Coord from, Coord to) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultAccessEgressStopFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultAccessEgressStopFinder.java
@@ -135,7 +135,7 @@ public class DefaultAccessEgressStopFinder implements AccessEgressStopFinder {
 		if (closestStopDistance > maxWalkDistance) {
 			return Collections.emptySet();
 		}
-		double searchRadius = Math.max(closestStopDistance + extensionRadius, maxWalkDistance);
+		double searchRadius = Math.min(closestStopDistance + extensionRadius, maxWalkDistance);
 		return stopsQT.getDisk(coord.getX(), coord.getY(), searchRadius);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -109,7 +109,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	static final String OP_SCHEME_EXP = "Operational Scheme, either of door2door, stopbased or serviceAreaBased. door2door by default";
 
 	public static final String MAX_WALK_DISTANCE = "maxWalkDistance";
-	static final String MAX_WALK_EXP = "Maximum desired walk distance (in meters) to next stop location in stopbased system. If no suitable stop is found in that range, the search radius will be extended in steps of maxWalkDistance until a stop is found.";
+	static final String MAX_WALK_EXP = "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return a direct walk of type drtMode_walk";
 
 	public static final String ESTIMATED_DRT_SPEED = "estimatedDrtSpeed";
 	static final String ESTIMATED_DRT_SPEED_EXP =
@@ -174,7 +174,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	private OperationalScheme operationalScheme = OperationalScheme.door2door;
 
 	@PositiveOrZero // used only for stopbased DRT scheme
-	private double maxWalkDistance = 0;// [m];
+	private double maxWalkDistance = Double.MAX_VALUE;// [m];
 
 	@PositiveOrZero
 	private double estimatedDrtSpeed = 25. / 3.6;// [m/s]

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
@@ -47,10 +47,13 @@ import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.TeleportationRoutingModule;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.pt.transitSchedule.TransitScheduleUtils;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.testcases.MatsimTestUtils;
 
 /**
@@ -69,8 +72,8 @@ public class StopBasedDrtRoutingModuleTest {
 		TeleportationRoutingModule walkRouter = new TeleportationRoutingModule(TransportMode.walk, scenario,
 				networkTravelSpeed, beelineFactor);
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(scenario.getConfig());
-		AccessEgressStopFinder stopFinder = new DefaultAccessEgressStopFinder(scenario.getTransitSchedule(), drtCfg,
-				scenario.getConfig().plansCalcRoute(), scenario.getNetwork());
+		QuadTree<TransitStopFacility> stopsQT = TransitScheduleUtils.createQuadTreeOfTransitStopFacilities(scenario.getTransitSchedule());
+		AccessEgressStopFinder stopFinder = new DefaultAccessEgressStopFinder(drtCfg, scenario.getNetwork(), stopsQT);
 		DrtRoutingModule drtRoutingModule = new DrtRoutingModule(drtCfg, scenario.getNetwork(),
 				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new, walkRouter,
 				scenario);
@@ -107,7 +110,7 @@ public class StopBasedDrtRoutingModuleTest {
 		List<? extends PlanElement> routedList3 = stopBasedDRTRoutingModule.calcRoute(hf3, wf3, 8 * 3600, p3);
 
 		Assert.assertEquals(5, routedList.size());
-		Assert.assertEquals(5, routedList2.size());
+		Assert.assertEquals(1, routedList2.size());
 		Assert.assertEquals(1, routedList3.size());
 
 		System.out.println(routedList);

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
@@ -14,6 +14,7 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.TransitScheduleUtils;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
 import org.matsim.pt.transitSchedule.api.TransitLine;
@@ -161,26 +162,8 @@ public class SwissRailRaptorData {
         }
 
         // only put used transit stops into the quad tree
-        double minX = Double.POSITIVE_INFINITY;
-        double minY = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        double maxY = Double.NEGATIVE_INFINITY;
         Set<TransitStopFacility> stops = routeStopsPerStopFacility.keySet();
-        for (TransitStopFacility stopFacility : stops) {
-            double x = stopFacility.getCoord().getX();
-            double y = stopFacility.getCoord().getY();
-
-            if (x < minX) minX = x;
-            if (y < minY) minY = y;
-            if (x > maxX) maxX = x;
-            if (y > maxY) maxY = y;
-        }
-        QuadTree<TransitStopFacility> stopsQT = new QuadTree<>(minX, minY, maxX, maxY);
-        for (TransitStopFacility stopFacility : stops) {
-            double x = stopFacility.getCoord().getX();
-            double y = stopFacility.getCoord().getY();
-            stopsQT.put(x, y, stopFacility);
-        }
+        QuadTree<TransitStopFacility> stopsQT = TransitScheduleUtils.createQuadTreeOfTransitStopFacilities(stops);
         int countStopFacilities = stops.size();
 
         Map<Integer, RTransfer[]> allTransfers = calculateRouteStopTransfers(schedule, stopsQT, routeStopsPerStopFacility, routeStops, staticConfig);

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
@@ -1,9 +1,39 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * TransitScheduleUtils
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.pt.transitSchedule;
 
+import java.util.Collection;
+
+import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
-public class TransitScheduleUtils {
+/**
+ * Helper class for commonly used operations on TransitSchedules
+ * 
+ * @author Thibaut Dubernet, gleich
+ *
+ */
+public final class TransitScheduleUtils {
 	// Logic gotten from PopulationUtils, but I am actually a bit unsure about the value of those methods now that
 	// attributable is the only way to get attributes...
 
@@ -29,5 +59,36 @@ public class TransitScheduleUtils {
 
 	public static Object removeLineAttribute( TransitLine facility, String key ) {
 		return facility.getAttributes().removeAttribute( key );
+	}
+	
+	public final static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(TransitSchedule transitSchedule) {
+		return createQuadTreeOfTransitStopFacilities(transitSchedule.getFacilities().values());
+	}
+	
+	public final static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(Collection<TransitStopFacility> transitStopFacilities) {
+		double minX = Double.POSITIVE_INFINITY;
+		double minY = Double.POSITIVE_INFINITY;
+		double maxX = Double.NEGATIVE_INFINITY;
+		double maxY = Double.NEGATIVE_INFINITY;
+		for (TransitStopFacility stopFacility : transitStopFacilities) {
+			double x = stopFacility.getCoord().getX();
+			double y = stopFacility.getCoord().getY();
+
+			if (x < minX)
+				minX = x;
+			if (y < minY)
+				minY = y;
+			if (x > maxX)
+				maxX = x;
+			if (y > maxY)
+				maxY = y;
+		}
+		QuadTree<TransitStopFacility> stopsQT = new QuadTree<>(minX, minY, maxX, maxY);
+		for (TransitStopFacility stopFacility : transitStopFacilities) {
+			double x = stopFacility.getCoord().getX();
+			double y = stopFacility.getCoord().getY();
+			stopsQT.put(x, y, stopFacility);
+		}
+		return stopsQT;
 	}
 }


### PR DESCRIPTION
Make stop finder in DRT more similar to those in public transit routers, re-apply hard constraint for access/egress walk distance to drt to reduce number of passengers walking into drt service area for very long distances

* interpret maxWalkDistance as a real max, use quad tree to find drt stops

* do not factor in beeline distance factor in maximum distance

* set default value of maxWalkDistance to Double.MAX_VALUE, so default
behaviour is very similar to situation before this commit

* change StopBasedDrtRoutingModuleTest to new (respectively initial)
interpretation of maxWalkDistance

* maxWalkDistance was already a hard constraint until commit
d99ef91