### PR TITLE
Customise access egress routing for drt

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/NonNetworkWalkRouter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/NonNetworkWalkRouter.java
@@ -29,6 +29,9 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
 
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
 import one.util.streamex.StreamEx;
 
 /**
@@ -37,7 +40,8 @@ import one.util.streamex.StreamEx;
 public final class NonNetworkWalkRouter implements RoutingModule {
 	private final RoutingModule walkRouter;
 
-	public NonNetworkWalkRouter(RoutingModule walkRouter) {
+	@Inject
+	public NonNetworkWalkRouter(@Named(TransportMode.walk) RoutingModule walkRouter) {
 		this.walkRouter = walkRouter;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtModule.java
@@ -22,7 +22,6 @@ package org.matsim.contrib.drt.run;
 
 import org.matsim.contrib.drt.analysis.DrtModeAnalysisModule;
 import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
@@ -37,13 +36,10 @@ public final class MultiModeDrtModule extends AbstractModule {
 	@Inject
 	private MultiModeDrtConfigGroup multiModeDrtCfg;
 
-	@Inject
-	private PlansCalcRouteConfigGroup plansCalcRouteCfg;
-
 	@Override
 	public void install() {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
-			install(new DrtModeModule(drtCfg, plansCalcRouteCfg));
+			install(new DrtModeModule(drtCfg));
 			installQSimModule(new DrtModeQSimModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
@@ -25,7 +25,6 @@ import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
@@ -39,13 +38,10 @@ public class MultiModeEDrtModule extends AbstractModule {
 	@Inject
 	private MultiModeDrtConfigGroup multiModeDrtCfg;
 
-	@Inject
-	private PlansCalcRouteConfigGroup plansCalcRouteCfg;
-
 	@Override
 	public void install() {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
-			install(new DrtModeModule(drtCfg, plansCalcRouteCfg));
+			install(new DrtModeModule(drtCfg));
 			installQSimModule(new EDrtModeQSimModule(drtCfg));
 			install(new DrtModeAnalysisModule(drtCfg));
 		}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeModule.java
@@ -28,6 +28,7 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.MapBinder;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -57,6 +58,10 @@ public abstract class AbstractDvrpModeModule extends AbstractModule {
 
 	protected <T> LinkedBindingBuilder<T> bindModal(TypeLiteral<T> typeLiteral) {
 		return bind(modalKey(typeLiteral));
+	}
+
+	protected <K, V> MapBinder<K, V> modalMapBinder(Class<K> keyType, Class<V> valueType) {
+		return MapBinder.newMapBinder(binder(), keyType, valueType, DvrpModes.mode(getMode()));
 	}
 
 	protected <T> Provider<T> modalProvider(Function<ModalProviders.InstanceGetter, T> delegate) {


### PR DESCRIPTION
access/egress routing modules for each DRT mode can be set in the following way:

```
MapBinder<Direction, RoutingModule> mapBinder = modalMapBinder(Direction.class, RoutingModule.class);

//access DRT with taxi :-)
mapBinder.addBinding(Direction.ACCESS).to(Key.get(RoutingModule.class, Names.named("taxi")));

//provide some fancy dynamic way of routing the egress (sub-)trip
mapBinder.addBinding(Direction.EGRESS).toProvider(...);
```

When not set, a `non_network_walk` is inserted for both access and egress.

====

To be backward-compatible with the "no access/egress walks" option, set the following bindings:
```
mapBinder.addBinding(Direction.ACCESS).toInstance((fromFacility, toFacility, departureTime, person) -> Collections.emptyList());
mapBinder.addBinding(Direction.EGRESS).toInstance((fromFacility, toFacility, departureTime, person) -> Collections.emptyList());
```