### PR TITLE
ConfigurableQNetworkFactory should only set explicitly set properties

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
@@ -29,91 +29,96 @@ import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.interfaces.AgentCounter;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngine.NetsimInternalInterface;
-import org.matsim.core.mobsim.qsim.qnetsimengine.flow_efficiency.DefaultFlowEfficiencyCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.flow_efficiency.FlowEfficiencyCalculator;
-import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
-import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.DefaultVehicleHandler;
 import org.matsim.core.mobsim.qsim.qnetsimengine.vehicle_handler.VehicleHandler;
-import org.matsim.core.mobsim.qsim.qnetsimengine.vehicleq.FIFOVehicleQ;
 import org.matsim.core.mobsim.qsim.qnetsimengine.vehicleq.VehicleQ;
 import org.matsim.vis.snapshotwriters.SnapshotLinkWidthCalculator;
 
+import java.util.Optional;
+
 
 /**
- * 
  * @author knagel
- * 
  * @see DefaultQNetworkFactory
  */
 public final class ConfigurableQNetworkFactory implements QNetworkFactory {
-	private QSimConfigGroup qsimConfig ;
-	private EventsManager events ;
-	private Network network ;
-	private Scenario scenario ;
+	private QSimConfigGroup qsimConfig;
+	private EventsManager events;
+	private Network network;
+	private Scenario scenario;
 	private NetsimEngineContext context;
-	private NetsimInternalInterface netsimEngine ;
-	private LinkSpeedCalculator linkSpeedCalculator = new DefaultLinkSpeedCalculator() ;
-	private TurnAcceptanceLogic turnAcceptanceLogic = new DefaultTurnAcceptanceLogic() ;
-	private VehicleHandler vehicleHandler = new DefaultVehicleHandler();
-	private FlowEfficiencyCalculator flowEfficiencyCalculator = new DefaultFlowEfficiencyCalculator();
-	private VehicleQ.Factory<QVehicle> vehicleQFactory = FIFOVehicleQ::new ;
+	private NetsimInternalInterface netsimEngine;
+	private Optional<LinkSpeedCalculator> linkSpeedCalculator = Optional.empty();
+	private Optional<TurnAcceptanceLogic> turnAcceptanceLogic = Optional.empty();
+	private Optional<VehicleHandler> vehicleHandler = Optional.empty();
+	private Optional<FlowEfficiencyCalculator> flowEfficiencyCalculator = Optional.empty();
+	private Optional<VehicleQ.Factory<QVehicle>> vehicleQFactory = Optional.empty();
 
-	public ConfigurableQNetworkFactory( EventsManager events, Scenario scenario ) {
+	public ConfigurableQNetworkFactory(EventsManager events, Scenario scenario) {
 		this.events = events;
 		this.scenario = scenario;
-		this.network = scenario.getNetwork() ;
-		this.qsimConfig = scenario.getConfig().qsim() ;
+		this.network = scenario.getNetwork();
+		this.qsimConfig = scenario.getConfig().qsim();
 	}
+
 	@Override
-	public void initializeFactory( AgentCounter agentCounter, MobsimTimer mobsimTimer, NetsimInternalInterface netsimEngine1 ) {
+	public void initializeFactory(AgentCounter agentCounter, MobsimTimer mobsimTimer, NetsimInternalInterface netsimEngine1) {
 		this.netsimEngine = netsimEngine1;
-		double effectiveCellSize = network.getEffectiveCellSize() ;
+		double effectiveCellSize = network.getEffectiveCellSize();
 		SnapshotLinkWidthCalculator linkWidthCalculator = new SnapshotLinkWidthCalculator();
-		linkWidthCalculator.setLinkWidthForVis( qsimConfig.getLinkWidthForVis() );
-		if (! Double.isNaN(network.getEffectiveLaneWidth())){
-			linkWidthCalculator.setLaneWidth( network.getEffectiveLaneWidth() );
+		linkWidthCalculator.setLinkWidthForVis(qsimConfig.getLinkWidthForVis());
+		if (!Double.isNaN(network.getEffectiveLaneWidth())) {
+			linkWidthCalculator.setLaneWidth(network.getEffectiveLaneWidth());
 		}
-		AbstractAgentSnapshotInfoBuilder agentSnapshotInfoBuilder = QNetsimEngine.createAgentSnapshotInfoBuilder( scenario, linkWidthCalculator );
-		context = new NetsimEngineContext( events, effectiveCellSize, agentCounter, agentSnapshotInfoBuilder, qsimConfig, mobsimTimer, linkWidthCalculator );
+		AbstractAgentSnapshotInfoBuilder agentSnapshotInfoBuilder = QNetsimEngine.createAgentSnapshotInfoBuilder(scenario, linkWidthCalculator);
+		context = new NetsimEngineContext(events, effectiveCellSize, agentCounter, agentSnapshotInfoBuilder, qsimConfig, mobsimTimer, linkWidthCalculator);
 	}
 	@Override
 	public QLinkI createNetsimLink( final Link link, final QNodeI toQueueNode ) {
 
-		QLinkImpl.Builder linkBuilder = new QLinkImpl.Builder(context, netsimEngine) ;
+		// the QLink.Builder and the QueueWithBuffer.Builder pick the correct implementations of
+		// vehicleQFactory, flowEfficiencyCalculator and so on based on the config.
+		// We should only override that choice if the configured properties are explicitly set. Janek 11.19
+		QLinkImpl.Builder linkBuilder = new QLinkImpl.Builder(context, netsimEngine);
 		{
-			QueueWithBuffer.Builder laneFactory = new QueueWithBuffer.Builder( context );
-			laneFactory.setVehicleQueue( vehicleQFactory.createVehicleQ() );
-			laneFactory.setFlowEfficiencyCalculator(flowEfficiencyCalculator);
-			linkBuilder.setLaneFactory( laneFactory );
+			QueueWithBuffer.Builder laneFactory = new QueueWithBuffer.Builder(context);
+			vehicleQFactory.ifPresent(factory -> laneFactory.setVehicleQueue(factory.createVehicleQ()));
+			flowEfficiencyCalculator.ifPresent(laneFactory::setFlowEfficiencyCalculator);
+			linkBuilder.setLaneFactory(laneFactory);
 		}
-		linkBuilder.setLinkSpeedCalculator( linkSpeedCalculator ) ;
-		linkBuilder.setVehicleHandler(vehicleHandler);
+		linkSpeedCalculator.ifPresent(linkBuilder::setLinkSpeedCalculator);
+		vehicleHandler.ifPresent(linkBuilder::setVehicleHandler);
 
-		return linkBuilder.build(link, toQueueNode) ;
+		return linkBuilder.build(link, toQueueNode);
 	}
+
 	@Override
 	public QNodeI createNetsimNode( final Node node ) {
-		QNodeImpl.Builder builder = new QNodeImpl.Builder( netsimEngine, context ) ;
+		QNodeImpl.Builder builder = new QNodeImpl.Builder(netsimEngine, context);
 
-		builder.setTurnAcceptanceLogic( this.turnAcceptanceLogic ) ;
+		turnAcceptanceLogic.ifPresent(builder::setTurnAcceptanceLogic);
 
-		return builder.build( node ) ;
+		return builder.build(node);
 	}
+
 	public final void setLinkSpeedCalculator(LinkSpeedCalculator linkSpeedCalculator) {
-		this.linkSpeedCalculator = linkSpeedCalculator;
-	}
-	public final void setTurnAcceptanceLogic( TurnAcceptanceLogic turnAcceptanceLogic ) {
-		this.turnAcceptanceLogic = turnAcceptanceLogic;
-	}
-	public final void setVehicleHandler(VehicleHandler vehicleHandler) {
-		this.vehicleHandler = vehicleHandler;
-	}
-	public final void setVehicleQFactory( VehicleQ.Factory<QVehicle> factory ) {
-		this.vehicleQFactory = factory ;
-	}
-	public final void setFlowEfficiencyCalculator(FlowEfficiencyCalculator flowEfficiencyCalculator) {
-		this.flowEfficiencyCalculator = flowEfficiencyCalculator;
+		this.linkSpeedCalculator = Optional.of(linkSpeedCalculator);
 	}
 
+	public final void setTurnAcceptanceLogic( TurnAcceptanceLogic turnAcceptanceLogic ) {
+		this.turnAcceptanceLogic = Optional.of(turnAcceptanceLogic);
+	}
+
+	public final void setVehicleHandler(VehicleHandler vehicleHandler) {
+		this.vehicleHandler = Optional.of(vehicleHandler);
+	}
+
+	public final void setVehicleQFactory( VehicleQ.Factory<QVehicle> factory ) {
+		this.vehicleQFactory = Optional.of(factory);
+	}
+
+	public final void setFlowEfficiencyCalculator(FlowEfficiencyCalculator flowEfficiencyCalculator) {
+		this.flowEfficiencyCalculator = Optional.of(flowEfficiencyCalculator);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/RunConfigurableQNetworkFactoryExample.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/RunConfigurableQNetworkFactoryExample.java
@@ -22,9 +22,9 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.DefaultLinkSpeedCalculator;
 import org.matsim.core.scenario.ScenarioUtils;
 
 /**
@@ -50,10 +50,10 @@ public class RunConfigurableQNetworkFactoryExample {
 		
 		controler.addOverridingQSimModule( new AbstractQSimModule(){
 			@Override public void configureQSim() {
-				final ConfigurableQNetworkFactory factory = new ConfigurableQNetworkFactory( events, scenario ) ;
-				factory.setLinkSpeedCalculator(null); // fill with something reasonable
-				factory.setTurnAcceptanceLogic(null); // fill with something reasonable
-				bind( QNetworkFactory.class ).toInstance( factory ) ;
+				final ConfigurableQNetworkFactory factory = new ConfigurableQNetworkFactory(events, scenario);
+				factory.setLinkSpeedCalculator(new DefaultLinkSpeedCalculator()); // You would obviously set something else than the default
+				factory.setTurnAcceptanceLogic(new DefaultTurnAcceptanceLogic()); // You would obviously set something else than the default
+				bind(QNetworkFactory.class).toInstance(factory);
 				// NOTE: Other than when using a provider, this uses the same factory instance over all iterations, re-configuring
 				// it in every iteration via the initializeFactory(...) method. kai, mar'16
 			}


### PR DESCRIPTION
Make ConfigurableQNetworkFactory only override defaults of QLink and QNode implementations if overrides are explicitly set. Otherwise just leave those defaults alone