### PR TITLE
downgrade surefire/failsafe from 3.0.0-M4 to 2.22.2

### DIFF
--- a/contribs/pom.xml
+++ b/contribs/pom.xml
@@ -59,7 +59,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M4</version>
+				<version>2.22.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -116,7 +116,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M4</version>
+					<version>2.22.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M4</version>
+				<version>2.22.2</version>
 				<configuration>
 					<excludes>
 						<exclude>**/*$*</exclude> <!-- exclude all inner classes -->
@@ -218,7 +218,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M4</version>
+				<version>2.22.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -260,7 +260,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.0.0-M4</version>
+				<version>2.22.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
try out as a temp fix for the failing jenkins pipeline: http://ci.matsim.org:8080/job/MATSim_M2/