### PR TITLE
Fallback routing: remove/mark for deletion methods no longer used since routing mode

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Activity;
@@ -83,16 +84,16 @@ public class DrtRoutingModule implements RoutingModule {
 				Objects.requireNonNull(fromFacility, "fromFacility is null"),
 				Objects.requireNonNull(toFacility, "toFacility is null"));
 		if (!stops.isPresent()) {
-			logger.debug("No access/egress stops found, agent will use fallback mode " + TripRouter.getFallbackMode(
-					drtCfg.getMode()) + ". Agent Id:\t" + person.getId());
+			logger.debug("No access/egress stops found, agent will use fallback mode as leg mode (usually " + 
+					TransportMode.walk + ") and routing mode " + drtCfg.getMode() + ". Agent Id:\t" + person.getId());
 			return null;
 		}
 
 		Facility accessFacility = stops.get().getLeft();
 		Facility egressFacility = stops.get().getRight();
 		if (accessFacility.getLinkId().equals(egressFacility.getLinkId())) {
-			logger.debug("Start and end stop are the same, agent will use fallback mode " + TripRouter.getFallbackMode(
-					drtCfg.getMode()) + ". Agent Id:\t" + person.getId());
+			logger.debug("Start and end stop are the same, agent will use fallback mode as leg mode (usually " + 
+					TransportMode.walk + ") and routing mode " + drtCfg.getMode() + ". Agent Id:\t" + person.getId());
 			return null;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifier.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifier.java
@@ -49,6 +49,8 @@ public class MultiModeDrtMainModeIdentifier implements MainModeIdentifier {
 				.stream()
 				.map(DrtConfigGroup::getMode)
 				.collect(Collectors.toMap(s -> new DrtStageActivityType(s).drtStageActivity, s -> s));
+		
+		// #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 		fallbackModeToDrtMode = drtCfg.getModalElements()
 				.stream()
 				.map(DrtConfigGroup::getMode)
@@ -64,6 +66,7 @@ public class MultiModeDrtMainModeIdentifier implements MainModeIdentifier {
 					return type;
 				}
 			} else if (pe instanceof Leg) {
+				// #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 				String mode = fallbackModeToDrtMode.get(((Leg)pe).getMode());
 				if (mode != null) {
 					return mode;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
@@ -51,9 +51,6 @@ public class DrtConfigs {
 				addDrtStageActivityParams(planCalcScoreCfg, drtStageActivityType.drtStageActivity);
 			}
 		}
-		if (!planCalcScoreCfg.getModes().containsKey(TripRouter.getFallbackMode(drtCfg.getMode()))) {
-			addDrtWalkModeParams(planCalcScoreCfg, TripRouter.getFallbackMode(drtCfg.getMode()));
-		}
 	}
 
 	private static void addDrtStageActivityParams(PlanCalcScoreConfigGroup planCalcScoreCfg, String stageActivityType) {
@@ -65,14 +62,4 @@ public class DrtConfigs {
 		LOGGER.info("drt interaction scoring parameters not set. Adding default values (activity will not be scored).");
 	}
 
-	private static void addDrtWalkModeParams(PlanCalcScoreConfigGroup planCalcScoreCfg, String drtWalkMode) {
-		PlanCalcScoreConfigGroup.ModeParams drtWalk = new PlanCalcScoreConfigGroup.ModeParams(drtWalkMode);
-		PlanCalcScoreConfigGroup.ModeParams walk = planCalcScoreCfg.getModes().get(TransportMode.walk);
-		drtWalk.setConstant(walk.getConstant());
-		drtWalk.setMarginalUtilityOfDistance(walk.getMarginalUtilityOfDistance());
-		drtWalk.setMarginalUtilityOfTraveling(walk.getMarginalUtilityOfTraveling());
-		drtWalk.setMonetaryDistanceRate(walk.getMonetaryDistanceRate());
-		planCalcScoreCfg.getScoringParametersPerSubpopulation().values().forEach(k -> k.addModeParams(drtWalk));
-		LOGGER.info("drt_walk scoring parameters not set. Adding default values (same as for walk mode).");
-	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifierTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/MultiModeDrtMainModeIdentifierTest.java
@@ -45,6 +45,8 @@ public class MultiModeDrtMainModeIdentifierTest {
 		{
 			DrtStageActivityType drtStageActivityType = new DrtStageActivityType(drtMode);
 			List<PlanElement> testElements = new ArrayList<>();
+			
+			// #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 			Leg l1 = PopulationUtils.createLeg(TripRouter.getFallbackMode(drtMode));
 			Activity a2 = PopulationUtils.createActivityFromCoord(drtStageActivityType.drtStageActivity,
 					new Coord(0, 0));

--- a/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
+++ b/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
@@ -34,6 +34,11 @@ class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 		Coord toCoord = FacilitiesUtils.decideOnCoord( toFacility, network, config ) ;
 		Id<Link> dpLinkId = FacilitiesUtils.decideOnLink( fromFacility, network ).getId() ;
 		Id<Link> arLinkId = FacilitiesUtils.decideOnLink( toFacility, network ).getId() ;
+		/*
+		 * Even TransportMode.walk needs an "UltimateFallbackRoutingModule", but for all other modes (pt, drt, ...) it
+		 * would be better if we would try the walkRouter first and fall back to "UltimateFallbackRoutingModule" or a
+		 * handwritten teleported walk like below only if the walkRouter returns null. - gl/kn-dec'19
+		 */
 		NetworkRoutingInclAccessEgressModule.routeBushwhackingLeg( person, leg, fromCoord, toCoord, departureTime, dpLinkId, arLinkId, population.getFactory(), 
 				pcrCfg.getModeRoutingParams().get(TransportMode.walk) ) ;
 		return Collections.singletonList( leg ) ;

--- a/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
+++ b/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 
+	@Deprecated // #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 	public static final String _fallback = "_fallback";
 
 	@Inject private PlansCalcRouteConfigGroup pcrCfg;

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -322,10 +322,12 @@ public final class TripRouter implements MatsimExtensionPoint {
 		return config;
 	}
 
+	@Deprecated // #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 	public static String getFallbackMode(String transportMode) {
 		return transportMode + FallbackRoutingModuleDefaultImpl._fallback;
 	}
 
+	@Deprecated // #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)
 	public static boolean isFallbackMode(String mode) {
 		return mode.endsWith(FallbackRoutingModuleDefaultImpl._fallback);
 	}


### PR DESCRIPTION
With routing mode we do not need separate fallback modes any longer. This made some methods only introduced in september superfluous. Some calls to these methods could already be removed. However, others are necessary for the MultiModeDrtMainModeIdentifier to retrofit old plans (created from september to december 2019) for routing mode. Those are marked for deletion before the 12.0 relaese with the following comment:

`// #deleteBeforeRelease : only used to retrofit plans created since the merge of fallback routing module (sep'-dec'19)`