### PR TITLE
Routing obeying max speed of vehicle implemented for link-to-link TT's

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
@@ -186,7 +186,7 @@ class LinkToLinkRoutingModule implements RoutingModule
                     .get(Id.create(invLink.getFromNode().getId(), Link.class));
             Link toLink = network.getLinks()
                     .get(Id.create(invLink.getToNode().getId(), Link.class));
-            return linkToLinkTravelTime.getLinkToLinkTravelTime(fromLink, toLink, time);
+            return linkToLinkTravelTime.getLinkToLinkTravelTime(fromLink, toLink, time, person, vehicle);
         }
     }
 

--- a/matsim/src/main/java/org/matsim/core/router/costcalculators/FreespeedTravelTimeAndDisutility.java
+++ b/matsim/src/main/java/org/matsim/core/router/costcalculators/FreespeedTravelTimeAndDisutility.java
@@ -111,7 +111,7 @@ public class FreespeedTravelTimeAndDisutility implements TravelDisutility, Trave
 	 * If travelling freespeed the turning move travel time is not relevant
 	 */
 	@Override
-	public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time) {
+	public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time, Person person, Vehicle vehicle) {
 		return this.getLinkTravelTime(fromLink, time, null, null);
 	}
 	

--- a/matsim/src/main/java/org/matsim/core/router/util/LinkToLinkTravelTime.java
+++ b/matsim/src/main/java/org/matsim/core/router/util/LinkToLinkTravelTime.java
@@ -20,6 +20,8 @@
 package org.matsim.core.router.util;
 
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.vehicles.Vehicle;
 
 
 
@@ -44,6 +46,6 @@ public interface LinkToLinkTravelTime {
 	 * 		<code>fromLink</code> and enter the toLink <code>toLink</code>, 
 	 * departing at time <code>time</code>.
 	 */
-	public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time);
+	public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time, Person person, Vehicle vehicle);
 
 }

--- a/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
@@ -31,7 +31,7 @@ import org.matsim.core.router.costcalculators.*;
 import org.matsim.core.router.util.*;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
-
+import org.matsim.vehicles.Vehicle;
 import org.junit.Assert;
 
 
@@ -121,7 +121,7 @@ public class InvertertedNetworkRoutingTest {
 		}
 
 		@Override
-		public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time) {
+		public double getLinkToLinkTravelTime(Link fromLink, Link toLink, double time, Person person, Vehicle vehicle) {
 			double tt = fromLink.getLength() / fromLink.getFreespeed(time);
 			if (Id.create("34", Link.class).equals(toLink.getId())){
 				tt = tt + this.turningMoveCosts34;

--- a/matsim/src/test/java/org/matsim/core/trafficmonitoring/LinkToLinkTravelTimeCalculatorTest.java
+++ b/matsim/src/test/java/org/matsim/core/trafficmonitoring/LinkToLinkTravelTimeCalculatorTest.java
@@ -89,18 +89,18 @@ public class LinkToLinkTravelTimeCalculatorTest extends MatsimTestCase {
 		assertEquals(10     , ttcalc.getLinkTravelTimes().getLinkTravelTime(link1, 7.0 * 3600 + 5 * 60 + 4*timeBinSize, null, null), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 1*timeBinSize
 		assertEquals(10     , ttcalc.getLinkTravelTimes().getLinkTravelTime(link1, 7.0 * 3600 + 5 * 60 + 5*timeBinSize, null, null), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 2*timeBinSize
 		
-		assertEquals(50 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60), EPSILON); // linkTravelTime1
-		assertEquals(35 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 1*timeBinSize), EPSILON);  // linkTravelTime1 - 1*timeBinSize
-		assertEquals(20 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 2*timeBinSize), EPSILON);  // linkTravelTime1 - 2*timeBinSize
-		assertEquals(10 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 3*timeBinSize), EPSILON);  // linkTravelTime2 > linkTravelTime1 - 3*timeBinSize !
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 4*timeBinSize), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 1*timeBinSize
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 5*timeBinSize), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 2*timeBinSize
+		assertEquals(50 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60, null, null), EPSILON); // linkTravelTime1
+		assertEquals(35 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 1*timeBinSize, null, null), EPSILON);  // linkTravelTime1 - 1*timeBinSize
+		assertEquals(20 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 2*timeBinSize, null, null), EPSILON);  // linkTravelTime1 - 2*timeBinSize
+		assertEquals(10 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 3*timeBinSize, null, null), EPSILON);  // linkTravelTime2 > linkTravelTime1 - 3*timeBinSize !
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 4*timeBinSize, null, null), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 1*timeBinSize
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link2, 7.0 * 3600 + 5 * 60 + 5*timeBinSize, null, null), EPSILON);  // freespeedTravelTime > linkTravelTime2 - 2*timeBinSize
 
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60), EPSILON); // freespeed travel time
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 1*timeBinSize), EPSILON);  // freespeed
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 2*timeBinSize), EPSILON);  // freespeed
-		assertEquals(16 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 3*timeBinSize), EPSILON);  // linkTravelTime3
-		assertEquals( 1 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 4*timeBinSize), EPSILON);  // linkTravelTime3 - 1*timeBinSize
-		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 5*timeBinSize), EPSILON);  // freespeedTravelTime > linkTravelTime2b - 2*timeBinSize
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60, null, null), EPSILON); // freespeed travel time
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 1*timeBinSize, null, null), EPSILON);  // freespeed
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 2*timeBinSize, null, null), EPSILON);  // freespeed
+		assertEquals(16 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 3*timeBinSize, null, null), EPSILON);  // linkTravelTime3
+		assertEquals( 1 * 60, ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 4*timeBinSize, null, null), EPSILON);  // linkTravelTime3 - 1*timeBinSize
+		assertEquals(10     , ttcalc.getLinkToLinkTravelTimes().getLinkToLinkTravelTime(link1, link3, 7.0 * 3600 + 5 * 60 + 5*timeBinSize, null, null), EPSILON);  // freespeedTravelTime > linkTravelTime2b - 2*timeBinSize
 	}
 }


### PR DESCRIPTION
About a year ago the traveltimes and traveltimescalculators were changed in order to not allow the router too use too small observed (from earlier iteration) speeds, i.e. that the routing travel time for a link can never be lower than when using the maximum speed of the vehicle.

This feature has now been introduced for link-to-link-traveltimes too. 

I'm still a newbie concerning these requests, so tell me if I'm doing something wrong.