### PR TITLE
don't add activitiy params for the default subpopulation (null) in case

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
@@ -61,7 +61,7 @@ public class DrtConfigs {
 		params.setTypicalDuration(1);
 		params.setScoringThisActivityAtAll(false);
 		planCalcScoreCfg.getScoringParametersPerSubpopulation().values().forEach(k -> k.addActivityParams(params));
-		planCalcScoreCfg.addActivityParams(params);
+		if (planCalcScoreCfg.getScoringParameters(null) != null) planCalcScoreCfg.addActivityParams(params);
 		LOGGER.info("drt interaction scoring parameters not set. Adding default values (activity will not be scored).");
 	}
 


### PR DESCRIPTION
we don't have any scoring parameters for the default subpopulation