### PR TITLE
Remove undefined time usages

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -181,10 +181,11 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 		DriveEnergyConsumption driveEnergyConsumption = pseudoVehicle.getDriveEnergyConsumption();
 		AuxEnergyConsumption auxEnergyConsumption = pseudoVehicle.getAuxEnergyConsumption();
 		double lastSoc = pseudoVehicle.getBattery().getSoc();
+		double linkEnterTime = basicLeg.getDepartureTime();
 		for (Link l : links) {
 			double travelT = travelTime.getLinkTravelTime(l, basicLeg.getDepartureTime(), null, null);
 
-			double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, Time.getUndefinedTime())
+			double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, linkEnterTime)
 					+ auxEnergyConsumption.calcEnergyConsumption(basicLeg.getDepartureTime(), travelT, l.getId());
 			pseudoVehicle.getBattery().changeSoc(-consumption);
 			double currentSoc = pseudoVehicle.getBattery().getSoc();
@@ -192,6 +193,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 			double consumptionDiff = (lastSoc - currentSoc);
 			lastSoc = currentSoc;
 			consumptions.put(l, consumptionDiff);
+			linkEnterTime += travelT;
 		}
 		return consumptions;
 	}

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/mobsim/StrategyManagerFactoryForTests.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/mobsim/StrategyManagerFactoryForTests.java
@@ -44,17 +44,16 @@ public class StrategyManagerFactoryForTests implements CarrierPlanStrategyManage
         @Override
         public double getLinkTravelDisutility(final Link link,
                                               final double time, final Person person, final Vehicle vehicle) {
-            double genCosts = link.getLength() * cost_per_m
-                    + travelTime.getLinkTravelTime(link, time, null, null) * cost_per_s;
-            // double genCosts = travelTime.getLinkTravelTime(link,
-            // time)*cost_per_s;
-            return genCosts;
+            return disutility(link.getLength(),  travelTime.getLinkTravelTime(link, time, null, null));
         }
 
         @Override
         public double getLinkMinimumTravelDisutility(Link link) {
-            return getLinkTravelDisutility(link, Time.UNDEFINED_TIME, null,
-                    null);
+            return disutility(link.getLength(),  link.getLength() / link.getFreespeed());
+        }
+
+        private double disutility(double distance, double time) {
+            return distance * cost_per_m + time * cost_per_s;
         }
     }
 

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/AdvancedMarginalCongestionPricingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/AdvancedMarginalCongestionPricingHandler.java
@@ -47,7 +47,6 @@ import org.matsim.contrib.noise.personLinkMoneyEvents.PersonLinkMoneyEvent;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.scoring.functions.ScoringParameters;
-import org.matsim.core.utils.misc.Time;
 
 import playground.vsp.congestion.events.CongestionEvent;
 
@@ -179,12 +178,14 @@ public class AdvancedMarginalCongestionPricingHandler implements CongestionEvent
 		}
 	}
 
+	private final static double FINAL_CONGESTION_EVENT_TIME = Double.NEGATIVE_INFINITY;
+
 	/*
 	 * This method has to be called after the MobSim. Here, the disutility from being delayed at the last / overnight activity is taken into account.
 	 */
 	public void processFinalCongestionEvents() {
 		for (Id<Person> affectedPersonId : this.affectedPersonId2congestionEventsToProcess.keySet()) {
-			processCongestionEventsForAffectedPerson(affectedPersonId, Time.UNDEFINED_TIME, null);
+			processCongestionEventsForAffectedPerson(affectedPersonId, FINAL_CONGESTION_EVENT_TIME, null);//
 		}
 	}
 	
@@ -205,7 +206,7 @@ public class AdvancedMarginalCongestionPricingHandler implements CongestionEvent
 			if (this.personId2currentActivityType.containsKey(personId) && this.personId2currentActivityStartTime.containsKey(personId)) {
 				// Yes, the plan seems to be completed.
 				
-				if (activityEndTime == Time.UNDEFINED_TIME) {
+				if (activityEndTime == FINAL_CONGESTION_EVENT_TIME) {
 					// The end time is undefined...
 												
 					// ... now handle the first and last OR overnight activity. This is figured out by the scoring function itself (depending on the activity types).
@@ -265,7 +266,7 @@ public class AdvancedMarginalCongestionPricingHandler implements CongestionEvent
 				double amount = this.factor * congestionEvent.getDelay() * delayCostPerSecond * (-1);
 				this.amountSum = this.amountSum + amount;
 				
-				if (activityEndTime == Time.UNDEFINED_TIME) {
+				if (activityEndTime == FINAL_CONGESTION_EVENT_TIME) {
 					activityEndTime = this.scenario.getConfig().qsim().getEndTime();
 				}
 				

--- a/matsim/src/main/java/org/matsim/core/router/costcalculators/OnlyTimeDependentTravelDisutility.java
+++ b/matsim/src/main/java/org/matsim/core/router/costcalculators/OnlyTimeDependentTravelDisutility.java
@@ -54,7 +54,6 @@ public class OnlyTimeDependentTravelDisutility implements TravelDisutility {
 
 	@Override
 	public double getLinkMinimumTravelDisutility(final Link link) {
-		return this.travelTime.getLinkTravelTime(link, Time.UNDEFINED_TIME, null, null);
+		return link.getLength() / link.getFreespeed();
 	}
-	
 }


### PR DESCRIPTION
continuation of  #807 

Almost all calls of "compute-like" methods with UNDEFINED_TIME passed as time are removed.

Probably the last remaining one:
https://github.com/matsim-org/matsim/blob/adc6e7209e747d29457455e1ad850cb945795d60/matsim/src/main/java/org/matsim/pt/router/TransitLeastCostPathTree.java#L294-L295
which I even cannot say if it works properly when called with UNDEFINED_TIME??