### PR TITLE
teleportation routers config go back to earlier design

### DIFF
--- a/contribs/minibus/test/input/org/matsim/contrib/minibus/integration/PControlerTestIT/config_corr_s1_0.xml
+++ b/contribs/minibus/test/input/org/matsim/contrib/minibus/integration/PControlerTestIT/config_corr_s1_0.xml
@@ -229,7 +229,7 @@
 
 		<!-- Speed for a teleported mode based on beeline-distance: (<beeline distance> * beelineDistanceFactor) / speed. Insert a line like this for every such mode. -->
 		<param name="teleportedModeSpeed_walk" value="1.111111111111111" />
-		
+
 		<!-- write a plans file in each iteration directory which contains what each agent actually did, and the score it received. -->
 		<!--<param name="writeExperiencedPlans" value="true" />-->
 	</module>

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -26,6 +26,7 @@ import org.matsim.core.api.internal.MatsimParameters;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup.ModeRoutingParams;
 import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.pt.config.TransitRouterConfigGroup;
@@ -38,6 +39,7 @@ import org.matsim.pt.config.TransitRouterConfigGroup;
  *
  */
 public class TransitRouterConfig implements MatsimParameters {
+	private static final Logger log = Logger.getLogger( TransitRouterConfig.class ) ;
 
 	/**
 	 * The distance in meters in which stop facilities should be searched for
@@ -116,10 +118,14 @@ public class TransitRouterConfig implements MatsimParameters {
 		
 		// walk:
 		{
-			final PlansCalcRouteConfigGroup.ModeRoutingParams params = pcrConfig.getModeRoutingParams().get( TransportMode.non_network_walk );
+			 ModeRoutingParams params = pcrConfig.getModeRoutingParams().get( TransportMode.non_network_walk );
+			if ( params==null ) {
+				log.warn( "more routing params for non_network_walk are not provided; trying to fall back on regular walk parameters");
+				params = pcrConfig.getModeRoutingParams().get(  TransportMode.walk );
+			}
 			Gbl.assertNotNull( params );
 			this.beelineDistanceFactor = params.getBeelineDistanceFactor();
-			this.beelineWalkSpeed = pcrConfig.getTeleportedModeSpeeds().get( TransportMode.non_network_walk ) / beelineDistanceFactor;
+			this.beelineWalkSpeed = params.getTeleportedModeSpeed() / beelineDistanceFactor;
 		}
 		// yyyyyy the two above need to be moved away from walk since otherwise one is not able to move walk routing to network routing!!!!!! Now trying access_walk ...  kai,
 		// apr'19

--- a/matsim/src/test/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroupTest.java
@@ -22,6 +22,7 @@ package org.matsim.core.config.groups;
 import java.util.Arrays;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -36,11 +37,46 @@ import org.matsim.core.config.groups.PlansCalcRouteConfigGroup.ModeRoutingParams
 import org.matsim.testcases.MatsimTestUtils;
 
 public class PlansCalcRouteConfigGroupTest {
-
 	private final static Logger log = Logger.getLogger(PlansCalcRouteConfigGroupTest.class);
+	private final static int N_MODE_ROUTING_PARAMS_DEFAULT = 5 ;
 
 	@Rule
 	public final MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void test1() {
+		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup();
+		Assert.assertEquals( N_MODE_ROUTING_PARAMS_DEFAULT, group.getModeRoutingParams().size() );
+		group.setTeleportedModeSpeed( TransportMode.bike, 1. );
+		Assert.assertEquals( 1, group.getModeRoutingParams().size() );
+		group.setTeleportedModeSpeed( "abc", 1. );
+		Assert.assertEquals( 2, group.getModeRoutingParams().size() );
+		group.clearModeRoutingParams(  );
+		Assert.assertEquals( 0, group.getModeRoutingParams().size() );
+	}
+	@Test
+	public void test2() {
+		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup();
+		Assert.assertEquals( N_MODE_ROUTING_PARAMS_DEFAULT, group.getModeRoutingParams().size() );
+		group.setTeleportedModeSpeed( "def", 1. );
+		Assert.assertEquals( 1, group.getModeRoutingParams().size() );
+		group.setTeleportedModeSpeed( "abc", 1. );
+		Assert.assertEquals( 2, group.getModeRoutingParams().size() );
+		group.clearModeRoutingParams( );
+		Assert.assertEquals( 0, group.getModeRoutingParams().size() );
+	}
+	@Test
+	public void test3() {
+		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup() ;
+		group.clearModeRoutingParams();
+		group.setClearingDefaultModeRoutingParams( true ); // should be ok
+	}
+	@Test( expected = RuntimeException.class )
+	public void test4() {
+		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup() ;
+		group.clearModeRoutingParams();
+		group.setClearingDefaultModeRoutingParams( false ); // should fail
+	}
 
 	@Test
 	public void testBackwardsCompatibility() {
@@ -63,7 +99,7 @@ public class PlansCalcRouteConfigGroupTest {
 	@Test
 	public void testDefaultsAreCleared() {
 		PlansCalcRouteConfigGroup group = new PlansCalcRouteConfigGroup();
-		group.clearModeRoutingParams();
+//		group.clearModeRoutingParams();
 		group.setTeleportedModeSpeed( "skateboard" , 20 / 3.6 );
 		group.setTeleportedModeSpeed( "longboard" , 20 / 3.6 );
 		Assert.assertEquals(


### PR DESCRIPTION
It used to be the case that setting _any_ teleportation router would clear the default settings.  I removed that mechanism some time ago (but after r11.x), since it is automagic, and we try to reduce automagic.  However, I wanted to leave the teleportation default routers in place, since they provide a default for some of the speeds, unifying results for cases where users do not think deeply about the corresponding parameters.  Yet, I was not able to find a design that works both from code and from xml config file.  The reason roughly is the following:
1. assume you start with some config where you have the default teleportation routers
2. now you remove some of them
3. if you print this to output_config and then read it back in, and the first occurrence of a teleportation router clears the default teleportation routers, then it works.

If, however, one does not clear the default teleportation routers upon first read of a declared teleportation router, all of the default teleportation routers will survive, meaning a different config than the one that was written to file.  Yuck.