### PR TITLE
use a more efficient Map implementation for small maps in ScoringParams.

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
@@ -20,9 +20,6 @@
 
 package org.matsim.core.scoring.functions;
 
-import java.util.Map;
-import java.util.TreeMap;
-
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.api.internal.MatsimParameters;
@@ -31,6 +28,10 @@ import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ActivityParams;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ModeParams;
 import org.matsim.core.config.groups.ScenarioConfigGroup;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.utils.collections.ArrayMap;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 public class ScoringParameters implements MatsimParameters {
 
@@ -221,12 +222,12 @@ public class ScoringParameters implements MatsimParameters {
 		}
 
 		public ScoringParameters build() {
-			final Map<String, ModeUtilityParameters> modes = new TreeMap<>();
+			final Map<String, ModeUtilityParameters> modes = modeParams.size() <= 20 ? new ArrayMap() : new TreeMap<>();
 			for ( Map.Entry<String, ModeUtilityParameters.Builder> e : modeParams.entrySet() ) {
 				modes.put( e.getKey() , e.getValue().build() );
 			}
 
-			final Map<String, ActivityUtilityParameters> acts = new TreeMap<>();
+			final Map<String, ActivityUtilityParameters> acts = utilParams.size() <= 20 ? new ArrayMap() : new TreeMap<>();
 			for ( Map.Entry<String, ActivityUtilityParameters.Builder> e : utilParams.entrySet() ) {
 				acts.put( e.getKey() , e.getValue().build() );
 			}

--- a/matsim/src/main/java/org/matsim/core/utils/collections/ArrayMap.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/ArrayMap.java
@@ -1,0 +1,691 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2012 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.collections;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Memory-optimized map, backed by two simple arrays, for storing a <b>small</b> number of entries.
+ * Many operations (like {@link #get(Object)}) have a runtime of <code>O(n)</code>, so this map implementation
+ * should only be used to store a small number of elements in it. But for small number of elements,
+ * this implementation performs very well, especially because of its very low memory overhead.
+ *
+ * Internally, this implementation uses a single array which stores boths keys and values in sequential order
+ * (data[i * 2] contains the keys, data[i * 2 + 1] contains the values).
+ *
+ * @author mrieser / Simunto GmbH
+ */
+public class ArrayMap<K, V> implements Map<K, V> {
+
+	private final static Object[] EMPTY = new Object[0];
+
+	@SuppressWarnings("unchecked")
+	private Object[] data = EMPTY;
+
+	public ArrayMap() {
+	}
+
+	public ArrayMap(Map<K, V> map) {
+		this.data = new Object[map.size() * 2];
+		int i = 0;
+		for (Map.Entry<K, V> e : map.entrySet()) {
+			this.data[i] = e.getKey();
+			this.data[i + 1] = e.getValue();
+			i += 2;
+		}
+	}
+
+	@Override
+	public int size() {
+		return this.data.length / 2;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.data.length == 0;
+	}
+
+	@Override
+	public boolean containsKey(Object key) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		for (int i = 1, n = this.data.length; i < n; i += 2) {
+			Object v = this.data[i];
+			if (Objects.equals(v, value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public V get(Object key) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				return (V) this.data[i + 1];
+			}
+		}
+		return null;
+	}
+
+	public V put(K key, V value) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				V oldValue = (V) this.data[i + 1];
+				this.data[i + 1] = value;
+				return oldValue;
+			}
+		}
+		int oldLength = this.data.length;
+		this.data = Arrays.copyOf(this.data, oldLength + 2);
+		this.data[oldLength] = key;
+		this.data[oldLength + 1] = value;
+		return null;
+	}
+
+	@Override
+	public V replace(K key, V value) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				V oldValue = (V) this.data[i + 1];
+				this.data[i + 1] = value;
+				return oldValue;
+			}
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public V remove(final Object key) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				V oldValue = (V) this.data[i + 1];
+				removeIndex(i);
+				return oldValue;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean remove(Object key, Object value) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				V v = (V) this.data[i + 1];
+				if (Objects.equals(v, value)) {
+					removeIndex(i);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	public boolean removeKey(final Object key) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object k = this.data[i];
+			if (Objects.equals(k, key)) {
+				removeIndex(i);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean removeValue(final Object value) {
+		for (int i = 0, n = this.data.length; i < n; i += 2) {
+			Object v = this.data[i + 1];
+			if (Objects.equals(v, value)) {
+				removeIndex(i);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void removeIndex(int i) {
+		Object[] tmp = new Object[this.data.length - 2];
+		if (i > 0) {
+			System.arraycopy(this.data, 0, tmp, 0, i);
+		}
+		if (i + 2 < this.data.length) {
+			System.arraycopy(this.data, i + 2, tmp, i, this.data.length - 2 - i);
+		}
+		this.data = tmp;
+	}
+
+	@Override
+	public void putAll(final Map<? extends K, ? extends V> m) {
+		m.forEach(this::put);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void clear() {
+		this.data = EMPTY;
+	}
+
+	@Override
+	public Set<K> keySet() {
+		return new KeySetView<>(this);
+	}
+
+	@Override
+	public Collection<V> values() {
+		return new ValuesView(this);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Set<java.util.Map.Entry<K, V>> entrySet() {
+		return new EntrySetView(this);
+	}
+
+	private static class Entry<K, V> implements Map.Entry<K, V> {
+
+		private final K k;
+		private final V v;
+
+		public Entry(K k, V v) {
+			this.k = k;
+			this.v = v;
+		}
+
+		@Override
+		public K getKey() {
+			return this.k;
+		}
+
+		@Override
+		public V getValue() {
+			return this.v;
+		}
+
+		@Override
+		public V setValue(final V value) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Entry<?, ?> entry = (Entry<?, ?>) o;
+			return Objects.equals(this.k, entry.k) &&
+					Objects.equals(this.v, entry.v);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.k, this.v);
+		}
+	}
+
+	private static class KeySetView<K, V> implements Set<K> {
+
+		private final ArrayMap<K, V> map;
+
+		KeySetView(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return this.map.containsKey(o);
+		}
+
+		@Override
+		public Iterator<K> iterator() {
+			return new KeyIterator<K, V>(this.map);
+		}
+
+		@Override
+		public Object[] toArray() {
+			Object[] data = this.map.data;
+			Object[] result = new Object[data.length / 2];
+			for (int i = 0; i < result.length; i++) {
+				result[i] = data[i * 2];
+			}
+			return result;
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			Object[] data = this.map.data;
+			int resultLength = data.length / 2;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			for (int i = 0; i < result.length; i++) {
+				result[i] = data[i * 2];
+			}
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(K k) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			return this.map.removeKey(o);
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (!this.map.containsKey(o)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends K> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			Object[] data = this.map.data;
+			for (int i = 0, n = data.length; i < n; i += 2) {
+				Object key = data[i];
+				if (!c.contains(key)) {
+					this.map.remove(key);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (this.map.removeKey(o)) {
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class KeyIterator<K, V> implements Iterator<K> {
+		private final ArrayMap<K, V> map;
+		private int nextIndex;
+
+		KeyIterator(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.data.length > this.nextIndex;
+		}
+
+		@Override
+		public K next() {
+			if (hasNext()) {
+				K key = (K) this.map.data[this.nextIndex];
+				this.nextIndex += 2;
+				return key;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			this.nextIndex -= 2;
+			this.map.removeIndex(this.nextIndex);
+		}
+	}
+
+	private static class ValuesView<K, V> implements Collection<V> {
+
+		private final ArrayMap<K, V> map;
+
+		public ValuesView(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return this.map.containsValue(o);
+		}
+
+		@Override
+		public Iterator<V> iterator() {
+			return new ValueIterator<>(this.map);
+		}
+
+		@Override
+		public Object[] toArray() {
+			Object[] data = this.map.data;
+			Object[] result = new Object[data.length / 2];
+			for (int i = 0; i < result.length; i++) {
+				result[i] = data[i * 2 + 1];
+			}
+			return result;
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			Object[] data = this.map.data;
+			int resultLength = data.length / 2;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			for (int i = 0; i < result.length; i++) {
+				result[i] = data[i * 2 + 1];
+			}
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(V v) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			return this.map.removeValue(o);
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (!this.map.containsValue(o)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends V> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (this.map.removeValue(o)) {
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			Object[] data = this.map.data;
+			for (int i = 0, n = data.length; i < n; i += 2) {
+				Object value = data[i + 1];
+				if (!c.contains(value)) {
+					this.map.removeValue(value);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class ValueIterator<K, V> implements Iterator<V> {
+
+		private final ArrayMap<K, V> map;
+		private int nextIndex;
+
+		ValueIterator(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.data.length > this.nextIndex;
+		}
+
+		@Override
+		public V next() {
+			if (hasNext()) {
+				V value = (V) this.map.data[this.nextIndex + 1];
+				this.nextIndex += 2;
+				return value;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			this.nextIndex -= 2;
+			this.map.removeIndex(this.nextIndex);
+		}
+	}
+
+	private static class EntrySetView<K, V> implements Set<java.util.Map.Entry<K, V>> {
+
+		private final ArrayMap<K, V> map;
+
+		EntrySetView(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			if (o instanceof Entry) {
+				Entry e = (Entry) o;
+				return Objects.equals(e.v, this.map.get(e.k));
+			}
+			return false;
+		}
+
+		@Override
+		public Iterator<Map.Entry<K, V>> iterator() {
+			return new EntryIterator<>(this.map);
+		}
+
+		@Override
+		public Object[] toArray() {
+			Object[] data = this.map.data;
+			Object[] result = new Object[data.length / 2];
+			for (int i = 0; i < result.length; i++) {
+				result[i] = new Entry<>(data[i * 2], data[i * 2 + 1]);
+			}
+			return result;
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			Object[] data = this.map.data;
+			int resultLength = data.length / 2;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			for (int i = 0; i < result.length; i++) {
+				result[i] = new Entry<>(data[i * 2], data[i * 2 + 1]);
+			}
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(Map.Entry<K, V> kvEntry) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			if (o instanceof Entry) {
+				Entry e = (Entry) o;
+				return this.map.remove(e.k, e.v);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (!this.contains(o)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends Map.Entry<K, V>> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			Object[] data = this.map.data;
+			for (int i = 0, n = data.length; i < n; i += 2) {
+				Object key = data[i];
+				Object value = data[i + 1];
+				if (!c.contains(new Entry<>(key, value))) {
+					this.map.remove(key, value);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (o instanceof Entry) {
+					Entry e = (Entry) o;
+					if (this.map.remove(e.k, e.v)) {
+						modified = true;
+					}
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class EntryIterator<K, V> implements Iterator<java.util.Map.Entry<K, V>> {
+
+		private final ArrayMap<K, V> map;
+		private int nextIndex;
+
+		EntryIterator(ArrayMap<K, V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.data.length > this.nextIndex;
+		}
+
+		@Override
+		public java.util.Map.Entry<K, V> next() {
+			K key = (K) this.map.data[this.nextIndex];
+			V value = (V) this.map.data[this.nextIndex + 1];
+			this.nextIndex += 2;
+			return new Entry<>(key, value);
+		}
+
+	}
+
+
+}

--- a/matsim/src/test/java/org/matsim/core/utils/collections/ArrayMapTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/collections/ArrayMapTest.java
@@ -1,0 +1,546 @@
+package org.matsim.core.utils.collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class ArrayMapTest {
+
+	@Test
+	public void testPutGetRemoveSize() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		Assert.assertEquals(0, map.size());
+		Assert.assertTrue(map.isEmpty());
+
+		Assert.assertNull(map.put("1", "one"));
+
+		Assert.assertEquals(1, map.size());
+		Assert.assertFalse(map.isEmpty());
+
+		Assert.assertNull(map.put("2", "two"));
+
+		Assert.assertEquals(2, map.size());
+		Assert.assertFalse(map.isEmpty());
+
+		Assert.assertEquals("one", map.put("1", "also-one"));
+		Assert.assertEquals(2, map.size());
+
+		Assert.assertNull(map.put("3", "three"));
+		Assert.assertEquals(3, map.size());
+
+		Assert.assertNull(map.put("4", null));
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("also-one", map.get("1"));
+		Assert.assertEquals("two", map.get("2"));
+		Assert.assertEquals("three", map.get("3"));
+		Assert.assertNull(map.get("4"));
+
+		Assert.assertEquals("two", map.remove("2"));
+		Assert.assertEquals(3, map.size());
+		Assert.assertNull(map.get("2"));
+	}
+
+	@Test
+	public void testValuesIterable() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		int i = 0;
+		for (String data : map.values()) {
+			if (i == 0) {
+				Assert.assertEquals("one", data);
+			} else if (i == 1) {
+				Assert.assertEquals("two", data);
+			} else if (i == 2) {
+				Assert.assertEquals("four", data);
+			} else if (i == 3) {
+				Assert.assertEquals("five", data);
+			} else {
+				throw new RuntimeException("unexpected element: " + data);
+			}
+			i++;
+		}
+		Assert.assertEquals(4, i);
+	}
+
+	@Test
+	public void testForEach() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		List<Tuple<String, String>> data = new ArrayList<>();
+
+		map.forEach((k, v) -> data.add(new Tuple<>(k, v)));
+
+		Assert.assertEquals("1", data.get(0).getFirst());
+		Assert.assertEquals("one", data.get(0).getSecond());
+
+		Assert.assertEquals("2", data.get(1).getFirst());
+		Assert.assertEquals("two", data.get(1).getSecond());
+
+		Assert.assertEquals("4", data.get(2).getFirst());
+		Assert.assertEquals("four", data.get(2).getSecond());
+
+		Assert.assertEquals("5", data.get(3).getFirst());
+		Assert.assertEquals("five", data.get(3).getSecond());
+	}
+
+	@Test
+	public void testContainsKey() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		Assert.assertTrue(map.containsKey("1"));
+		Assert.assertTrue(map.containsKey("2"));
+		Assert.assertFalse(map.containsKey("3"));
+		Assert.assertTrue(map.containsKey("4"));
+		Assert.assertTrue(map.containsKey("5"));
+		Assert.assertFalse(map.containsKey("6"));
+
+		Assert.assertTrue(map.containsKey("1"));
+		Assert.assertTrue(map.containsKey("2"));
+		Assert.assertFalse(map.containsKey("3"));
+		Assert.assertTrue(map.containsKey("4"));
+		Assert.assertTrue(map.containsKey("5"));
+		Assert.assertFalse(map.containsKey("6"));
+	}
+
+	@Test
+	public void testContainsValue() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		Assert.assertTrue(map.containsValue("one"));
+		Assert.assertTrue(map.containsValue("two"));
+		Assert.assertFalse(map.containsValue("three"));
+		Assert.assertTrue(map.containsValue("four"));
+		Assert.assertTrue(map.containsValue("five"));
+		Assert.assertFalse(map.containsValue("six"));
+	}
+
+	@Test
+	public void testPutAll_ArrayMap() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		ArrayMap<String, String> map2 = new ArrayMap<>();
+		map2.put("1", "one");
+		map2.put("2", "two");
+		map2.put("4", "four");
+		map2.put("5", "five");
+
+		map.putAll(map2);
+
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("one", map.get("1"));
+		Assert.assertEquals("two", map.get("2"));
+		Assert.assertNull(map.get("3"));
+		Assert.assertEquals("four", map.get("4"));
+		Assert.assertEquals("five", map.get("5"));
+	}
+
+	@Test
+	public void testPutAll_GenericMap() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		Map<String, String> map2 = new HashMap<>();
+		map2.put("1", "one");
+		map2.put("2", "two");
+		map2.put("4", "four");
+		map2.put("5", "five");
+
+		map.putAll(map2);
+
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("one", map.get("1"));
+		Assert.assertEquals("two", map.get("2"));
+		Assert.assertNull(map.get("3"));
+		Assert.assertEquals("four", map.get("4"));
+		Assert.assertEquals("five", map.get("5"));
+	}
+
+	@Test
+	public void testClear() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		Assert.assertEquals(4, map.size());
+
+		map.clear();
+
+		Assert.assertEquals(0, map.size());
+
+		Assert.assertNull(map.get("1"));
+		Assert.assertNull(map.get("2"));
+		Assert.assertNull(map.get("3"));
+
+		Assert.assertFalse(map.containsKey("1"));
+	}
+
+	@Test
+	public void testValues() {
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put("1", "one");
+		map.put("2", "two");
+		map.put("4", "four");
+		map.put("5", "five");
+
+		Collection<String> coll = map.values();
+		Assert.assertEquals(4, coll.size());
+
+		map.put("6", "six");
+		Assert.assertEquals(5, coll.size());
+
+		Assert.assertTrue(coll.remove("one"));
+		Assert.assertFalse(coll.remove("null"));
+
+		Assert.assertFalse(map.containsValue("one"));
+		Assert.assertTrue(map.containsValue("two"));
+
+		Assert.assertTrue(coll.contains("two"));
+		Assert.assertFalse(coll.contains("one"));
+
+		Set<String> values = new HashSet<>();
+		coll.forEach(v -> values.add(v));
+
+		Assert.assertEquals(4, values.size());
+		Assert.assertTrue(values.contains("two"));
+		Assert.assertTrue(values.contains("four"));
+		Assert.assertTrue(values.contains("five"));
+		Assert.assertTrue(values.contains("six"));
+	}
+
+	@Test
+	public void testKeySet() {
+		String key1 = "1";
+		String key2 = "2";
+		String key3 = "3";
+		String key4 = "4";
+		String key5 = "5";
+		String key6 = "6";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Set<String> set = map.keySet();
+		Assert.assertEquals(4, set.size());
+
+		map.put(key6, "six");
+		Assert.assertEquals(5, set.size());
+
+		Assert.assertTrue(set.remove(key1));
+		Assert.assertFalse(set.remove(key3));
+
+		Assert.assertFalse(map.containsKey(key1));
+		Assert.assertTrue(map.containsKey(key2));
+
+		Assert.assertTrue(set.contains(key2));
+		Assert.assertFalse(set.contains(key1));
+
+		Set<String> keys = new HashSet<>();
+		set.forEach(k -> keys.add(k));
+
+		Assert.assertEquals(4, keys.size());
+		Assert.assertTrue(keys.contains(key2));
+		Assert.assertTrue(keys.contains(key4));
+		Assert.assertTrue(keys.contains(key5));
+		Assert.assertTrue(keys.contains(key6));
+	}
+
+	@Test
+	public void testEntrySet() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+		String key6 = "6";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Set<Map.Entry<String, String>> set = map.entrySet();
+		Assert.assertEquals(4, set.size());
+
+		map.put(key6, "six");
+		Assert.assertEquals(5, set.size());
+
+		Map<String, Map.Entry<String, String>> entries = new HashMap<>();
+
+		for (Map.Entry<String, String> e : set) {
+			entries.put(e.getKey(), e);
+		}
+
+		Assert.assertEquals(key1, entries.get(key1).getKey());
+		Assert.assertEquals("one", entries.get(key1).getValue());
+		Assert.assertEquals("two", entries.get(key2).getValue());
+		Assert.assertEquals("four", entries.get(key4).getValue());
+		Assert.assertEquals("five", entries.get(key5).getValue());
+
+		Assert.assertTrue(set.remove(entries.get(key1)));
+		//noinspection SuspiciousMethodCalls
+		Assert.assertFalse(set.remove(new Object()));
+
+		Assert.assertFalse(map.containsKey(key1));
+		Assert.assertTrue(map.containsKey(key2));
+
+		Assert.assertTrue(set.contains(entries.get(key2)));
+		Assert.assertFalse(set.contains(entries.get(key1)));
+
+		// test forEach
+		Set<Map.Entry<String, String>> es = new HashSet<>();
+		set.forEach(k -> es.add(k));
+
+		Assert.assertEquals(4, es.size());
+		Assert.assertTrue(es.contains(entries.get(key2)));
+		Assert.assertTrue(es.contains(entries.get(key4)));
+		Assert.assertTrue(es.contains(entries.get(key5)));
+		Assert.assertTrue(es.contains(entries.get(key6)));
+	}
+
+	@Test
+	public void testValuesIterator_iterate() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.values().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("one", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("two", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("four", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("five", iter.next());
+
+		Assert.assertFalse(iter.hasNext());
+		try {
+			iter.next();
+			Assert.fail("Expected exception, got none.");
+		} catch (NoSuchElementException ignore) {
+		}
+
+		Assert.assertFalse(iter.hasNext());
+	}
+
+	@Test
+	public void testValuesIterator_remove() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.values().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("one", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("two", iter.next());
+
+		iter.remove();
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("four", iter.next());
+
+		Assert.assertEquals(3, map.size());
+		Assert.assertTrue(map.containsValue("one"));
+		Assert.assertFalse(map.containsValue("two"));
+		Assert.assertTrue(map.containsValue("four"));
+		Assert.assertTrue(map.containsValue("five"));
+	}
+
+	@Test
+	public void testKeySetIterator_iterate() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.keySet().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("1", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("2", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("4", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("5", iter.next());
+
+		Assert.assertFalse(iter.hasNext());
+		try {
+			iter.next();
+			Assert.fail("Expected exception, got none.");
+		} catch (NoSuchElementException ignore) {
+		}
+
+		Assert.assertFalse(iter.hasNext());
+	}
+
+	@Test
+	public void testKeySetIterator_remove() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.keySet().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("1", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("2", iter.next());
+
+		iter.remove();
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("4", iter.next());
+
+		Assert.assertEquals(3, map.size());
+		Assert.assertTrue(map.containsKey("1"));
+		Assert.assertFalse(map.containsKey("2"));
+		Assert.assertTrue(map.containsKey("4"));
+		Assert.assertTrue(map.containsKey("5"));
+	}
+
+	@Test
+	public void testKeySetToArray() {
+		String key1 = "1";
+		String key2 = "2";
+		String key4 = "4";
+		String key5 = "5";
+
+		ArrayMap<String, String> map = new ArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Object[] array = map.keySet().toArray();
+		Assert.assertEquals(key1, array[0]);
+		Assert.assertEquals(key2, array[1]);
+		Assert.assertEquals(key4, array[2]);
+		Assert.assertEquals(key5, array[3]);
+
+	}
+
+	@Test
+	public void testCopyConstructor() {
+		Map<String, String> map0 = new HashMap<>();
+		map0.put("1", "one");
+		map0.put("2", "two");
+		map0.put("3", "three");
+		map0.put("4", "four");
+
+		ArrayMap<String, String> map = new ArrayMap<>(map0);
+
+		Assert.assertEquals(4, map.size());
+		Assert.assertFalse(map.isEmpty());
+
+		Assert.assertTrue(map.containsKey("2"));
+		Assert.assertTrue(map.containsKey("1"));
+		Assert.assertTrue(map.containsKey("3"));
+		Assert.assertTrue(map.containsKey("4"));
+		Assert.assertFalse(map.containsKey("5"));
+
+		Assert.assertTrue(map.containsValue("one"));
+		Assert.assertTrue(map.containsValue("two"));
+		Assert.assertTrue(map.containsValue("three"));
+		Assert.assertTrue(map.containsValue("four"));
+		Assert.assertFalse(map.containsValue("five"));
+
+		Assert.assertEquals("one", map.get("1"));
+		Assert.assertEquals("two", map.get("2"));
+		Assert.assertEquals("three", map.get("3"));
+		Assert.assertEquals("four", map.get("4"));
+		Assert.assertNull(map.get("5"));
+	}
+
+}


### PR DESCRIPTION
This helps reducing the memory consumption in cases where custom scoring functions use truly agent-specific scoring parameters (i.e. in cases here a lot of ScoringParameters objects exist), and should also be minimally faster due to fewer memory accesses needed than the previously used TreeMap.