### PR TITLE
Add class MemoryObserver to regularly report on the used memory.

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -24,6 +24,7 @@ import org.matsim.analysis.IterationStopWatch;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.listener.ControlerListener;
 import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.utils.MemoryObserver;
 
 /*package*/ abstract class AbstractController {
     // we already had one case where a method of this was removed, causing downstream failures; better just not
@@ -58,10 +59,8 @@ import org.matsim.core.gbl.MatsimRandom;
     private void resetRandomNumbers(long seed, int iteration) {
         MatsimRandom.reset(seed + iteration);
         MatsimRandom.getRandom().nextDouble(); // draw one because of strange
-        // "not-randomness" is the first
-        // draw...
-        // Fixme [kn] this should really be ten thousand draws instead of just
-        // one
+        // "not-randomness" is the first draw...
+        // Fixme [kn] this should really be ten thousand draws instead of just one
     }
 
     final void setupOutputDirectory(OutputDirectoryHierarchy controlerIO) {
@@ -70,6 +69,7 @@ import org.matsim.core.gbl.MatsimRandom;
     }
 
     protected final void run(final Config config) {
+        MemoryObserver.start(60);
         MatsimRuntimeModifications.MyRunnable runnable = new MatsimRuntimeModifications.MyRunnable() {
             @Override
             public void run() throws MatsimRuntimeModifications.UnexpectedShutdownException {
@@ -87,6 +87,7 @@ import org.matsim.core.gbl.MatsimRandom;
         };
         MatsimRuntimeModifications.run(runnable);
         OutputDirectoryLogging.closeOutputDirLogging();
+        MemoryObserver.stop();
     }
 
     protected abstract void loadCoreListeners();

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -533,8 +533,6 @@ public final class QSim extends Thread implements VisMobsim, Netsim, ActivityEnd
 					+ this.agentCounter.getLost() + " simT=" + diffsim
 					+ "s realT=" + (diffreal) + "s; (s/r): "
 					+ (diffsim / (diffreal + Double.MIN_VALUE)));
-
-			Gbl.printMemoryUsage();
 		}
 	}
 

--- a/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
+++ b/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
@@ -1,0 +1,71 @@
+package org.matsim.utils;
+
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class MemoryObserver {
+
+	private final static Logger LOG = Logger.getLogger(MemoryObserver.class);
+
+	private static Thread thread = null;
+	private static MemoryPrinter runnable = null;
+
+	public static void start(int interval_seconds) {
+		startMillis(interval_seconds * 1000L);
+	}
+
+	static void startMillis(long interval) {
+		stop();
+
+		runnable = new MemoryPrinter(interval);
+		thread = new Thread(runnable, "MemoryPrinter");
+		thread.setDaemon(true);
+		thread.start();
+	}
+
+	public static void stop() {
+		if (thread != null) {
+			runnable.stopFlag.set(true);
+			thread.interrupt();
+		}
+	}
+
+	public static void printMemory() {
+		long totalMem = Runtime.getRuntime().totalMemory();
+		long freeMem = Runtime.getRuntime().freeMemory();
+		long usedMem = totalMem - freeMem;
+		LOG.info("used RAM: " + (usedMem/1024/1024) + " MB  free: " + (freeMem/1024/1024) + " MB  total: " + (totalMem/1024/1024) + " MB");
+	}
+
+	private static class MemoryPrinter implements Runnable {
+
+		private final long millis;
+		private final AtomicBoolean stopFlag = new AtomicBoolean(false);
+
+		MemoryPrinter(long millis) {
+			this.millis = millis;
+		}
+
+		public void run() {
+			while (true) {
+				MemoryObserver.printMemory();
+
+				try {
+					Thread.sleep(this.millis);
+				} catch (InterruptedException e) {
+					if (this.stopFlag.get()) {
+						return;
+					}
+					e.printStackTrace();
+				}
+			}
+		}
+
+	}
+
+
+}

