### PR TITLE
Add DrtStopNetwork

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/ClosestAccessEgressFacilityFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/ClosestAccessEgressFacilityFinder.java
@@ -26,26 +26,26 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.routing.DrtRoutingModule.AccessEgressFacilityFinder;
 import org.matsim.core.utils.collections.QuadTree;
+import org.matsim.core.utils.collections.QuadTrees;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
+
+import com.google.common.base.Preconditions;
 
 /**
  * @author michalm
  */
 public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFinder {
 	private final Network network;
-	private final QuadTree<? extends Facility> facilityQT;
+	private final QuadTree<DrtStopFacility> drtStopQuadTree;
 	private final double maxDistance;
 
-	public ClosestAccessEgressFacilityFinder(double maxDistance, Network network,
-			QuadTree<? extends Facility> facilityQT) {
-		if (facilityQT.size() == 0) {
-			throw new IllegalArgumentException("Empty facility QuadTree");
-		}
-
+	public ClosestAccessEgressFacilityFinder(double maxDistance, Network network, DrtStopNetwork drtStopNetwork) {
+		Preconditions.checkArgument(!drtStopNetwork.getDrtStops().isEmpty(), "Empty DrtStopNetwork");
 		this.network = network;
-		this.facilityQT = facilityQT;
 		this.maxDistance = maxDistance;
+
+		drtStopQuadTree = QuadTrees.createQuadTree(drtStopNetwork.getDrtStops().values());
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFi
 
 	private Facility findClosestStop(Facility facility) {
 		Coord coord = DrtRoutingModule.getFacilityCoord(facility, network);
-		Facility closestStop = facilityQT.getClosest(coord.getX(), coord.getY());
+		Facility closestStop = drtStopQuadTree.getClosest(coord.getX(), coord.getY());
 		double closestStopDistance = CoordUtils.calcEuclideanDistance(coord, closestStop.getCoord());
 		return closestStopDistance > maxDistance ? null : closestStop;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacility.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacility.java
@@ -1,0 +1,30 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.routing;
+
+import org.matsim.api.core.v01.Identifiable;
+import org.matsim.facilities.Facility;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface DrtStopFacility extends Identifiable<DrtStopFacility>, Facility {
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacilityImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacilityImpl.java
@@ -1,0 +1,73 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.routing;
+
+import java.util.Map;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Identifiable;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.facilities.Facility;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DrtStopFacilityImpl implements DrtStopFacility {
+	public static <F extends Identifiable<?> & Facility> DrtStopFacility createFromIdentifiableFacility(F facility) {
+		return new DrtStopFacilityImpl(Id.create(facility.getId(), DrtStopFacility.class), facility.getLinkId(),
+				facility.getCoord());
+	}
+
+	public static DrtStopFacility createFromLink(Link link) {
+		return new DrtStopFacilityImpl(Id.create(link.getId(), DrtStopFacility.class), link.getId(), link.getCoord());
+	}
+
+	private final Id<DrtStopFacility> id;
+	private final Id<Link> linkId;
+	private final Coord coord;
+
+	public DrtStopFacilityImpl(Id<DrtStopFacility> id, Id<Link> linkId, Coord coord) {
+		this.id = id;
+		this.linkId = linkId;
+		this.coord = coord;
+	}
+
+	@Override
+	public Id<DrtStopFacility> getId() {
+		return id;
+	}
+
+	@Override
+	public Id<Link> getLinkId() {
+		return linkId;
+	}
+
+	@Override
+	public Coord getCoord() {
+		return coord;
+	}
+
+	@Override
+	public Map<String, Object> getCustomAttributes() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopNetwork.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopNetwork.java
@@ -1,0 +1,32 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.routing;
+
+import org.matsim.api.core.v01.Id;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface DrtStopNetwork {
+	ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> getDrtStops();
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -23,14 +23,11 @@ package org.matsim.contrib.drt.run;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.optimizer.rebalancing.NoRebalancingStrategy;
@@ -43,6 +40,9 @@ import org.matsim.contrib.drt.routing.DrtRouteLegCalculator;
 import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRoutingModule;
 import org.matsim.contrib.drt.routing.DrtRoutingModule.AccessEgressFacilityFinder;
+import org.matsim.contrib.drt.routing.DrtStopFacility;
+import org.matsim.contrib.drt.routing.DrtStopFacilityImpl;
+import org.matsim.contrib.drt.routing.DrtStopNetwork;
 import org.matsim.contrib.drt.routing.NonNetworkWalkRouter;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
@@ -60,15 +60,11 @@ import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.core.utils.collections.QuadTree;
-import org.matsim.pt.transitSchedule.TransitScheduleUtils;
-import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.utils.gis.shp2matsim.ShpGeometryUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
 
 /**
@@ -114,20 +110,15 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			case serviceAreaBased:
 			case stopbased:
 				if (drtCfg.getOperationalScheme() == DrtConfigGroup.OperationalScheme.serviceAreaBased) {
-					bindModal(TransitSchedule.class).toProvider(new ShapeFileStopProvider(getConfig(), drtCfg))
+					bindModal(DrtStopNetwork.class).toProvider(new ShapeFileStopProvider(getConfig(), drtCfg))
 							.asEagerSingleton();
 				} else {
-					bindModal(TransitSchedule.class).toInstance(readTransitSchedule());
+					bindModal(DrtStopNetwork.class).toInstance(readDrtStopNetwork());
 				}
-
-				TypeLiteral<QuadTree<TransitStopFacility>> quadTreeTypeLiteral = new TypeLiteral<QuadTree<TransitStopFacility>>() {
-				};
-
-				bindModal(quadTreeTypeLiteral).toProvider(new StopsQuadTreeProvider(drtCfg));
 
 				bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
 						getter -> new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
-								getter.get(Network.class), getter.getModal(quadTreeTypeLiteral)))).asEagerSingleton();
+								getter.get(Network.class), getter.getModal(DrtStopNetwork.class)))).asEagerSingleton();
 				break;
 
 			default:
@@ -211,7 +202,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		}
 	}
 
-	private static class ShapeFileStopProvider extends ModalProviders.AbstractProvider<TransitSchedule> {
+	private static class ShapeFileStopProvider extends ModalProviders.AbstractProvider<DrtStopNetwork> {
 
 		private final DrtConfigGroup drtCfg;
 		private final URL context;
@@ -223,52 +214,30 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		}
 
 		@Override
-		public TransitSchedule get() {
+		public DrtStopNetwork get() {
 			final List<PreparedGeometry> preparedGeometries = ShpGeometryUtils.loadPreparedGeometries(
 					drtCfg.getDrtServiceAreaShapeFileURL(context));
-			Network network = getModalInstance(Network.class);
-			Set<Link> relevantLinks = network.getLinks()
+			ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = getModalInstance(Network.class).getLinks()
 					.values()
 					.stream()
 					.filter(link -> ShpGeometryUtils.isCoordInPreparedGeometries(link.getToNode().getCoord(),
 							preparedGeometries))
-					.collect(Collectors.toSet());
-			final TransitSchedule schedule = ScenarioUtils.createScenario(ConfigUtils.createConfig())
-					.getTransitSchedule();
-			relevantLinks.stream().forEach(link -> {
-				TransitStopFacility f = schedule.getFactory()
-						.createTransitStopFacility(Id.create(link.getId(), TransitStopFacility.class),
-								link.getToNode().getCoord(), false);
-				f.setLinkId(link.getId());
-				schedule.addStopFacility(f);
-			});
-			return schedule;
+					.map(DrtStopFacilityImpl::createFromLink)
+					.collect(ImmutableMap.toImmutableMap(DrtStopFacility::getId, f -> f));
+			return () -> drtStops;
 		}
 	}
 
-	private TransitSchedule readTransitSchedule() {
+	private DrtStopNetwork readDrtStopNetwork() {
 		URL url = drtCfg.getTransitStopsFileUrl(getConfig().getContext());
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		new TransitScheduleReader(scenario).readURL(url);
-		return scenario.getTransitSchedule();
+		ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = scenario.getTransitSchedule()
+				.getFacilities()
+				.values()
+				.stream()
+				.map(DrtStopFacilityImpl::createFromIdentifiableFacility)
+				.collect(ImmutableMap.toImmutableMap(DrtStopFacility::getId, f -> f));
+		return () -> drtStops;
 	}
-
-	private static class StopsQuadTreeProvider extends ModalProviders.AbstractProvider<QuadTree<TransitStopFacility>> {
-
-		private QuadTree<TransitStopFacility> stopsQT = null;
-
-		private StopsQuadTreeProvider(DrtConfigGroup drtCfg) {
-			super(drtCfg.getMode());
-		}
-
-		@Override
-		public QuadTree<TransitStopFacility> get() {
-			if (stopsQT == null) {
-				TransitSchedule stopsTransitSchedule = getModalInstance(TransitSchedule.class);
-				stopsQT = TransitScheduleUtils.createQuadTreeOfTransitStopFacilities(stopsTransitSchedule);
-			}
-			return stopsQT;
-		}
-	}
-
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleet.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleet.java
@@ -32,5 +32,5 @@ import com.google.common.collect.ImmutableMap;
  * @author michalm
  */
 public interface Fleet {
-	ImmutableMap<Id<DvrpVehicle>, ? extends DvrpVehicle> getVehicles();
+	ImmutableMap<Id<DvrpVehicle>, DvrpVehicle> getVehicles();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleets.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleets.java
@@ -39,7 +39,7 @@ public class Fleets {
 
 	public static Fleet createCustomFleet(FleetSpecification fleetSpecification,
 			Function<DvrpVehicleSpecification, DvrpVehicle> vehicleCreator) {
-		ImmutableMap<Id<DvrpVehicle>, ? extends DvrpVehicle> vehicles = fleetSpecification.getVehicleSpecifications()
+		ImmutableMap<Id<DvrpVehicle>, DvrpVehicle> vehicles = fleetSpecification.getVehicleSpecifications()
 				.values()
 				.stream()
 				.map(vehicleCreator)

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleet.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleet.java
@@ -32,5 +32,5 @@ import com.google.common.collect.ImmutableMap;
  * @author michalm
  */
 public interface ElectricFleet {
-	ImmutableMap<Id<ElectricVehicle>, ? extends ElectricVehicle> getElectricVehicles();
+	ImmutableMap<Id<ElectricVehicle>, ElectricVehicle> getElectricVehicles();
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleets.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleets.java
@@ -31,7 +31,7 @@ public class ElectricFleets {
 	public static ElectricFleet createDefaultFleet(ElectricFleetSpecification fleetSpecification,
 			DriveEnergyConsumption.Factory driveConsumptionFactory, AuxEnergyConsumption.Factory auxConsumptionFactory,
 			ChargingPower.Factory chargingFactory) {
-		ImmutableMap<Id<ElectricVehicle>, ? extends ElectricVehicle> vehicles = fleetSpecification.getVehicleSpecifications()
+		ImmutableMap<Id<ElectricVehicle>, ElectricVehicle> vehicles = fleetSpecification.getVehicleSpecifications()
 				.values()
 				.stream()
 				.map(s -> ElectricVehicleImpl.create(s, driveConsumptionFactory, auxConsumptionFactory,

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
@@ -202,15 +202,13 @@ public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 		// TODO move it to AssignmentETaxiOptimizerParams
 		double chargingPlanningHorizon = 10 * 60;// 10 minutes (should be longer than socCheckTimeStep)
 		double maxDepartureTime = timer.getTimeOfDay() + chargingPlanningHorizon;
-		@SuppressWarnings("unchecked")
-		Stream<EvDvrpVehicle> vehiclesBelowMinSocLevel = ((Stream<EvDvrpVehicle>)fleet.getVehicles()
-				.values()
-				.stream()).filter(v -> isChargingSchedulable(v, eScheduler, maxDepartureTime));
+		Stream<DvrpVehicle> vehiclesBelowMinSocLevel = fleet.getVehicles()
+				.values().stream().filter(v -> isChargingSchedulable((EvDvrpVehicle)v, eScheduler, maxDepartureTime));
 
 		// filter least charged vehicles
 		// assumption: all b.capacities are equal
-		List<EvDvrpVehicle> leastChargedVehicles = PartialSort.kSmallestElements(pData.getSize(),
-				vehiclesBelowMinSocLevel, v -> v.getElectricVehicle().getBattery().getSoc());
+		List<DvrpVehicle> leastChargedVehicles = PartialSort.kSmallestElements(pData.getSize(),
+				vehiclesBelowMinSocLevel, v -> ((EvDvrpVehicle)v).getElectricVehicle().getBattery().getSoc());
 
 		return new VehicleData(timer.getTimeOfDay(), eScheduler, leastChargedVehicles.stream());
 	}

--- a/contribs/vsp/src/main/java/playground/vsp/avparking/PrivateAVFleetGenerator.java
+++ b/contribs/vsp/src/main/java/playground/vsp/avparking/PrivateAVFleetGenerator.java
@@ -80,7 +80,7 @@ public class PrivateAVFleetGenerator implements Fleet, BeforeMobsimListener {
 	
 	
 	@Override
-	public ImmutableMap<Id<DvrpVehicle>, ? extends DvrpVehicle> getVehicles() {
+	public ImmutableMap<Id<DvrpVehicle>, DvrpVehicle> getVehicles() {
 		return vehiclesForIteration;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/utils/collections/QuadTrees.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/QuadTrees.java
@@ -1,0 +1,70 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.core.utils.collections;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.matsim.api.core.v01.BasicLocation;
+import org.matsim.api.core.v01.Coord;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class QuadTrees {
+	public static <E extends BasicLocation> QuadTree<E> createQuadTree(Collection<E> elements) {
+		return createQuadTree(elements, BasicLocation::getCoord, 0);
+	}
+
+	public static <E> QuadTree<E> createQuadTree(Collection<E> elements, Function<E, Coord> coordFunction,
+			double buffer) {
+		Preconditions.checkArgument(buffer >= 0, "Only non-negative buffer allowed");
+		double minX = Double.POSITIVE_INFINITY;
+		double minY = Double.POSITIVE_INFINITY;
+		double maxX = Double.NEGATIVE_INFINITY;
+		double maxY = Double.NEGATIVE_INFINITY;
+
+		for (E e : elements) {
+			Coord c = coordFunction.apply(e);
+			if (c.getX() < minX) {
+				minX = c.getX();
+			}
+			if (c.getY() < minY) {
+				minY = c.getY();
+			}
+			if (c.getX() > maxX) {
+				maxX = c.getX();
+			}
+			if (c.getY() > maxY) {
+				maxY = c.getY();
+			}
+		}
+
+		QuadTree<E> quadTree = new QuadTree<E>(minX - buffer, minY - buffer, maxX + buffer, maxY + buffer);
+		for (E stop : elements) {
+			Coord c = coordFunction.apply(stop);
+			quadTree.put(c.getX(), c.getY(), stop);
+		}
+		return quadTree;
+	}
+}


### PR DESCRIPTION
To be used instead of TransitSchedule for keeping bus stops. Depending on the case, it is empty (door2door) or contains all drt-allowed links in a given area (serviceAreaBased) or contains all stops provided in a separate file (stopBased).

The input file for the 3rd case uses "transit schedule" format (as before), but this may be changed at some point in the future.

===

7555ad4 adds a simple `QuadTrees` util for creating quad trees - I have seen almost exactly the same code in dozens of places (incl. contribs, playgrounds etc.). Have not yet refactored that duplication though.