### PR TITLE
Support for streaming facilities with a special data container.

### DIFF
--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV1.java
@@ -110,6 +110,7 @@ final class FacilitiesReaderMatsimV1 extends MatsimXmlParser {
     @Override
     public void endTag(final String name, final String content, final Stack<String> context) {
         if (FACILITY.equals(name)) {
+            this.facilities.addActivityFacility(this.currfacility);
             this.currfacility = null;
         } else if (ACTIVITY.equals(name)) {
             this.curractivity = null;
@@ -171,7 +172,6 @@ final class FacilitiesReaderMatsimV1 extends MatsimXmlParser {
             }
         }
 
-        this.facilities.addActivityFacility(this.currfacility);
         ((ActivityFacilityImpl) this.currfacility).setDesc(atts.getValue("desc"));
     }
 

--- a/matsim/src/main/java/org/matsim/facilities/StreamingActivityFacilities.java
+++ b/matsim/src/main/java/org/matsim/facilities/StreamingActivityFacilities.java
@@ -1,0 +1,64 @@
+package org.matsim.facilities;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.utils.objectattributes.FailingObjectAttributes;
+import org.matsim.utils.objectattributes.attributable.Attributes;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+/**
+ * A special facilities container that does not store facilities, but passes them on
+ * to a consumer to process otherwise.
+ *
+ * @author mrieser / SBB
+ */
+public class StreamingActivityFacilities implements ActivityFacilities {
+
+    private final Consumer<ActivityFacility> consumer;
+    private final ActivityFacilitiesFactory factory = new ActivityFacilitiesFactoryImpl();
+
+    public StreamingActivityFacilities(Consumer<ActivityFacility> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public void setName(String name) {
+    }
+
+    @Override
+    public ActivityFacilitiesFactory getFactory() {
+        return this.factory;
+    }
+
+    @Override
+    public Map<Id<ActivityFacility>, ? extends ActivityFacility> getFacilities() {
+        return null;
+    }
+
+    @Override
+    public void addActivityFacility(ActivityFacility facility) {
+        this.consumer.accept(facility);
+    }
+
+    @Override
+    public FailingObjectAttributes getFacilityAttributes() {
+        return FailingObjectAttributes.createFacilitiesAttributes();
+    }
+
+    @Override
+    public TreeMap<Id<ActivityFacility>, ActivityFacility> getFacilitiesForActivityType(String actType) {
+        return null;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+        return null;
+    }
+}

--- a/matsim/src/test/java/org/matsim/facilities/StreamingActivityFacilitiesTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/StreamingActivityFacilitiesTest.java
@@ -1,0 +1,74 @@
+package org.matsim.facilities;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class StreamingActivityFacilitiesTest {
+
+	@Test
+	public void testFacilityIsComplete() {
+		String str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<!DOCTYPE facilities SYSTEM \"http://www.matsim.org/files/dtd/facilities_v1.dtd\">\n" +
+				"<facilities name=\"test facilities for triangle network\">\n" +
+				"\n" +
+				"	<facility id=\"1\" x=\"60.0\" y=\"110.0\" linkId=\"Aa\">\n" +
+				"		<activity type=\"home\">\n" +
+				"			<capacity value=\"201.0\" />\n" +
+				"			<opentime start_time=\"00:00:00\" end_time=\"24:00:00\" />\n" +
+				"		</activity>\n" +
+				"		<attributes>" +
+				"			<attribute name=\"population\" class=\"java.lang.Integer\">1000</attribute>" +
+				"		</attributes>" +
+				"	</facility>\n" +
+				"\n" +
+				"	<facility id=\"10\" x=\"110.0\" y=\"270.0\" linkId=\"Bb\">\n" +
+				"		<activity type=\"education\">\n" +
+				"			<capacity value=\"201.0\" />\n" +
+				"			<opentime start_time=\"08:00:00\" end_time=\"12:00:00\" />\n" +
+				"		</activity>\n" +
+				"	</facility>\n" +
+				"\n" +
+				"	<facility id=\"20\" x=\"120.0\" y=\"240.0\">\n" +
+				"		<activity type=\"shop\">\n" +
+				"			<capacity value=\"50.0\" />\n" +
+				"			<opentime start_time=\"08:00:00\" end_time=\"20:00:00\" />\n" +
+				"		</activity>\n" +
+				"	</facility>\n" +
+				"</facilities>";
+
+
+		boolean[] foundFacilities = new boolean[3];
+		StreamingActivityFacilities streamingFacilities = new StreamingActivityFacilities(f -> {
+			if (f.getId().toString().equals("1")) {
+				Assert.assertEquals(60.0, f.getCoord().getX(), 1e-7);
+				Assert.assertTrue(f.getActivityOptions().containsKey("home"));
+				Assert.assertEquals(1000, ((Integer) f.getAttributes().getAttribute("population")).intValue());
+				foundFacilities[0] = true;
+			}
+			if (f.getId().toString().equals("10")) {
+				Assert.assertEquals(110.0, f.getCoord().getX(), 1e-7);
+				Assert.assertTrue(f.getActivityOptions().containsKey("education"));
+				Assert.assertTrue(f.getAttributes().isEmpty());
+				foundFacilities[1] = true;
+			}
+			if (f.getId().toString().equals("20")) {
+				Assert.assertEquals(120.0, f.getCoord().getX(), 1e-7);
+				Assert.assertTrue(f.getActivityOptions().containsKey("shop"));
+				Assert.assertTrue(f.getAttributes().isEmpty());
+				foundFacilities[2] = true;
+			}
+		});
+		MatsimFacilitiesReader reader = new MatsimFacilitiesReader(null, null, streamingFacilities);
+		reader.parse(new ByteArrayInputStream(str.getBytes()));
+
+		Assert.assertTrue(foundFacilities[0]);
+		Assert.assertTrue(foundFacilities[1]);
+		Assert.assertTrue(foundFacilities[2]);
+	}
+
+}


### PR DESCRIPTION
Only add the facility to the facilities container once the facility is completely loaded, and not at the start when it's still missing activity options and attributes.
This allows for a special ActivityFacility implementation to handle one ActivityFacility after the other, without the need to load all into memory at the same time.