### PR TITLE
Fewer undefined time uses

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/LinkLengthTravelDisutility.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/LinkLengthTravelDisutility.java
@@ -35,11 +35,11 @@ class LinkLengthTravelDisutility implements TravelDisutility {
 
 	@Override
 	public double getLinkTravelDisutility(final Link link, final double time, final Person person, final Vehicle vehicle) {
-		return link.getLength();	
+		return link.getLength();
 	}
 
 	@Override
 	public double getLinkMinimumTravelDisutility(Link link) {
-		return getLinkTravelDisutility(link, Time.UNDEFINED_TIME, null, null);
+		return link.getLength();
 	}
 }

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/FreeSpeedTravelTimeCostCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/FreeSpeedTravelTimeCostCalculator.java
@@ -26,30 +26,31 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.vehicles.Vehicle;
 
 /**
- * This cost calulator is based on freespeed travel times 
+ * This cost calulator is based on freespeed travel times
  * tnicolai feb'12
- * 
- * @author thomas
  *
+ * @author thomas
  */
 public class FreeSpeedTravelTimeCostCalculator implements TravelDisutility {
-	
+
 	private static final Logger log = Logger.getLogger(FreeSpeedTravelTimeCostCalculator.class);
-	
+
 	@Override
-	public double getLinkTravelDisutility(final Link link, final double time, final Person person, final Vehicle vehicle) {
-		if(link!=null)
-			return link.getLength() / link.getFreespeed();
-		log.warn("Link is null. Returned 0 as free speed time.");
-		return 0.;
+	public double getLinkTravelDisutility(final Link link, final double time, final Person person,
+			final Vehicle vehicle) {
+		return getLinkTravelDisutilityImpl(link);
 	}
 
 	@Override
 	public double getLinkMinimumTravelDisutility(Link link) {
-		if(link!=null)
+		return getLinkTravelDisutilityImpl(link);
+	}
+
+	private double getLinkTravelDisutilityImpl(Link link) {
+		if (link != null) {
 			return link.getLength() / link.getFreespeed();
+		}
 		log.warn("Link is null. Returned 0 as free speed time.");
 		return 0.;
 	}
-
 }

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/TravelDistanceCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/TravelDistanceCalculator.java
@@ -23,28 +23,33 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
 
 /**
  * cost calculator for travel distances
- * @author thomas
  *
+ * @author thomas
  */
-public class TravelDistanceCalculator implements TravelDisutility{
+public class TravelDistanceCalculator implements TravelDisutility {
 
 	private static final Logger log = Logger.getLogger(TravelDistanceCalculator.class);
-	
+
 	@Override
-	public double getLinkTravelDisutility(final Link link, final double time, final Person person, final Vehicle vehicle) {
-		if(link != null)
-			return link.getLength();	// travel distance in meter
-		log.warn("Link is null. Returned 0 as distance.");
-		return 0.;
+	public double getLinkTravelDisutility(final Link link, final double time, final Person person,
+			final Vehicle vehicle) {
+		return getLinkTravelDisutilityImpl(link);
 	}
 
 	@Override
 	public double getLinkMinimumTravelDisutility(Link link) {
-		return getLinkTravelDisutility(link, Time.UNDEFINED_TIME, null, null);
+		return getLinkTravelDisutilityImpl(link);
+	}
+
+	private double getLinkTravelDisutilityImpl(Link link) {
+		if (link != null) {
+			return link.getLength();    // travel distance in meter
+		}
+		log.warn("Link is null. Returned 0 as distance.");
+		return 0.;
 	}
 }

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/TravelWalkTimeCostCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/costcalculators/TravelWalkTimeCostCalculator.java
@@ -23,45 +23,48 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
 
 /**
  * this cost calculator is an attempt to substitute travel distances by travel times
- * 
+ * <p>
  * the average walk speed is 5km/h. this speed is independent of the type of road (motorway, sidewalk ...)
  * therefore, walking time can be considered to be linear. it directly correlates with travel distances
  * tnicolai feb'12
- * 
- * @author thomas
  *
+ * @author thomas
  */
-public class TravelWalkTimeCostCalculator implements TravelDisutility{
-	
+public class TravelWalkTimeCostCalculator implements TravelDisutility {
+
 	private static final Logger log = Logger.getLogger(TravelWalkTimeCostCalculator.class);
-	
+
 	private double meterPerSecWalkSpeed;
-	
-	public TravelWalkTimeCostCalculator(double meterPerSecWalkSpeed){
+
+	public TravelWalkTimeCostCalculator(double meterPerSecWalkSpeed) {
 		this.meterPerSecWalkSpeed = meterPerSecWalkSpeed;
 	}
-	
+
 	/**
-	 * uses network link lengths * walk speed as costs. 
+	 * uses network link lengths * walk speed as costs.
 	 * lengths usually are given in meter and walk speed in meter/sec
 	 */
 	@Override
-	public double getLinkTravelDisutility(final Link link, final double time, final Person person, final Vehicle vehicle) {
-		if(link != null){
+	public double getLinkTravelDisutility(final Link link, final double time, final Person person,
+			final Vehicle vehicle) {
+		return getLinkTravelDisutilityImpl(link);
+	}
+
+	@Override
+	public double getLinkMinimumTravelDisutility(Link link) {
+		return getLinkTravelDisutilityImpl(link);
+	}
+
+	private double getLinkTravelDisutilityImpl(Link link) {
+		if (link != null) {
 			double secondWalkTime = link.getLength() / meterPerSecWalkSpeed;
 			return secondWalkTime;
 		}
 		log.warn("Link is null. Returned 0 as walk time.");
 		return 0.;
-	}
-	
-	@Override
-	public double getLinkMinimumTravelDisutility(Link link) {
-		return getLinkTravelDisutility(link, Time.UNDEFINED_TIME, null, null);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduleTimingUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduleTimingUpdater.java
@@ -89,7 +89,7 @@ public class DrtScheduleTimingUpdater {
 			DrtTask task = (DrtTask)tasks.get(i);
 			double calcEndTime = calcNewEndTime(vehicle, task, newBeginTime);
 
-			if (Time.isUndefinedTime(calcEndTime)) {
+			if (calcEndTime == UNDEFINED_TIME) {
 				schedule.removeTask(task);
 				i--;
 			} else if (calcEndTime < newBeginTime) {// 0 s is fine (e.g. last 'wait')
@@ -102,6 +102,8 @@ public class DrtScheduleTimingUpdater {
 		}
 	}
 
+	private final static double UNDEFINED_TIME = Double.NEGATIVE_INFINITY;
+
 	private double calcNewEndTime(DvrpVehicle vehicle, DrtTask task, double newBeginTime) {
 		switch (task.getDrtTaskType()) {
 			case STAY: {
@@ -113,7 +115,7 @@ public class DrtScheduleTimingUpdater {
 					// must have been added at time submissionTime <= t
 					double oldEndTime = task.getEndTime();
 					if (oldEndTime <= newBeginTime) {// may happen if the previous task is delayed
-						return Time.UNDEFINED_TIME;// remove the task
+						return UNDEFINED_TIME;// remove the task
 					} else {
 						return oldEndTime;
 					}

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterNetworkWW.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterNetworkWW.java
@@ -46,8 +46,8 @@ public final class TransitRouterNetworkWW implements Network {
 
 	private final static Logger log = Logger.getLogger(TransitRouterNetworkWW.class);
 	
-	private final Map<Id<Link>, TransitRouterNetworkLink> links = new LinkedHashMap<Id<Link>, TransitRouterNetworkLink>();
-	private final Map<Id<Node>, TransitRouterNetworkNode> nodes = new LinkedHashMap<Id<Node>, TransitRouterNetworkNode>();
+	private final Map<Id<Link>, TransitRouterNetworkLink> links = new LinkedHashMap<>();
+	private final Map<Id<Node>, TransitRouterNetworkNode> nodes = new LinkedHashMap<>();
 	protected QuadTree<TransitRouterNetworkNode> qtNodes = null;
 
 	private long nextNodeId = 0;
@@ -59,8 +59,8 @@ public final class TransitRouterNetworkWW implements Network {
 		public final TransitRoute route;
 		public final TransitLine line;
 		final Id<Node> id;
-		final Map<Id<Link>, TransitRouterNetworkLink> ingoingLinks = new LinkedHashMap<Id<Link>, TransitRouterNetworkLink>();
-		final Map<Id<Link>, TransitRouterNetworkLink> outgoingLinks = new LinkedHashMap<Id<Link>, TransitRouterNetworkLink>();
+		final Map<Id<Link>, TransitRouterNetworkLink> ingoingLinks = new LinkedHashMap<>();
+		final Map<Id<Link>, TransitRouterNetworkLink> outgoingLinks = new LinkedHashMap<>();
 
 		public TransitRouterNetworkNode(final Id<Node> id, final TransitRouteStop stop, final TransitRoute route, final TransitLine line) {
 			this.id = id;
@@ -174,22 +174,22 @@ public final class TransitRouterNetworkWW implements Network {
 
 		@Override
 		public double getCapacity() {
-			return getCapacity(Time.UNDEFINED_TIME);
-		}
-
-		@Override
-		public double getCapacity(final double time) {
 			return 9999;
 		}
 
 		@Override
+		public double getCapacity(final double time) {
+			return getCapacity();
+		}
+
+		@Override
 		public double getFreespeed() {
-			return getFreespeed(Time.UNDEFINED_TIME);
+			return 10;
 		}
 
 		@Override
 		public double getFreespeed(final double time) {
-			return 10;
+			return getFreespeed();
 		}
 
 		@Override
@@ -199,12 +199,12 @@ public final class TransitRouterNetworkWW implements Network {
 
 		@Override
 		public double getNumberOfLanes() {
-			return getNumberOfLanes(Time.UNDEFINED_TIME);
+			return 1;
 		}
 
 		@Override
 		public double getNumberOfLanes(final double time) {
-			return 1;
+			return getNumberOfLanes();
 		}
 
 		@Override

--- a/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/handler/OTFLinkAgentsHandler.java
+++ b/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/handler/OTFLinkAgentsHandler.java
@@ -104,7 +104,7 @@ public class OTFLinkAgentsHandler extends OTFDataReader {
 			out.putFloat((float) linkEnd.x); 
 			out.putFloat((float) linkEnd.y);
 				if ( OTFVisConfigGroup.NUMBER_OF_LANES.equals(OTFClientControl.getInstance().getOTFVisConfig().getLinkWidthIsProportionalTo()) ) {
-					out.putInt(NetworkUtils.getNumberOfLanesAsInt(0, this.src.getLink()));
+					out.putInt(NetworkUtils.getNumberOfLanesAsInt(this.src.getLink()));
 				} else if ( OTFVisConfigGroup.CAPACITY.equals(OTFClientControl.getInstance().getOTFVisConfig().getLinkWidthIsProportionalTo()) ) {
 					out.putInt( 1 + (int)(2.*this.src.getLink().getCapacity()/3600.) ) ;
 					// yyyyyy 3600. is a magic number (the default of the capacity period attribute in Network) but I cannot get to the network (where "capacityPeriod" resides).  

--- a/matsim/src/main/java/org/matsim/core/events/algorithms/SnapshotGenerator.java
+++ b/matsim/src/main/java/org/matsim/core/events/algorithms/SnapshotGenerator.java
@@ -362,7 +362,7 @@ public class SnapshotGenerator implements PersonDepartureEventHandler, PersonArr
 				int cmp = (int) (agent.time + this.freespeedTravelTime + this.inverseTimeCap + 2.0);
 				double speed = (time > cmp) ? 0.0 : this.link.getFreespeed(time);
 				agent.speed = speed;
-				int lane = 1 + (agent.intId % NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), this.link));
+				int lane = 1 + (agent.intId % NetworkUtils.getNumberOfLanesAsInt(this.link));
 				AgentSnapshotInfo position = snapshotInfoFactory.createAgentSnapshotInfo(agent.id, this.link, distanceOnLink/* + NetworkLayer.CELL_LENGTH*/, lane);
 				position.setColorValueBetweenZeroAndOne( agent.speed) ;
 				position.setAgentState(AgentSnapshotInfo.AgentState.PERSON_DRIVING_CAR);
@@ -373,7 +373,7 @@ public class SnapshotGenerator implements PersonDepartureEventHandler, PersonArr
 			/* Put the vehicles from the waiting list in positions.
 			 * Their actual position doesn't matter, so they are just placed
 			 * to the coordinates of the from node */
-			int lane = NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), this.link) + 1; // place them next to the link
+			int lane = NetworkUtils.getNumberOfLanesAsInt(this.link) + 1; // place them next to the link
 			for (EventAgent agent : this.waitingQueue) {
 				AgentSnapshotInfo position = snapshotInfoFactory.createAgentSnapshotInfo(agent.id, this.link, this.effectiveCellSize, lane);
 				position.setColorValueBetweenZeroAndOne( 0.0) ;
@@ -384,7 +384,7 @@ public class SnapshotGenerator implements PersonDepartureEventHandler, PersonArr
 			/* put the vehicles from the parking list in positions
 			 * their actual position doesn't matter, so they are just placed
 			 * to the coordinates of the from node */
-			lane = NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), this.link) + 2; // place them next to the link
+			lane = NetworkUtils.getNumberOfLanesAsInt(this.link) + 2; // place them next to the link
 			for (EventAgent agent : this.parkingQueue) {
 				AgentSnapshotInfo position = snapshotInfoFactory.createAgentSnapshotInfo(agent.id, this.link, this.effectiveCellSize, lane);
 				position.setColorValueBetweenZeroAndOne(0.0) ;

--- a/matsim/src/main/java/org/matsim/core/mobsim/jdeqsim/Road.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/jdeqsim/Road.java
@@ -111,7 +111,7 @@ public class Road extends SimUnit {
 		 * same time
 		 */
 		this.maxNumberOfCarsOnRoad = Math.round(link.getLength()
-				* NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), link)
+				* NetworkUtils.getNumberOfLanesAsInt(link)
 				* config.getStorageCapacityFactor() / config.getCarSize());
 
 		/**
@@ -123,7 +123,7 @@ public class Road extends SimUnit {
 		}
 
 		double maxInverseInFlowCapacity = 3600 / (config.getMinimumInFlowCapacity()
-				* config.getFlowCapacityFactor() * NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), link));
+				* config.getFlowCapacityFactor() * NetworkUtils.getNumberOfLanesAsInt(link));
 
 		this.inverseOutFlowCapacity = 1 / (link.getFlowCapacityPerSec() * config.getFlowCapacityFactor());
 

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -221,12 +221,14 @@ public final class NetworkUtils {
 	 */
 	public static int getNumberOfLanesAsInt(final double time, final Link link) {
 		int numberOfLanes = (int) link.getNumberOfLanes(time);
-		if (numberOfLanes == 0) {
-			return 1;
-		} else {
-			return numberOfLanes;
-		}
+		return Math.max(1, numberOfLanes);
 	}
+
+	public static int getNumberOfLanesAsInt(final Link link) {
+		int numberOfLanes = (int) link.getNumberOfLanes();
+		return Math.max(1, numberOfLanes);
+	}
+
 
 	public static boolean isMultimodal(final Network network) {
 		String mode = null;

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkMergeDoubleLinks.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkMergeDoubleLinks.java
@@ -94,7 +94,7 @@ public final class NetworkMergeDoubleLinks implements NetworkRunnable {
 
 				double cap = link1.getCapacity() + link2.getCapacity();
 				double fs = Math.max(link1.getFreespeed(),link2.getFreespeed());
-				int lanes = NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), link1) + NetworkUtils.getNumberOfLanesAsInt(Time.UNDEFINED_TIME, link2);
+				int lanes = NetworkUtils.getNumberOfLanesAsInt(link1) + NetworkUtils.getNumberOfLanesAsInt(link2);
 				double length = Math.max(link1.getLength(),link2.getLength());
 				//			String origid = "add-merge(" + link1.getId() + "," + link2.getId() + ")";
 				link1.setCapacity(cap);
@@ -112,7 +112,7 @@ public final class NetworkMergeDoubleLinks implements NetworkRunnable {
 				{
 					double cap = Math.max(link1.getCapacity(),link2.getCapacity());
 					double fs = Math.max(link1.getFreespeed(),link2.getFreespeed());
-					int lanes = Math.max(NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), link1), NetworkUtils.getNumberOfLanesAsInt(Time.UNDEFINED_TIME, link2));
+					int lanes = Math.max(NetworkUtils.getNumberOfLanesAsInt(link1), NetworkUtils.getNumberOfLanesAsInt(link2));
 					double length = Math.max(link1.getLength(),link2.getLength());
 					//			String origid = "max-merge(" + link1.getId() + "," + link2.getId() + ")";
 					link1.setCapacity(cap);

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkWriteAsTable.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkWriteAsTable.java
@@ -111,13 +111,13 @@ public final class NetworkWriteAsTable implements NetworkRunnable {
 				out_l.write(tc.getX() + "\t" + tc.getY() + "\t" + l.getLength() + "\t");
 				out_l.write(l.getFreespeed()+"\t"
 						+(l.getCapacity()/capperiod)+"\t"
-						+ NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), l)+"\t"
+						+ NetworkUtils.getNumberOfLanesAsInt(l)+"\t"
 						+l.getAllowedModes().toString()+"\n");
 				out_l.flush();
 
 				out_et.write(l.getId() + "\t" + l.getFromNode().getId() + "\t" + l.getToNode().getId() + "\t");
 				out_et.write(Math.round(l.getLength()) + "\t" + Math.round(l.getFreespeed()*3.6) + "\t");
-				out_et.write(Math.round(l.getCapacity()/capperiod) + "\t" + NetworkUtils.getNumberOfLanesAsInt(Time.getUndefinedTime(), l) + "\t");
+				out_et.write(Math.round(l.getCapacity()/capperiod) + "\t" + NetworkUtils.getNumberOfLanesAsInt(l) + "\t");
 				out_et.write(NetworkUtils.getOrigId( ((Link) l) ) + "\t" + NetworkUtils.getType(((Link) l)) + "\t"+l.getAllowedModes().toString()+"\n");
 				out_et.write(fc.getX() + "\t" + fc.getY() + "\n");
 				out_et.write(tc.getX() + "\t" + tc.getY() + "\n");

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterNetwork.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterNetwork.java
@@ -58,8 +58,8 @@ public final class TransitRouterNetwork implements Network {
 
 	private final static Logger log = Logger.getLogger(TransitRouterNetwork.class);
 
-	private final Map<Id<Link>, TransitRouterNetworkLink> links = new LinkedHashMap<Id<Link>, TransitRouterNetworkLink>();
-	private final Map<Id<Node>, TransitRouterNetworkNode> nodes = new LinkedHashMap<Id<Node>, TransitRouterNetworkNode>();
+	private final Map<Id<Link>, TransitRouterNetworkLink> links = new LinkedHashMap<>();
+	private final Map<Id<Node>, TransitRouterNetworkNode> nodes = new LinkedHashMap<>();
 	private QuadTree<TransitRouterNetworkNode> qtNodes = null;
 
 	private long nextNodeId = 0;
@@ -72,8 +72,8 @@ public final class TransitRouterNetwork implements Network {
 		public final TransitRoute route;
 		public final TransitLine line;
 		final Id<Node> id;
-		final Map<Id<Link>, TransitRouterNetworkLink> ingoingLinks = new IdentifiableArrayMap<Link, TransitRouterNetworkLink>();
-		final Map<Id<Link>, TransitRouterNetworkLink> outgoingLinks = new IdentifiableArrayMap<Link, TransitRouterNetworkLink>();
+		final Map<Id<Link>, TransitRouterNetworkLink> ingoingLinks = new IdentifiableArrayMap<>();
+		final Map<Id<Link>, TransitRouterNetworkLink> outgoingLinks = new IdentifiableArrayMap<>();
 
 		public TransitRouterNetworkNode(final Id<Node> id, final TransitRouteStop stop, final TransitRoute route, final TransitLine line) {
 			this.id = id;
@@ -189,22 +189,22 @@ public final class TransitRouterNetwork implements Network {
 
 		@Override
 		public double getCapacity() {
-			return getCapacity(Time.UNDEFINED_TIME);
-		}
-
-		@Override
-		public double getCapacity(final double time) {
 			return 9999;
 		}
 
 		@Override
+		public double getCapacity(final double time) {
+			return getCapacity();
+		}
+
+		@Override
 		public double getFreespeed() {
-			return getFreespeed(Time.UNDEFINED_TIME);
+			return 10;
 		}
 
 		@Override
 		public double getFreespeed(final double time) {
-			return 10;
+			return getFreespeed();
 		}
 
 		@Override
@@ -214,12 +214,12 @@ public final class TransitRouterNetwork implements Network {
 
 		@Override
 		public double getNumberOfLanes() {
-			return getNumberOfLanes(Time.UNDEFINED_TIME);
+			return 1;
 		}
 
 		@Override
 		public double getNumberOfLanes(final double time) {
-			return 1;
+			return getNumberOfLanes();
 		}
 
 		@Override

--- a/matsim/src/main/java/org/matsim/withinday/trafficmonitoring/WithinDayTravelTime.java
+++ b/matsim/src/main/java/org/matsim/withinday/trafficmonitoring/WithinDayTravelTime.java
@@ -336,7 +336,7 @@ public class WithinDayTravelTime implements TravelTime,
 		
 		
 		for (Link link : this.network.getLinks().values()) {
-			double freeSpeedTravelTime = link.getLength() / link.getFreespeed(Time.UNDEFINED_TIME);
+			double freeSpeedTravelTime = link.getLength() / link.getFreespeed();
 
 			TravelTimeInfo travelTimeInfo = this.travelTimeInfoProvider.getTravelTimeInfo(link);
 			travelTimeInfo.travelTime = freeSpeedTravelTime;

--- a/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
@@ -311,7 +311,7 @@ public class NetworkUtilsTest {
 		}
 
 		@Override
-		public double getNumberOfLanes(final double time) {
+		public double getNumberOfLanes() {
 			return this.nOfLanes;
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
@@ -161,6 +161,20 @@ public class NetworkUtilsTest {
 		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(7*3600, new PseudoLink(0.5)));
 		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(7*3600, new PseudoLink(0.1)));
 		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(7*3600, new PseudoLink(0.0)));
+
+		assertEquals(3, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(3.2)));
+		assertEquals(3, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(3.1)));
+		assertEquals(3, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(3.0)));
+		assertEquals(2, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(2.9)));
+		assertEquals(2, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(2.5)));
+		assertEquals(2, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(2.0)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(1.9)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(1.5)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(1.0)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(0.9)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(0.5)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(0.1)));
+		assertEquals(1, NetworkUtils.getNumberOfLanesAsInt(new PseudoLink(0.0)));
 	}
 
 	@Test

--- a/matsim/src/test/java/org/matsim/testcases/fakes/FakeLink.java
+++ b/matsim/src/test/java/org/matsim/testcases/fakes/FakeLink.java
@@ -80,22 +80,22 @@ public class FakeLink implements Link {
 
 	@Override
 	public double getCapacity() {
-		return getCapacity(Time.UNDEFINED_TIME);
-	}
-
-	@Override
-	public double getCapacity(final double time) {
 		return 2000.0;
 	}
 
 	@Override
+	public double getCapacity(final double time) {
+		return getCapacity();
+	}
+
+	@Override
 	public double getFreespeed() {
-		return getFreespeed(Time.UNDEFINED_TIME);
+		return 15.0;
 	}
 
 	@Override
 	public double getFreespeed(final double time) {
-		return 15.0;
+		return getFreespeed();
 	}
 
 	@Override
@@ -105,12 +105,12 @@ public class FakeLink implements Link {
 
 	@Override
 	public double getNumberOfLanes() {
-		return getNumberOfLanes(Time.UNDEFINED_TIME);
+		return 1.0;
 	}
 
 	@Override
 	public double getNumberOfLanes(final double time) {
-		return 1.0;
+		return getNumberOfLanes();
 	}
 
 	@Override


### PR DESCRIPTION
A first step towards https://matsim.atlassian.net/browse/MATSIM-1000

This PR removes unnecessary uses of `Time.UNDEFINED_TIME`. It only deals "obvious" occurrences of case 3 (discussed here: https://matsim.atlassian.net/browse/MATSIM-1000?focusedCommentId=37229&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-37229)