### PR TITLE
FixTripRouter

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -290,10 +290,17 @@ public final class TripRouter implements MatsimExtensionPoint {
 			}
 			if (pe == destination) {
 				indexOfDestination = currentIndex;
+			}
+			if( indexOfDestination != -1 && indexOfOrigin != -1){
 				if (indexOfDestination < indexOfOrigin ) {
+					if(indexOfDestination == 0){ //the last activity in the plan might be the same as the firt activity, so this could be the last (return) trip of the day. we should continue searching
+						indexOfDestination = -1;
+						currentIndex ++;
+						continue;
+					}
 					throw new RuntimeException(
 							"destination "+destination+" found before origin "+
-							origin+" in "+plan );
+									origin+" in "+plan );
 				}
 				break;
 			}

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -293,7 +293,7 @@ public final class TripRouter implements MatsimExtensionPoint {
 			}
 			if( indexOfDestination != -1 && indexOfOrigin != -1){
 				if (indexOfDestination < indexOfOrigin ) {
-					if(indexOfDestination == 0){ //the last activity in the plan might be the same as the firt activity, so this could be the last (return) trip of the day. we should continue searching
+					if(indexOfDestination == 0){ //the last activity in the plan might be the same as the first activity, so this could be the last (return) trip of the day. we should continue searching
 						indexOfDestination = -1;
 						currentIndex ++;
 						continue;


### PR DESCRIPTION
deal with plans where the last activity is the same instance as the first activity (MATSim logic).

This fixes a bug which seems to occur when one creates plan with the default population factory.
Before, the trip router would not find the indexOfOrigin for the last trip of the day, since after setting the indexOfDestination to 0 (which is wrong) it would break out of the loop.
Now, we only break if both indices are altered and still have the consistency check if indices have the right order. Moreover, we check for the above mentioned special case.

This problem did not seem to occur for population which was parsed in from an input file.