### PR TITLE
Generalise drt routing

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -24,7 +24,7 @@ import org.matsim.contrib.drt.optimizer.VehicleData.Stop;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
-import org.matsim.contrib.drt.routing.DrtRouteLegCalculator;
+import org.matsim.contrib.drt.routing.DrtMainLegRouter;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtTask;
@@ -225,7 +225,7 @@ public class InsertionCostCalculator {
 
 	/**
 	 * The request constraints are set in {@link DrtRequest}, which is used by {@link DrtRequestCreator},
-	 * which is used by {@link DrtRouteLegCalculator} and {@link DefaultDrtRouteUpdater}.  kai, nov'18
+	 * which is used by {@link DrtMainLegRouter} and {@link DefaultDrtRouteUpdater}.  kai, nov'18
 	 */
 	private double calcSoftConstraintPenalty(DrtRequest drtRequest, VehicleData.Entry vEntry,
 			InsertionWithDetourTimes insertion, double pickupDetourTimeLoss) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtMainLegRouter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtMainLegRouter.java
@@ -24,17 +24,21 @@ import java.util.List;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.facilities.Facility;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.name.Named;
 
@@ -43,13 +47,14 @@ import com.google.inject.name.Named;
  * @author michalm (Michal Maciejewski)
  * @author Kai Nagel
  */
-public class DrtRouteLegCalculator {
+public class DrtMainLegRouter implements RoutingModule {
 	private final DrtConfigGroup drtCfg;
 	private final TravelTime travelTime;
 	private final LeastCostPathCalculator router;
 	private final PopulationFactory populationFactory;
+	private final Network modalNetwork;
 
-	public DrtRouteLegCalculator(DrtConfigGroup drtCfg, Network drtNetwork,
+	public DrtMainLegRouter(DrtConfigGroup drtCfg, Network modalNetwork,
 			LeastCostPathCalculatorFactory leastCostPathCalculatorFactory,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
 			TravelDisutilityFactory travelDisutilityFactory, PopulationFactory populationFactory) {
@@ -60,10 +65,11 @@ public class DrtRouteLegCalculator {
 		this.drtCfg = drtCfg;
 		this.travelTime = travelTime;
 		this.populationFactory = populationFactory;
+		this.modalNetwork = modalNetwork;
 
 		// Euclidean with overdoFactor > 1.0 could lead to 'experiencedTT < unsharedRideTT',
 		// while the benefit would be a marginal reduction of computation time ==> so stick to 1.0
-		router = leastCostPathCalculatorFactory.createPathCalculator(drtNetwork,
+		router = leastCostPathCalculatorFactory.createPathCalculator(modalNetwork,
 				travelDisutilityFactory.createTravelDisutility(travelTime), travelTime);
 	}
 
@@ -78,8 +84,13 @@ public class DrtRouteLegCalculator {
 		return drtCfg.getMaxTravelTimeAlpha() * unsharedRideTime + drtCfg.getMaxTravelTimeBeta();
 	}
 
-	List<PlanElement> createRealDrtLeg(final double departureTime, final Link accessActLink,
-			final Link egressActLink) {
+	@Override
+	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
+			Person person) {
+		Link accessActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(fromFacility.getLinkId()),
+				"link: %s does not exist in the network of mode: %s", fromFacility.getLinkId(), drtCfg.getMode());
+		Link egressActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(toFacility.getLinkId()),
+				"link: %s does not exist in the network of mode: %s", toFacility.getLinkId(), drtCfg.getMode());
 		DrtRoute route = createDrtRoute(departureTime, accessActLink, egressActLink);
 
 		Leg leg = populationFactory.createLeg(drtCfg.getMode());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -53,13 +53,13 @@ public class DrtRoutingModule implements RoutingModule {
 	private final AccessEgressFacilityFinder stopFinder;
 	private final DrtConfigGroup drtCfg;
 	private final Scenario scenario;
-	private final DrtMainLegRouter drtMainLegRouter;
+	private final RoutingModule mainRouter;
 	private final RoutingModule accessRouter;
 	private final RoutingModule egressRouter;
 
-	public DrtRoutingModule(DrtMainLegRouter drtMainLegRouter, RoutingModule accessRouter, RoutingModule egressRouter,
+	public DrtRoutingModule(RoutingModule mainRouter, RoutingModule accessRouter, RoutingModule egressRouter,
 			AccessEgressFacilityFinder stopFinder, DrtConfigGroup drtCfg, Scenario scenario) {
-		this.drtMainLegRouter = drtMainLegRouter;
+		this.mainRouter = mainRouter;
 		this.stopFinder = stopFinder;
 		this.drtCfg = drtCfg;
 		this.scenario = scenario;
@@ -114,8 +114,7 @@ public class DrtRoutingModule implements RoutingModule {
 		}
 
 		// drt proper leg:
-		List<? extends PlanElement> drtLeg = drtMainLegRouter.calcRoute(accessFacility, egressFacility, now,
-				person);
+		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(accessFacility, egressFacility, now, person);
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {
 			now = TripRouter.calcEndOfPlanElement(now, planElement, scenario.getConfig());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoutingModule.java
@@ -17,9 +17,6 @@
  *                                                                         *
  * *********************************************************************** */
 
-/**
- *
- */
 package org.matsim.contrib.drt.routing;
 
 import java.util.ArrayList;
@@ -32,7 +29,6 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Person;
@@ -41,8 +37,6 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.Facility;
-
-import com.google.common.base.Verify;
 
 /**
  * @author jbischoff
@@ -56,23 +50,20 @@ public class DrtRoutingModule implements RoutingModule {
 	}
 
 	private final DrtStageActivityType drtStageActivityType;
-	private final Network modalNetwork;
 	private final AccessEgressFacilityFinder stopFinder;
 	private final DrtConfigGroup drtCfg;
 	private final Scenario scenario;
-	private final DrtRouteLegCalculator drtRouteLegCalculator;
+	private final DrtMainLegRouter drtMainLegRouter;
 	private final RoutingModule accessRouter;
 	private final RoutingModule egressRouter;
 
-	public DrtRoutingModule(DrtRouteLegCalculator drtRouteLegCalculator, RoutingModule accessRouter,
-			RoutingModule egressRouter, AccessEgressFacilityFinder stopFinder, DrtConfigGroup drtCfg, Scenario scenario,
-			Network modalNetwork) {
-		this.drtRouteLegCalculator = drtRouteLegCalculator;
+	public DrtRoutingModule(DrtMainLegRouter drtMainLegRouter, RoutingModule accessRouter, RoutingModule egressRouter,
+			AccessEgressFacilityFinder stopFinder, DrtConfigGroup drtCfg, Scenario scenario) {
+		this.drtMainLegRouter = drtMainLegRouter;
 		this.stopFinder = stopFinder;
 		this.drtCfg = drtCfg;
 		this.scenario = scenario;
 		this.drtStageActivityType = new DrtStageActivityType(drtCfg.getMode());
-		this.modalNetwork = modalNetwork;
 		this.accessRouter = accessRouter;
 		this.egressRouter = egressRouter;
 	}
@@ -84,16 +75,24 @@ public class DrtRoutingModule implements RoutingModule {
 				Objects.requireNonNull(fromFacility, "fromFacility is null"),
 				Objects.requireNonNull(toFacility, "toFacility is null"));
 		if (!stops.isPresent()) {
-			logger.debug("No access/egress stops found, agent will use fallback mode as leg mode (usually " + 
-					TransportMode.walk + ") and routing mode " + drtCfg.getMode() + ". Agent Id:\t" + person.getId());
+			logger.debug("No access/egress stops found, agent will use fallback mode as leg mode (usually "
+					+ TransportMode.walk
+					+ ") and routing mode "
+					+ drtCfg.getMode()
+					+ ". Agent Id:\t"
+					+ person.getId());
 			return null;
 		}
 
 		Facility accessFacility = stops.get().getLeft();
 		Facility egressFacility = stops.get().getRight();
 		if (accessFacility.getLinkId().equals(egressFacility.getLinkId())) {
-			logger.debug("Start and end stop are the same, agent will use fallback mode as leg mode (usually " + 
-					TransportMode.walk + ") and routing mode " + drtCfg.getMode() + ". Agent Id:\t" + person.getId());
+			logger.debug("Start and end stop are the same, agent will use fallback mode as leg mode (usually "
+					+ TransportMode.walk
+					+ ") and routing mode "
+					+ drtCfg.getMode()
+					+ ". Agent Id:\t"
+					+ person.getId());
 			return null;
 		}
 
@@ -115,12 +114,8 @@ public class DrtRoutingModule implements RoutingModule {
 		}
 
 		// drt proper leg:
-		Link accessActLink = Verify.verifyNotNull(modalNetwork.getLinks().get(accessFacility.getLinkId()),
-				"link: %s does not exist in the network of mode: %s", accessFacility.getLinkId(), drtCfg.getMode());
-		Link egressActLink = Verify.verifyNotNull(modalNetwork.getLinks().get(egressFacility.getLinkId()),
-				"link: %s does not exist in the network of mode: %s", egressFacility.getLinkId(), drtCfg.getMode());
-		List<? extends PlanElement> drtLeg = drtRouteLegCalculator.createRealDrtLeg(now, accessActLink,
-				egressActLink);
+		List<? extends PlanElement> drtLeg = drtMainLegRouter.calcRoute(accessFacility, egressFacility, now,
+				person);
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {
 			now = TripRouter.calcEndOfPlanElement(now, planElement, scenario.getConfig());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -70,7 +70,7 @@ import com.google.inject.name.Named;
  * @author michalm (Michal Maciejewski)
  */
 public final class DrtModeModule extends AbstractDvrpModeModule {
-	public enum Direction {ACCESS, EGRESS}
+	public enum Stage {ACCESS, MAIN, EGRESS}
 
 	private final DrtConfigGroup drtCfg;
 
@@ -97,7 +97,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		addRoutingModuleBinding(getMode()).toProvider(new DrtRoutingModuleProvider(drtCfg));// not singleton
 
-		modalMapBinder(Direction.class, RoutingModule.class);//empty mapbinder for customising access/egress routing
+		modalMapBinder(Stage.class, RoutingModule.class);//empty mapbinder for customising stage routing
 		bindModal(DrtStopNetwork.class).toProvider(new DrtStopNetworkProvider(getConfig(), drtCfg)).asEagerSingleton();
 
 		if (drtCfg.getOperationalScheme() == DrtConfigGroup.OperationalScheme.door2door) {
@@ -155,17 +155,18 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		@Override
 		public DrtRoutingModule get() {
-			Map<Direction, RoutingModule> accessEgressRouters = getModalInstance(
-					new TypeLiteral<Map<Direction, RoutingModule>>() {
-					});
+			Map<Stage, RoutingModule> stageRouters = getModalInstance(new TypeLiteral<Map<Stage, RoutingModule>>() {
+			});
 
-			DrtMainLegRouter drtMainLegRouter = new DrtMainLegRouter(drtCfg, getModalInstance(Network.class),
-					leastCostPathCalculatorFactory, travelTime, getModalInstance(TravelDisutilityFactory.class),
-					scenario.getPopulation().getFactory());
+			RoutingModule mainRouter = stageRouters.get(Stage.MAIN);
+			if (mainRouter == null) {
+				mainRouter = new DrtMainLegRouter(drtCfg, getModalInstance(Network.class),
+						leastCostPathCalculatorFactory, travelTime, getModalInstance(TravelDisutilityFactory.class),
+						scenario.getPopulation().getFactory());
+			}
 
-			return new DrtRoutingModule(drtMainLegRouter,
-					accessEgressRouters.getOrDefault(Direction.ACCESS, walkRouter),
-					accessEgressRouters.getOrDefault(Direction.EGRESS, walkRouter),
+			return new DrtRoutingModule(mainRouter, stageRouters.getOrDefault(Stage.ACCESS, walkRouter),
+					stageRouters.getOrDefault(Stage.EGRESS, walkRouter),
 					getModalInstance(AccessEgressFacilityFinder.class), drtCfg, scenario);
 		}
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -36,7 +36,7 @@ import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.DrtModeMinCostFl
 import org.matsim.contrib.drt.routing.ClosestAccessEgressFacilityFinder;
 import org.matsim.contrib.drt.routing.DecideOnLinkAccessEgressFacilityFinder;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
-import org.matsim.contrib.drt.routing.DrtRouteLegCalculator;
+import org.matsim.contrib.drt.routing.DrtMainLegRouter;
 import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRoutingModule;
 import org.matsim.contrib.drt.routing.DrtRoutingModule.AccessEgressFacilityFinder;
@@ -159,15 +159,14 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 					new TypeLiteral<Map<Direction, RoutingModule>>() {
 					});
 
-			DrtRouteLegCalculator drtRouteLegCalculator = new DrtRouteLegCalculator(drtCfg,
-					getModalInstance(Network.class), leastCostPathCalculatorFactory, travelTime,
-					getModalInstance(TravelDisutilityFactory.class), scenario.getPopulation().getFactory());
+			DrtMainLegRouter drtMainLegRouter = new DrtMainLegRouter(drtCfg, getModalInstance(Network.class),
+					leastCostPathCalculatorFactory, travelTime, getModalInstance(TravelDisutilityFactory.class),
+					scenario.getPopulation().getFactory());
 
-			return new DrtRoutingModule(drtRouteLegCalculator,
+			return new DrtRoutingModule(drtMainLegRouter,
 					accessEgressRouters.getOrDefault(Direction.ACCESS, walkRouter),
 					accessEgressRouters.getOrDefault(Direction.EGRESS, walkRouter),
-					getModalInstance(AccessEgressFacilityFinder.class), drtCfg, scenario,
-					getModalInstance(Network.class));
+					getModalInstance(AccessEgressFacilityFinder.class), drtCfg, scenario);
 		}
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -86,11 +86,11 @@ public class DrtRoutingModuleTest {
 
 		AccessEgressFacilityFinder stopFinder = new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 				scenario.getNetwork(), () -> drtStops);
-		DrtRouteLegCalculator drtRouteLegCalculator = new DrtRouteLegCalculator(drtCfg, scenario.getNetwork(),
+		DrtMainLegRouter drtMainLegRouter = new DrtMainLegRouter(drtCfg, scenario.getNetwork(),
 				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new,
 				scenario.getPopulation().getFactory());
-		DrtRoutingModule drtRoutingModule = new DrtRoutingModule(drtRouteLegCalculator, walkRouter, walkRouter,
-				stopFinder, drtCfg, scenario, scenario.getNetwork());
+		DrtRoutingModule drtRoutingModule = new DrtRoutingModule(drtMainLegRouter, walkRouter, walkRouter, stopFinder,
+				drtCfg, scenario);
 
 		// case 1: origin and destination within max walking distance from next stop (200m)
 		Person p1 = scenario.getPopulation().getPersons().get(Id.createPersonId(1));


### PR DESCRIPTION
Now all 3 stages (`enum Stage {ACCESS, MAIN, EGRESS}`) are customisable via a map binder: `Map<Stage, RoutingModule> stageRouters`.

The defaults for DRT are: walk router, DrtMainLegRouter and walk router, respectively 