--- a/matsim/src/test/java/org/matsim/utils/MemoryObserverTest.java
+++ b/matsim/src/test/java/org/matsim/utils/MemoryObserverTest.java
@@ -1,0 +1,92 @@
+package org.matsim.utils;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.testcases.utils.LogCounter;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class MemoryObserverTest {
+
+	private final static Logger LOG = Logger.getLogger(MemoryObserverTest.class);
+
+	@Test
+	public void testStartStop() throws InterruptedException {
+		LogCounter logger = new LogCounter(Level.INFO);
+		Logger.getRootLogger().addAppender(logger);
+
+		int count1 = logger.getInfoCount();
+
+		MemoryObserver.start(1);
+		Thread.sleep(3_000);
+		int count2 = logger.getInfoCount();
+
+		MemoryObserver.stop();
+		Thread.sleep(3_000);
+		int count3 = logger.getInfoCount();
+
+		MemoryObserver.startMillis(300);
+		Thread.sleep(900);
+		int count4 = logger.getInfoCount();
+
+		MemoryObserver.stop();
+		Thread.sleep(900);
+		int count5 = logger.getInfoCount();
+
+		Logger.getRootLogger().removeAppender(logger);
+
+		int activeLogs1 = count2 - count1;
+		int inactiveLogs2 = count3 - count2;
+		int activeLogs3 = count4 - count3;
+		int inactiveLogs4 = count5 - count4;
+
+		// there should be 3 log messages, than none, than 3 again, than none.
+		// but due to it being threads and influences of the OS scheduler, the numbers might be off by 1 or so, let's consider this in the tests.
+
+		LOG.info("received the following numbers of log statements: " + activeLogs1 + ", " + inactiveLogs2 + ", " + activeLogs3 + ", " + inactiveLogs4);
+		Assert.assertTrue("There should be between 2 and 4 log messages", activeLogs1 >= 2 && activeLogs1 <= 4);
+		Assert.assertTrue("There should be at most 1 log message when being stopped", inactiveLogs2 <= 1);
+		Assert.assertTrue("There should be between 2 and 4 log messages", activeLogs3 >= 2 && activeLogs3 <= 4);
+		Assert.assertTrue("There should be at most 1 log message when being stopped", inactiveLogs4 <= 1);
+	}
+
+	@Test
+	public void testDoubleStart() throws InterruptedException {
+		LogCounter logger = new LogCounter(Level.INFO);
+		Logger.getRootLogger().addAppender(logger);
+
+		int count1 = logger.getInfoCount();
+
+		MemoryObserver.start(1);
+		Thread.sleep(3_000);
+		int count2 = logger.getInfoCount();
+
+		// start it again without stopping, the logging should not double
+		MemoryObserver.start(1);
+		Thread.sleep(3_000);
+		int count3 = logger.getInfoCount();
+
+		MemoryObserver.stop();
+		Thread.sleep(900);
+		int count4 = logger.getInfoCount();
+
+		Logger.getRootLogger().removeAppender(logger);
+
+		int activeLogs1 = count2 - count1;
+		int activeLogs2 = count3 - count2;
+		int inactiveLogs3 = count4 - count3;
+
+		// there should be 3 log messages, again 3, than none.
+		// but due to it being threads and influences of the OS scheduler, the numbers might be off by 1 or so, let's consider this in the tests.
+
+		LOG.info("received the following numbers of log statements: " + activeLogs1 + ", " + activeLogs2 + ", " + inactiveLogs3);
+		Assert.assertTrue("There should be between 2 and 4 log messages", activeLogs1 >= 2 && activeLogs1 <= 4);
+		Assert.assertTrue("There should be between 2 and 4 log messages", activeLogs2 >= 2 && activeLogs2 <= 4);
+		Assert.assertTrue("There should be at most 1 log message when being stopped", inactiveLogs3 <= 1);
+
+	}
+
+}


### PR DESCRIPTION
Replace QSim's memory reporting by the new MemoryObserver in the AbstractController. The QSim reported the memory usage every simulated hour, but in small scenarios this this was not much of relevance as it progressed very fast, and in large scenarios it was only partially of help, as the memory consumption during replanning was not observable. The new MemoryObserver will now just print out the memory usage every 60 seconds, allowing for a more consistent observation of the memory usage over all phases of a simulation.