### PR TITLE
Only StopBasedDrtRoutingModule

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -24,7 +24,7 @@ import org.matsim.contrib.drt.optimizer.VehicleData.Stop;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
-import org.matsim.contrib.drt.routing.DrtRoutingModule;
+import org.matsim.contrib.drt.routing.DrtRouteLegCalculator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtTask;
@@ -225,7 +225,7 @@ public class InsertionCostCalculator {
 
 	/**
 	 * The request constraints are set in {@link DrtRequest}, which is used by {@link DrtRequestCreator},
-	 * which is used by {@link DrtRoutingModule} and {@link DefaultDrtRouteUpdater}.  kai, nov'18
+	 * which is used by {@link DrtRouteLegCalculator} and {@link DefaultDrtRouteUpdater}.  kai, nov'18
 	 */
 	private double calcSoftConstraintPenalty(DrtRequest drtRequest, VehicleData.Entry vEntry,
 			InsertionWithDetourTimes insertion, double pickupDetourTimeLoss) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/ClosestAccessEgressFacilityFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/ClosestAccessEgressFacilityFinder.java
@@ -32,12 +32,12 @@ import org.matsim.facilities.Facility;
 /**
  * @author michalm
  */
-public class ClosestFacilityAccessEgressFacilityFinder implements AccessEgressFacilityFinder {
+public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFinder {
 	private final Network network;
 	private final QuadTree<? extends Facility> facilityQT;
 	private final double maxDistance;
 
-	public ClosestFacilityAccessEgressFacilityFinder(double maxDistance, Network network,
+	public ClosestAccessEgressFacilityFinder(double maxDistance, Network network,
 			QuadTree<? extends Facility> facilityQT) {
 		if (facilityQT.size() == 0) {
 			throw new IllegalArgumentException("Empty facility QuadTree");

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DecideOnLinkAccessEgressFacilityFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DecideOnLinkAccessEgressFacilityFinder.java
@@ -1,0 +1,50 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.routing;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.routing.StopBasedDrtRoutingModule.AccessEgressFacilityFinder;
+import org.matsim.core.router.LinkWrapperFacility;
+import org.matsim.facilities.FacilitiesUtils;
+import org.matsim.facilities.Facility;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DecideOnLinkAccessEgressFacilityFinder implements AccessEgressFacilityFinder {
+	private final Network network;
+
+	public DecideOnLinkAccessEgressFacilityFinder(Network network) {
+		this.network = network;
+	}
+
+	@Override
+	public Optional<Pair<Facility, Facility>> findFacilities(Facility fromFacility, Facility toFacility) {
+		LinkWrapperFacility accessFacility = new LinkWrapperFacility(
+				FacilitiesUtils.decideOnLink(fromFacility, network));
+		LinkWrapperFacility egressFacility = new LinkWrapperFacility(FacilitiesUtils.decideOnLink(toFacility, network));
+		return Optional.of(ImmutablePair.of(accessFacility, egressFacility));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
@@ -90,7 +90,7 @@ public class DefaultDrtRouteUpdater implements ShutdownListener, DrtRouteUpdater
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(fromLink, toLink, drtLeg.getDepartureTime(),
 				router, travelTime);
 		double unsharedRideTime = unsharedPath.getTravelTime();//includes first & last link
-		double maxTravelTime = DrtRoutingModule.getMaxTravelTime(drtCfg, unsharedRideTime);
+		double maxTravelTime = DrtRouteLegCalculator.getMaxTravelTime(drtCfg, unsharedRideTime);
 		double unsharedDistance = VrpPaths.calcDistance(unsharedPath);//includes last link
 
 		drtRoute.setDistance(unsharedDistance);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteLegCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteLegCalculator.java
@@ -22,31 +22,20 @@ package org.matsim.contrib.drt.routing;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
-import org.matsim.core.config.Config;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
-import org.matsim.core.gbl.Gbl;
-import org.matsim.core.router.LinkWrapperFacility;
-import org.matsim.core.router.RoutingModule;
-import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
-import org.matsim.facilities.FacilitiesUtils;
-import org.matsim.facilities.Facility;
 
 import com.google.inject.name.Named;
 
@@ -55,102 +44,27 @@ import com.google.inject.name.Named;
  * @author michalm (Michal Maciejewski)
  * @author Kai Nagel
  */
-public class DrtRoutingModule implements RoutingModule {
-	private static final Logger LOGGER = Logger.getLogger(DrtRoutingModule.class);
-
+public class DrtRouteLegCalculator {
 	private final DrtConfigGroup drtCfg;
-	private final Config config;
-	private final Network network;
 	private final TravelTime travelTime;
 	private final LeastCostPathCalculator router;
 	private final PopulationFactory populationFactory;
-	private final RoutingModule nonNetworkWalkRouter;
-	private final DrtStageActivityType drtStageActivityType;
-	private final PlansCalcRouteConfigGroup plansCalcRouteConfig;
 
-	public DrtRoutingModule(DrtConfigGroup drtCfg, Network network,
+	public DrtRouteLegCalculator(DrtConfigGroup drtCfg, Network drtNetwork,
 			LeastCostPathCalculatorFactory leastCostPathCalculatorFactory,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			TravelDisutilityFactory travelDisutilityFactory, NonNetworkWalkRouter nonNetworkWalkRouter,
-			Scenario scenario) {
+			TravelDisutilityFactory travelDisutilityFactory, Scenario scenario) {
 		// constructor was public when I found it, and cannot be made package private.  Thus now passing scenario as argument so we have a bit more
 		// flexibility for changes without having to change the argument list every time.  kai, jul'19
 
 		this.drtCfg = drtCfg;
-		this.config = scenario.getConfig();
-		this.network = network;
 		this.travelTime = travelTime;
 		this.populationFactory = scenario.getPopulation().getFactory();
-		this.nonNetworkWalkRouter = nonNetworkWalkRouter;
-		this.drtStageActivityType = new DrtStageActivityType(drtCfg.getMode());
-		this.plansCalcRouteConfig = scenario.getConfig().plansCalcRoute();
 
 		// Euclidean with overdoFactor > 1.0 could lead to 'experiencedTT < unsharedRideTT',
 		// while the benefit would be a marginal reduction of computation time ==> so stick to 1.0
-		router = leastCostPathCalculatorFactory.createPathCalculator(network,
+		router = leastCostPathCalculatorFactory.createPathCalculator(drtNetwork,
 				travelDisutilityFactory.createTravelDisutility(travelTime), travelTime);
-	}
-
-	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
-		LOGGER.debug("entering calcRoute ...");
-		LOGGER.debug("fromFacility=" + fromFacility.toString());
-		LOGGER.debug("toFacility=" + toFacility.toString());
-
-		Gbl.assertNotNull(fromFacility);
-		Gbl.assertNotNull(toFacility);
-
-		Link accessActLink = FacilitiesUtils.decideOnLink(fromFacility, network);
-		Link egressActLink = FacilitiesUtils.decideOnLink(toFacility, network);
-
-		double now = departureTime;
-		List<PlanElement> trip = new ArrayList<>();
-
-		if (accessActLink == egressActLink) {
-			if (drtCfg.isPrintDetailedWarnings()) {
-				LOGGER.error(
-						"Start and end stop are the same, agent will use fallback mode " + TripRouter.getFallbackMode(
-								drtCfg.getMode()) + ". Agent Id:\t" + person.getId());
-			}
-			return null;
-		}
-		// yyyy I think that our life will become easier if we don't do direct walk.  kai, jul'19
-
-		// === access:
-		if (plansCalcRouteConfig.isInsertingAccessEgressWalk()) {
-			List<? extends PlanElement> accessWalkTrip = nonNetworkWalkRouter.calcRoute(fromFacility,
-					new LinkWrapperFacility(accessActLink), now, person);
-			for (PlanElement planElement : accessWalkTrip) {
-				now = TripRouter.calcEndOfPlanElement(now, planElement, config);
-			}
-			trip.addAll(accessWalkTrip);
-			// interaction activity:
-			trip.add(createDrtStageActivity(new LinkWrapperFacility(accessActLink)));
-		}
-
-		// === drt proper:
-		{
-			final List<PlanElement> newResult = createRealDrtLeg(departureTime, accessActLink, egressActLink);
-			trip.addAll(newResult);
-			for (final PlanElement planElement : newResult) {
-				now = TripRouter.calcEndOfPlanElement(now, planElement, config);
-			}
-		}
-
-		// === egress:
-		if (plansCalcRouteConfig.isInsertingAccessEgressWalk()) {
-			// interaction activity:
-			trip.add(createDrtStageActivity(new LinkWrapperFacility(egressActLink)));
-			List<? extends PlanElement> egressWalkTrip = nonNetworkWalkRouter.calcRoute(
-					new LinkWrapperFacility(egressActLink), toFacility, now, person);
-			for (PlanElement planElement : egressWalkTrip) {
-				now = TripRouter.calcEndOfPlanElement(now, planElement, config);
-			}
-			trip.addAll(egressWalkTrip);
-		}
-
-		return trip;
 	}
 
 	/**
@@ -164,7 +78,7 @@ public class DrtRoutingModule implements RoutingModule {
 		return drtCfg.getMaxTravelTimeAlpha() * unsharedRideTime + drtCfg.getMaxTravelTimeBeta();
 	}
 
-	/* package */ List<PlanElement> createRealDrtLeg(final double departureTime, final Link accessActLink,
+	public List<PlanElement> createRealDrtLeg(final double departureTime, final Link accessActLink,
 			final Link egressActLink) {
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(accessActLink, egressActLink, departureTime,
 				router, travelTime);
@@ -186,13 +100,5 @@ public class DrtRoutingModule implements RoutingModule {
 		List<PlanElement> result = new ArrayList<>();
 		result.add(leg);
 		return result;
-	}
-
-	private Activity createDrtStageActivity(Facility stopFacility) {
-		Activity activity = populationFactory.createActivityFromCoord(drtStageActivityType.drtStageActivity,
-				stopFacility.getCoord());
-		activity.setMaximumDuration(0);
-		activity.setLinkId(stopFacility.getLinkId());
-		return activity;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
@@ -58,14 +58,14 @@ public class StopBasedDrtRoutingModule implements RoutingModule {
 	private final AccessEgressFacilityFinder stopFinder;
 	private final DrtConfigGroup drtCfg;
 	private final Scenario scenario;
-	private final DrtRoutingModule drtRoutingModule;
+	private final DrtRouteLegCalculator drtRouteLegCalculator;
 	private final RoutingModule accessRouter;
 	private final RoutingModule egressRouter;
 
-	public StopBasedDrtRoutingModule(DrtRoutingModule drtRoutingModule, RoutingModule accessRouter,
+	public StopBasedDrtRoutingModule(DrtRouteLegCalculator drtRouteLegCalculator, RoutingModule accessRouter,
 			RoutingModule egressRouter, AccessEgressFacilityFinder stopFinder, DrtConfigGroup drtCfg, Scenario scenario,
 			Network modalNetwork) {
-		this.drtRoutingModule = drtRoutingModule;
+		this.drtRouteLegCalculator = drtRouteLegCalculator;
 		this.stopFinder = stopFinder;
 		this.drtCfg = drtCfg;
 		this.scenario = scenario;
@@ -117,7 +117,7 @@ public class StopBasedDrtRoutingModule implements RoutingModule {
 				.get(accessFacility.getLinkId()); // we want that this crashes if not found.  kai/gl, oct'19
 		Link egressActLink = modalNetwork.getLinks()
 				.get(egressFacility.getLinkId()); // we want that this crashes if not found.  kai/gl, oct'19
-		List<? extends PlanElement> drtLeg = drtRoutingModule.createRealDrtLeg(departureTime, accessActLink,
+		List<? extends PlanElement> drtLeg = drtRouteLegCalculator.createRealDrtLeg(departureTime, accessActLink,
 				egressActLink);
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModule.java
@@ -24,6 +24,7 @@ package org.matsim.contrib.drt.routing;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -77,7 +78,9 @@ public class StopBasedDrtRoutingModule implements RoutingModule {
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
 			Person person) {
-		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(fromFacility, toFacility);
+		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(
+				Objects.requireNonNull(fromFacility, "fromFacility is null"),
+				Objects.requireNonNull(toFacility, "toFacility is null"));
 		if (!stops.isPresent()) {
 			printWarning(
 					() -> "No access/egress stops found, agent will use fallback mode " + TripRouter.getFallbackMode(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -100,7 +100,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
 		}
 
-		bindModal(DrtRouteLegCalculator.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
+		bindModal(DrtRouteLegCalculator.class).toProvider(new DrtRouteLegCalculatorProvider(drtCfg));// not singleton
 		addRoutingModuleBinding(getMode()).toProvider(
 				new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
 
@@ -188,7 +188,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		}
 	}
 
-	private static class DrtRoutingModuleProvider extends ModalProviders.AbstractProvider<DrtRouteLegCalculator> {
+	private static class DrtRouteLegCalculatorProvider extends ModalProviders.AbstractProvider<DrtRouteLegCalculator> {
 		private final LeastCostPathCalculatorFactory leastCostPathCalculatorFactory = new FastAStarEuclideanFactory();
 		private final DrtConfigGroup drtCfg;
 
@@ -199,7 +199,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		@Inject
 		private Scenario scenario;
 
-		private DrtRoutingModuleProvider(DrtConfigGroup drtCfg) {
+		private DrtRouteLegCalculatorProvider(DrtConfigGroup drtCfg) {
 			super(drtCfg.getMode());
 			this.drtCfg = drtCfg;
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -21,6 +21,7 @@
 package org.matsim.contrib.drt.run;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -36,6 +37,7 @@ import org.matsim.contrib.drt.optimizer.rebalancing.NoRebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.DrtModeMinCostFlowRebalancingModule;
 import org.matsim.contrib.drt.routing.ClosestAccessEgressFacilityFinder;
+import org.matsim.contrib.drt.routing.DecideOnLinkAccessEgressFacilityFinder;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRoutingModule;
@@ -51,6 +53,7 @@ import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
@@ -73,10 +76,12 @@ import com.google.inject.name.Named;
  */
 public final class DrtModeModule extends AbstractDvrpModeModule {
 	private final DrtConfigGroup drtCfg;
+	private final PlansCalcRouteConfigGroup plansCalcRouteCfg;
 
-	public DrtModeModule(DrtConfigGroup drtCfg) {
+	public DrtModeModule(DrtConfigGroup drtCfg, PlansCalcRouteConfigGroup plansCalcRouteCfg) {
 		super(drtCfg.getMode());
 		this.drtCfg = drtCfg;
+		this.plansCalcRouteCfg = plansCalcRouteCfg;
 	}
 
 	@Override
@@ -97,7 +102,13 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		switch (drtCfg.getOperationalScheme()) {
 			case door2door:
-				addRoutingModuleBinding(getMode()).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
+				bindModal(DrtRoutingModule.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
+				addRoutingModuleBinding(getMode()).toProvider(
+						new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
+
+				bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
+						getter -> new DecideOnLinkAccessEgressFacilityFinder(getter.getModal(Network.class))))
+						.asEagerSingleton();
 				break;
 
 			case serviceAreaBased:
@@ -111,7 +122,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				bindModal(DrtRoutingModule.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
 
 				addRoutingModuleBinding(getMode()).toProvider(
-						new StopBasedDrtRoutingModuleProvider(drtCfg));// not singleton
+						new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
 
 				TypeLiteral<QuadTree<TransitStopFacility>> quadTreeTypeLiteral = new TypeLiteral<QuadTree<TransitStopFacility>>() {
 				};
@@ -160,17 +171,24 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		private Scenario scenario;
 
 		private final DrtConfigGroup drtCfg;
+		private final boolean insertingAccessEgressWalk;
 
-		private StopBasedDrtRoutingModuleProvider(DrtConfigGroup drtCfg) {
+		private StopBasedDrtRoutingModuleProvider(DrtConfigGroup drtCfg, PlansCalcRouteConfigGroup plansCalcRouteCfg) {
 			super(drtCfg.getMode());
 			this.drtCfg = drtCfg;
+			//TODO this is a temporary switch for backward compatibility with (original) DrtRoutingModule
+			//XXX in the long term: always insert access/egress walk by default
+			insertingAccessEgressWalk = drtCfg.getOperationalScheme() != DrtConfigGroup.OperationalScheme.door2door
+					|| plansCalcRouteCfg.isInsertingAccessEgressWalk();
 		}
 
 		@Override
 		public StopBasedDrtRoutingModule get() {
-			RoutingModule nonNetworkWalkRouter = new NonNetworkWalkRouter(walkRouter);
-			return new StopBasedDrtRoutingModule(getModalInstance(DrtRoutingModule.class), nonNetworkWalkRouter,
-					nonNetworkWalkRouter, getModalInstance(AccessEgressFacilityFinder.class), drtCfg, scenario,
+			RoutingModule accessEgressRouter = insertingAccessEgressWalk ?
+					new NonNetworkWalkRouter(walkRouter) :
+					(fromFacility, toFacility, departureTime, person) -> Collections.emptyList();
+			return new StopBasedDrtRoutingModule(getModalInstance(DrtRoutingModule.class), accessEgressRouter,
+					accessEgressRouter, getModalInstance(AccessEgressFacilityFinder.class), drtCfg, scenario,
 					getModalInstance(Network.class));
 		}
 	}
@@ -209,7 +227,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		private final DrtConfigGroup drtCfg;
 		private final URL context;
 
-		protected ShapeFileStopProvider(Config config, DrtConfigGroup drtCfg) {
+		private ShapeFileStopProvider(Config config, DrtConfigGroup drtCfg) {
 			super(drtCfg.getMode());
 			this.drtCfg = drtCfg;
 			this.context = config.getContext();
@@ -250,7 +268,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		private QuadTree<TransitStopFacility> stopsQT = null;
 
-		protected StopsQuadTreeProvider(DrtConfigGroup drtCfg) {
+		private StopsQuadTreeProvider(DrtConfigGroup drtCfg) {
 			super(drtCfg.getMode());
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -100,12 +100,12 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
 		}
 
+		bindModal(DrtRouteLegCalculator.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
+		addRoutingModuleBinding(getMode()).toProvider(
+				new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
+
 		switch (drtCfg.getOperationalScheme()) {
 			case door2door:
-				bindModal(DrtRouteLegCalculator.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
-				addRoutingModuleBinding(getMode()).toProvider(
-						new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
-
 				bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
 						getter -> new DecideOnLinkAccessEgressFacilityFinder(getter.getModal(Network.class))))
 						.asEagerSingleton();
@@ -119,10 +119,6 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				} else {
 					bindModal(TransitSchedule.class).toInstance(readTransitSchedule());
 				}
-				bindModal(DrtRouteLegCalculator.class).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
-
-				addRoutingModuleBinding(getMode()).toProvider(
-						new StopBasedDrtRoutingModuleProvider(drtCfg, plansCalcRouteCfg));// not singleton
 
 				TypeLiteral<QuadTree<TransitStopFacility>> quadTreeTypeLiteral = new TypeLiteral<QuadTree<TransitStopFacility>>() {
 				};
@@ -132,7 +128,6 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
 						getter -> new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 								getter.get(Network.class), getter.getModal(quadTreeTypeLiteral)))).asEagerSingleton();
-
 				break;
 
 			default:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -35,7 +35,7 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.optimizer.rebalancing.NoRebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.DrtModeMinCostFlowRebalancingModule;
-import org.matsim.contrib.drt.routing.ClosestFacilityAccessEgressFacilityFinder;
+import org.matsim.contrib.drt.routing.ClosestAccessEgressFacilityFinder;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRoutingModule;
@@ -119,7 +119,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				bindModal(quadTreeTypeLiteral).toProvider(new StopsQuadTreeProvider(drtCfg));
 
 				bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
-						getter -> new ClosestFacilityAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
+						getter -> new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 								getter.get(Network.class), getter.getModal(quadTreeTypeLiteral)))).asEagerSingleton();
 
 				break;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
@@ -20,11 +20,13 @@
 
 package org.matsim.contrib.drt.run;
 
-import com.google.inject.Inject;
 import org.matsim.contrib.drt.analysis.DrtModeAnalysisModule;
 import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
+
+import com.google.inject.Inject;
 
 /**
  * @author jbischoff
@@ -35,10 +37,13 @@ public final class MultiModeDrtModule extends AbstractModule {
 	@Inject
 	private MultiModeDrtConfigGroup multiModeDrtCfg;
 
+	@Inject
+	private PlansCalcRouteConfigGroup plansCalcRouteCfg;
+
 	@Override
 	public void install() {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
-			install(new DrtModeModule(drtCfg));
+			install(new DrtModeModule(drtCfg, plansCalcRouteCfg));
 			installQSimModule(new DrtModeQSimModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
@@ -25,6 +25,7 @@ import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
@@ -38,10 +39,13 @@ public class MultiModeEDrtModule extends AbstractModule {
 	@Inject
 	private MultiModeDrtConfigGroup multiModeDrtCfg;
 
+	@Inject
+	private PlansCalcRouteConfigGroup plansCalcRouteCfg;
+
 	@Override
 	public void install() {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
-			install(new DrtModeModule(drtCfg));
+			install(new DrtModeModule(drtCfg, plansCalcRouteCfg));
 			installQSimModule(new EDrtModeQSimModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
@@ -74,17 +74,17 @@ public class StopBasedDrtRoutingModuleTest {
 		final Double beelineFactor = 1.3;
 		TeleportationRoutingModule walkRouter = new TeleportationRoutingModule(TransportMode.walk, scenario,
 				networkTravelSpeed, beelineFactor);
-		NonNetworkWalkRouter  nonNetworkWalkRouter = new NonNetworkWalkRouter(walkRouter);
+		NonNetworkWalkRouter nonNetworkWalkRouter = new NonNetworkWalkRouter(walkRouter);
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(scenario.getConfig());
 		String drtMode = "DrtX";
 		drtCfg.setMode(drtMode);
 		QuadTree<TransitStopFacility> stopsQT = TransitScheduleUtils.createQuadTreeOfTransitStopFacilities(
 				scenario.getTransitSchedule());
-		AccessEgressFacilityFinder stopFinder = new ClosestFacilityAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
+		AccessEgressFacilityFinder stopFinder = new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 				scenario.getNetwork(), stopsQT);
 		DrtRoutingModule drtRoutingModule = new DrtRoutingModule(drtCfg, scenario.getNetwork(),
-				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new, nonNetworkWalkRouter,
-				scenario);
+				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new,
+				nonNetworkWalkRouter, scenario);
 		StopBasedDrtRoutingModule stopBasedDRTRoutingModule = new StopBasedDrtRoutingModule(drtRoutingModule,
 				nonNetworkWalkRouter, nonNetworkWalkRouter, stopFinder, drtCfg, scenario, scenario.getNetwork());
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/StopBasedDrtRoutingModuleTest.java
@@ -82,10 +82,9 @@ public class StopBasedDrtRoutingModuleTest {
 				scenario.getTransitSchedule());
 		AccessEgressFacilityFinder stopFinder = new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 				scenario.getNetwork(), stopsQT);
-		DrtRoutingModule drtRoutingModule = new DrtRoutingModule(drtCfg, scenario.getNetwork(),
-				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new,
-				nonNetworkWalkRouter, scenario);
-		StopBasedDrtRoutingModule stopBasedDRTRoutingModule = new StopBasedDrtRoutingModule(drtRoutingModule,
+		DrtRouteLegCalculator drtRouteLegCalculator = new DrtRouteLegCalculator(drtCfg, scenario.getNetwork(),
+				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new, scenario);
+		StopBasedDrtRoutingModule stopBasedDRTRoutingModule = new StopBasedDrtRoutingModule(drtRouteLegCalculator,
 				nonNetworkWalkRouter, nonNetworkWalkRouter, stopFinder, drtCfg, scenario, scenario.getNetwork());
 
 		// case 1: origin and destination within max walking distance from next stop (200m)


### PR DESCRIPTION
Since `StopBasedDrtRoutingModule` now can use different routing modules for access/egress and use different access/egress facility finders, we can simply emulate the original `DrtRoutingModule` with it, and hence the latter has been removed.

Thinking about renaming of `StopBasedDrtRoutingModule` to simple `DrtRoutingModule` (as it is now the only one)