### PR TITLE
let fallback router use PlansCalcRouteConfigGroup mode params of

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
+++ b/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
@@ -3,12 +3,14 @@ package org.matsim.core.router;
 import com.google.inject.Inject;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
 
@@ -19,7 +21,7 @@ class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 
 	public static final String _fallback = "_fallback";
 
-
+	@Inject private PlansCalcRouteConfigGroup pcrCfg;
 	@Inject private Population population ;
 	@Inject private Network network ;
 
@@ -29,7 +31,8 @@ class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 		Coord toCoord = FacilitiesUtils.decideOnCoord( toFacility, network ) ;
 		Id<Link> dpLinkId = FacilitiesUtils.decideOnLink( fromFacility, network ).getId() ;
 		Id<Link> arLinkId = FacilitiesUtils.decideOnLink( toFacility, network ).getId() ;
-		NetworkRoutingInclAccessEgressModule.routeBushwhackingLeg( person, leg, fromCoord, toCoord, departureTime, dpLinkId, arLinkId, population.getFactory() ) ;
+		NetworkRoutingInclAccessEgressModule.routeBushwhackingLeg( person, leg, fromCoord, toCoord, departureTime, dpLinkId, arLinkId, population.getFactory(), 
+				pcrCfg.getModeRoutingParams().get(TransportMode.non_network_walk) ) ;
 		return Collections.singletonList( leg ) ;
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.*;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.PopulationUtils;
@@ -204,9 +205,17 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 		return act;
 	}
 
-
 	static double routeBushwhackingLeg(Person person, Leg leg, Coord fromCoord, Coord toCoord, double depTime,
 			Id<Link> dpLinkId, Id<Link> arLinkId, PopulationFactory pf) {
+		PlansCalcRouteConfigGroup.ModeRoutingParams params = new PlansCalcRouteConfigGroup.ModeRoutingParams();
+		// old defaults
+		params.setBeelineDistanceFactor(1.3);
+		params.setTeleportedModeSpeed(2.0);
+		return routeBushwhackingLeg(person, leg, fromCoord, toCoord, depTime, dpLinkId, arLinkId, pf, params);
+	}
+
+	static double routeBushwhackingLeg(Person person, Leg leg, Coord fromCoord, Coord toCoord, double depTime,
+			Id<Link> dpLinkId, Id<Link> arLinkId, PopulationFactory pf, PlansCalcRouteConfigGroup.ModeRoutingParams params) {
 		// I don't think that it makes sense to use a RoutingModule for this, since that again makes assumptions about how to
 		// map facilities, and if you follow through to the teleportation routers one even finds activity wrappers, which is yet another
 		// complication which I certainly don't want here.  kai, dec'15
@@ -220,9 +229,9 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 		// create an empty route, but with realistic travel time
 		Route route =pf.getRouteFactories().createRoute(Route.class, dpLinkId, arLinkId ); 
 
-		double beelineDistanceFactor = 1.3 ;
-		double networkTravelSpeed = 2.0 ;
-		// yyyyyy take this from config!
+		Gbl.assertNotNull( params );
+		double beelineDistanceFactor = params.getBeelineDistanceFactor();
+		double networkTravelSpeed = params.getTeleportedModeSpeed();
 
 		double estimatedNetworkDistance = dist * beelineDistanceFactor;
 		int travTime = (int) (estimatedNetworkDistance / networkTravelSpeed);


### PR DESCRIPTION
non_network_walk instead of hard coded 2.0m/s, which creates a fallback
mode faster than walk, do not alter these old defaults as they would
change lots of test results etc. and are not necessarily wrong, e.g. in
Brandenburg in a coarse network)